### PR TITLE
feat(tts): auto-download go2rtc + speaker selection

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,29 @@
+{
+  "mcpServers": {
+    "usb-webcam": {
+      "command": "uv",
+      "args": ["run", "--directory", "usb-webcam-mcp", "usb-webcam-mcp"]
+    },
+    "wifi-cam": {
+      "command": "uv",
+      "args": ["run", "--directory", "wifi-cam-mcp", "wifi-cam-mcp"]
+    },
+    "memory": {
+      "command": "uv",
+      "args": ["run", "--directory", "memory-mcp", "memory-mcp"]
+    },
+    "system-temperature": {
+      "command": "uv",
+      "args": ["run", "--directory", "system-temperature-mcp", "system-temperature-mcp"]
+    },
+    "elevenlabs-t2s": {
+      "command": "uv",
+      "args": ["run", "--directory", "elevenlabs-t2s-mcp", "elevenlabs-t2s"],
+      "env": {
+        "GO2RTC_URL": "http://localhost:1984",
+        "GO2RTC_STREAM": "tapo_cam",
+        "ELEVENLABS_PLAYBACK": "none"
+      }
+    }
+  }
+}

--- a/elevenlabs-t2s-mcp/pyproject.toml
+++ b/elevenlabs-t2s-mcp/pyproject.toml
@@ -9,6 +9,13 @@ dependencies = [
     "elevenlabs>=1.0.0",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "ruff>=0.3.0",
+]
+
 [project.scripts]
 elevenlabs-t2s = "elevenlabs_t2s_mcp.server:main"
 
@@ -18,3 +25,15 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/elevenlabs_t2s_mcp"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W"]
+per-file-ignores = {"src/elevenlabs_t2s_mcp/server.py" = ["E501"]}
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/elevenlabs-t2s-mcp/src/elevenlabs_t2s_mcp/config.py
+++ b/elevenlabs-t2s-mcp/src/elevenlabs_t2s_mcp/config.py
@@ -37,6 +37,15 @@ class ElevenLabsConfig:
     playback: str
     pulse_sink: str | None
     pulse_server: str | None
+    go2rtc_url: str | None
+    go2rtc_stream: str
+    go2rtc_ffmpeg: str
+    go2rtc_bin: str | None
+    go2rtc_config: str | None
+    go2rtc_auto_start: bool
+    go2rtc_camera_host: str | None
+    go2rtc_camera_username: str | None
+    go2rtc_camera_password: str | None
 
     @classmethod
     def from_env(cls) -> "ElevenLabsConfig":
@@ -55,6 +64,27 @@ class ElevenLabsConfig:
             playback=os.getenv("ELEVENLABS_PLAYBACK", "auto"),
             pulse_sink=os.getenv("ELEVENLABS_PULSE_SINK") or None,
             pulse_server=_detect_pulse_server(),
+            go2rtc_url=os.getenv("GO2RTC_URL") or None,
+            go2rtc_stream=os.getenv("GO2RTC_STREAM", "tapo_cam"),
+            go2rtc_ffmpeg=os.getenv("GO2RTC_FFMPEG", "ffmpeg"),
+            go2rtc_bin=os.getenv("GO2RTC_BIN") or None,
+            go2rtc_config=os.getenv("GO2RTC_CONFIG") or None,
+            go2rtc_auto_start=_parse_bool(os.getenv("GO2RTC_AUTO_START"), True),
+            go2rtc_camera_host=(
+                os.getenv("GO2RTC_CAMERA_HOST")
+                or os.getenv("TAPO_CAMERA_HOST")
+                or None
+            ),
+            go2rtc_camera_username=(
+                os.getenv("GO2RTC_CAMERA_USERNAME")
+                or os.getenv("TAPO_USERNAME")
+                or None
+            ),
+            go2rtc_camera_password=(
+                os.getenv("GO2RTC_CAMERA_PASSWORD")
+                or os.getenv("TAPO_PASSWORD")
+                or None
+            ),
         )
 
 

--- a/elevenlabs-t2s-mcp/src/elevenlabs_t2s_mcp/go2rtc.py
+++ b/elevenlabs-t2s-mcp/src/elevenlabs_t2s_mcp/go2rtc.py
@@ -1,0 +1,209 @@
+"""Auto-download and manage go2rtc for audio backchannel."""
+
+import asyncio
+import json
+import logging
+import platform
+import stat
+import subprocess
+import urllib.request
+import zipfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+GITHUB_RELEASES_URL = "https://api.github.com/repos/AlexxIT/go2rtc/releases/latest"
+
+PLATFORM_MAP = {
+    ("linux", "x86_64"): "go2rtc_linux_amd64",
+    ("linux", "aarch64"): "go2rtc_linux_arm64",
+    ("linux", "armv7l"): "go2rtc_linux_arm",
+    ("linux", "armv6l"): "go2rtc_linux_armv6",
+    ("darwin", "x86_64"): "go2rtc_mac_amd64",
+    ("darwin", "arm64"): "go2rtc_mac_arm64",
+    ("windows", "amd64"): "go2rtc_win64",
+    ("windows", "x86"): "go2rtc_win32",
+}
+
+
+def default_cache_dir() -> Path:
+    return Path.home() / ".cache" / "embodied-claude" / "go2rtc"
+
+
+def default_bin_path() -> Path:
+    name = "go2rtc.exe" if platform.system().lower() == "windows" else "go2rtc"
+    return default_cache_dir() / name
+
+
+def default_config_path() -> Path:
+    return default_cache_dir() / "go2rtc.yaml"
+
+
+def detect_platform() -> str:
+    """Detect the go2rtc asset name for the current platform."""
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    key = (system, machine)
+    asset_name = PLATFORM_MAP.get(key)
+    if not asset_name:
+        raise RuntimeError(f"Unsupported platform: {system}/{machine}")
+    return asset_name
+
+
+def _get_download_url(asset_name: str) -> str:
+    """Get download URL from GitHub Releases API."""
+    req = urllib.request.Request(
+        GITHUB_RELEASES_URL,
+        headers={"Accept": "application/vnd.github+json"},
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        release = json.loads(resp.read())
+
+    for asset in release.get("assets", []):
+        name = asset.get("name", "")
+        if name == asset_name or name.startswith(asset_name):
+            return asset["browser_download_url"]
+
+    raise RuntimeError(
+        f"Asset '{asset_name}' not found in latest release"
+    )
+
+
+def _download_file(url: str, dest: Path) -> None:
+    """Download a file from URL to dest path."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = dest.with_suffix(".tmp")
+    try:
+        urllib.request.urlretrieve(url, str(tmp_path))
+        tmp_path.rename(dest)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def ensure_binary(bin_path: Path | None = None) -> Path:
+    """Ensure go2rtc binary exists, downloading if needed."""
+    if bin_path is None:
+        bin_path = default_bin_path()
+
+    if bin_path.exists():
+        return bin_path
+
+    logger.info("go2rtc binary not found, downloading...")
+    asset_name = detect_platform()
+    url = _get_download_url(asset_name)
+    logger.info("Downloading go2rtc from %s", url)
+
+    is_zip = url.endswith(".zip")
+    if is_zip:
+        zip_path = bin_path.with_suffix(".zip")
+        _download_file(url, zip_path)
+        bin_path.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(zip_path) as zf:
+            # Find the binary inside the zip
+            for name in zf.namelist():
+                if "go2rtc" in name.lower():
+                    with zf.open(name) as src, open(bin_path, "wb") as dst:
+                        dst.write(src.read())
+                    break
+            else:
+                raise RuntimeError("go2rtc binary not found in zip")
+        zip_path.unlink()
+    else:
+        _download_file(url, bin_path)
+
+    # Make executable on Unix
+    if platform.system().lower() != "windows":
+        bin_path.chmod(bin_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP)
+
+    logger.info("go2rtc downloaded to %s", bin_path)
+    return bin_path
+
+
+def generate_config(
+    config_path: Path,
+    stream_name: str,
+    camera_host: str,
+    username: str,
+    password: str,
+    ffmpeg_bin: str | None = None,
+) -> Path:
+    """Generate go2rtc.yaml config file."""
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_ffmpeg = ffmpeg_bin or "ffmpeg"
+    content = (
+        f"streams:\n"
+        f"  {stream_name}:\n"
+        f"    - rtsp://{username}:{password}@{camera_host}:554/stream1\n"
+        f"    - tapo://{password}@{camera_host}\n"
+        f"\n"
+        f"ffmpeg:\n"
+        f"  bin: {resolved_ffmpeg}\n"
+        f"\n"
+        f"api:\n"
+        f"  listen: \":1984\"\n"
+        f"\n"
+        f"log:\n"
+        f"  level: info\n"
+    )
+    config_path.write_text(content)
+    logger.info("go2rtc config written to %s", config_path)
+    return config_path
+
+
+class Go2RTCProcess:
+    """Manage go2rtc daemon lifecycle."""
+
+    def __init__(self, bin_path: Path, config_path: Path, api_url: str = "http://localhost:1984"):
+        self._bin_path = bin_path
+        self._config_path = config_path
+        self._api_url = api_url
+        self._process: subprocess.Popen | None = None
+
+    def is_running(self) -> bool:
+        """Check if go2rtc is already responding."""
+        try:
+            req = urllib.request.Request(f"{self._api_url}/api", method="GET")
+            with urllib.request.urlopen(req, timeout=2):
+                return True
+        except Exception:
+            return False
+
+    async def start(self) -> None:
+        """Start go2rtc as a background process."""
+        if self.is_running():
+            logger.info("go2rtc already running at %s", self._api_url)
+            return
+
+        self._process = subprocess.Popen(
+            [str(self._bin_path), "-config", str(self._config_path)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        # Wait briefly and verify it started
+        await asyncio.sleep(1.5)
+
+        if self._process.poll() is not None:
+            stderr = self._process.stderr.read().decode() if self._process.stderr else ""
+            raise RuntimeError(f"go2rtc exited immediately: {stderr}")
+
+        if not self.is_running():
+            stderr = ""
+            if self._process.stderr:
+                self._process.stderr.close()
+            self._process.terminate()
+            raise RuntimeError("go2rtc started but not responding")
+
+        logger.info("go2rtc started (pid=%d)", self._process.pid)
+
+    def stop(self) -> None:
+        """Stop go2rtc process."""
+        if self._process is None or self._process.poll() is not None:
+            return
+        logger.info("Stopping go2rtc (pid=%d)", self._process.pid)
+        self._process.terminate()
+        try:
+            self._process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self._process.kill()
+            self._process.wait(timeout=2)

--- a/elevenlabs-t2s-mcp/tests/test_config.py
+++ b/elevenlabs-t2s-mcp/tests/test_config.py
@@ -1,0 +1,90 @@
+"""Tests for ElevenLabs TTS config."""
+
+import os
+from unittest.mock import patch
+
+from elevenlabs_t2s_mcp.config import ElevenLabsConfig, _parse_bool
+
+
+class TestParseBool:
+    """Tests for _parse_bool helper."""
+
+    def test_true_values(self):
+        for val in ("1", "true", "True", "TRUE", "yes", "on"):
+            assert _parse_bool(val, False) is True
+
+    def test_false_values(self):
+        for val in ("0", "false", "False", "no", "off", ""):
+            assert _parse_bool(val, True) is False
+
+    def test_none_returns_default(self):
+        assert _parse_bool(None, True) is True
+        assert _parse_bool(None, False) is False
+
+
+class TestElevenLabsConfigGo2rtc:
+    """Tests for go2rtc config fields."""
+
+    @patch.dict(os.environ, {"ELEVENLABS_API_KEY": "test-key"}, clear=False)
+    def test_go2rtc_defaults(self):
+        config = ElevenLabsConfig.from_env()
+        assert config.go2rtc_bin is None
+        assert config.go2rtc_config is None
+        assert config.go2rtc_auto_start is True
+        assert config.go2rtc_camera_host is None
+        assert config.go2rtc_camera_username is None
+        assert config.go2rtc_camera_password is None
+
+    @patch.dict(
+        os.environ,
+        {
+            "ELEVENLABS_API_KEY": "test-key",
+            "GO2RTC_BIN": "/opt/go2rtc",
+            "GO2RTC_CONFIG": "/etc/go2rtc.yaml",
+            "GO2RTC_AUTO_START": "false",
+            "GO2RTC_CAMERA_HOST": "10.0.0.1",
+            "GO2RTC_CAMERA_USERNAME": "admin",
+            "GO2RTC_CAMERA_PASSWORD": "pass123",
+        },
+        clear=False,
+    )
+    def test_go2rtc_from_env(self):
+        config = ElevenLabsConfig.from_env()
+        assert config.go2rtc_bin == "/opt/go2rtc"
+        assert config.go2rtc_config == "/etc/go2rtc.yaml"
+        assert config.go2rtc_auto_start is False
+        assert config.go2rtc_camera_host == "10.0.0.1"
+        assert config.go2rtc_camera_username == "admin"
+        assert config.go2rtc_camera_password == "pass123"
+
+    @patch.dict(
+        os.environ,
+        {
+            "ELEVENLABS_API_KEY": "test-key",
+            "TAPO_CAMERA_HOST": "192.168.1.50",
+            "TAPO_USERNAME": "tapo_user",
+            "TAPO_PASSWORD": "tapo_pass",
+        },
+        clear=False,
+    )
+    def test_tapo_env_fallback(self):
+        # Clear GO2RTC_ specific vars if present
+        for key in ("GO2RTC_CAMERA_HOST", "GO2RTC_CAMERA_USERNAME", "GO2RTC_CAMERA_PASSWORD"):
+            os.environ.pop(key, None)
+        config = ElevenLabsConfig.from_env()
+        assert config.go2rtc_camera_host == "192.168.1.50"
+        assert config.go2rtc_camera_username == "tapo_user"
+        assert config.go2rtc_camera_password == "tapo_pass"
+
+    @patch.dict(
+        os.environ,
+        {
+            "ELEVENLABS_API_KEY": "test-key",
+            "GO2RTC_CAMERA_HOST": "override",
+            "TAPO_CAMERA_HOST": "fallback",
+        },
+        clear=False,
+    )
+    def test_go2rtc_env_takes_precedence_over_tapo(self):
+        config = ElevenLabsConfig.from_env()
+        assert config.go2rtc_camera_host == "override"

--- a/elevenlabs-t2s-mcp/tests/test_go2rtc.py
+++ b/elevenlabs-t2s-mcp/tests/test_go2rtc.py
@@ -1,0 +1,157 @@
+"""Tests for go2rtc auto-download and process management."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from elevenlabs_t2s_mcp.go2rtc import (
+    Go2RTCProcess,
+    detect_platform,
+    ensure_binary,
+    generate_config,
+)
+
+
+class TestDetectPlatform:
+    """Tests for platform detection."""
+
+    @patch("elevenlabs_t2s_mcp.go2rtc.platform")
+    def test_linux_amd64(self, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        mock_platform.machine.return_value = "x86_64"
+        assert detect_platform() == "go2rtc_linux_amd64"
+
+    @patch("elevenlabs_t2s_mcp.go2rtc.platform")
+    def test_linux_arm64(self, mock_platform):
+        mock_platform.system.return_value = "Linux"
+        mock_platform.machine.return_value = "aarch64"
+        assert detect_platform() == "go2rtc_linux_arm64"
+
+    @patch("elevenlabs_t2s_mcp.go2rtc.platform")
+    def test_darwin_arm64(self, mock_platform):
+        mock_platform.system.return_value = "Darwin"
+        mock_platform.machine.return_value = "arm64"
+        assert detect_platform() == "go2rtc_mac_arm64"
+
+    @patch("elevenlabs_t2s_mcp.go2rtc.platform")
+    def test_unsupported_platform(self, mock_platform):
+        mock_platform.system.return_value = "FreeBSD"
+        mock_platform.machine.return_value = "sparc64"
+        with pytest.raises(RuntimeError, match="Unsupported platform"):
+            detect_platform()
+
+
+class TestEnsureBinary:
+    """Tests for binary download."""
+
+    def test_binary_already_exists(self, tmp_path):
+        bin_path = tmp_path / "go2rtc"
+        bin_path.write_text("fake binary")
+        result = ensure_binary(bin_path)
+        assert result == bin_path
+
+    @patch("elevenlabs_t2s_mcp.go2rtc._get_download_url")
+    @patch("elevenlabs_t2s_mcp.go2rtc._download_file")
+    @patch("elevenlabs_t2s_mcp.go2rtc.detect_platform")
+    @patch("elevenlabs_t2s_mcp.go2rtc.platform")
+    def test_download_linux_binary(
+        self, mock_platform, mock_detect, mock_download, mock_url, tmp_path
+    ):
+        mock_platform.system.return_value = "Linux"
+        mock_detect.return_value = "go2rtc_linux_amd64"
+        mock_url.return_value = "https://example.com/go2rtc_linux_amd64"
+
+        bin_path = tmp_path / "go2rtc"
+
+        def fake_download(url, dest):
+            dest.write_text("fake binary")
+
+        mock_download.side_effect = fake_download
+
+        result = ensure_binary(bin_path)
+        assert result == bin_path
+        assert bin_path.exists()
+        mock_download.assert_called_once()
+
+
+class TestGenerateConfig:
+    """Tests for config file generation."""
+
+    def test_generates_valid_yaml(self, tmp_path):
+        config_path = tmp_path / "go2rtc.yaml"
+        result = generate_config(
+            config_path=config_path,
+            stream_name="tapo_cam",
+            camera_host="192.168.1.100",
+            username="admin",
+            password="secret",
+            ffmpeg_bin="/usr/bin/ffmpeg",
+        )
+        assert result == config_path
+        content = config_path.read_text()
+        assert "tapo_cam:" in content
+        assert "rtsp://admin:secret@192.168.1.100:554/stream1" in content
+        assert "tapo://secret@192.168.1.100" in content
+        assert "/usr/bin/ffmpeg" in content
+        assert '":1984"' in content
+
+    def test_creates_parent_directories(self, tmp_path):
+        config_path = tmp_path / "sub" / "dir" / "go2rtc.yaml"
+        generate_config(
+            config_path=config_path,
+            stream_name="cam",
+            camera_host="10.0.0.1",
+            username="u",
+            password="p",
+        )
+        assert config_path.exists()
+
+    def test_overwrites_existing(self, tmp_path):
+        config_path = tmp_path / "go2rtc.yaml"
+        config_path.write_text("old content")
+        generate_config(
+            config_path=config_path,
+            stream_name="new_cam",
+            camera_host="10.0.0.2",
+            username="u",
+            password="p",
+        )
+        content = config_path.read_text()
+        assert "new_cam:" in content
+        assert "old content" not in content
+
+
+class TestGo2RTCProcess:
+    """Tests for process lifecycle."""
+
+    def test_is_running_returns_false_when_unreachable(self):
+        proc = Go2RTCProcess(
+            Path("/fake/go2rtc"),
+            Path("/fake/config.yaml"),
+            api_url="http://localhost:19999",
+        )
+        assert proc.is_running() is False
+
+    @patch("elevenlabs_t2s_mcp.go2rtc.urllib.request.urlopen")
+    def test_is_running_returns_true_when_api_responds(self, mock_urlopen):
+        mock_urlopen.return_value.__enter__ = MagicMock()
+        mock_urlopen.return_value.__exit__ = MagicMock(return_value=False)
+        proc = Go2RTCProcess(
+            Path("/fake/go2rtc"),
+            Path("/fake/config.yaml"),
+        )
+        assert proc.is_running() is True
+
+    @pytest.mark.asyncio
+    @patch.object(Go2RTCProcess, "is_running", return_value=True)
+    async def test_start_skips_when_already_running(self, mock_running):
+        proc = Go2RTCProcess(Path("/fake"), Path("/fake"))
+        await proc.start()
+        # Should not spawn a process
+        assert proc._process is None
+
+    def test_stop_when_no_process(self):
+        proc = Go2RTCProcess(Path("/fake"), Path("/fake"))
+        # Should not raise
+        proc.stop()

--- a/wifi-cam-mcp/src/wifi_cam_mcp/server.py
+++ b/wifi-cam-mcp/src/wifi_cam_mcp/server.py
@@ -707,10 +707,15 @@ class CameraMCPServer:
         # Try to connect right camera if configured
         right_config = CameraConfig.right_camera_from_env()
         if right_config:
-            self._camera_right = TapoCamera(right_config, self._server_config.capture_dir)
-            await self._camera_right.connect()
-            self._has_stereo = True
-            logger.info(f"Connected to right camera at {right_config.host} (stereo vision enabled)")
+            try:
+                self._camera_right = TapoCamera(right_config, self._server_config.capture_dir)
+                await self._camera_right.connect()
+                self._has_stereo = True
+                logger.info(f"Connected to right camera at {right_config.host} (stereo vision enabled)")
+            except Exception as e:
+                logger.warning(f"Failed to connect right camera at {right_config.host}: {e}")
+                self._camera_right = None
+                self._has_stereo = False
 
     async def disconnect_camera(self) -> None:
         """Disconnect from the camera(s)."""


### PR DESCRIPTION
- Add go2rtc.py module for auto-downloading binary from GitHub Releases
- Auto-generate go2rtc.yaml config from environment variables
- Auto-start/stop go2rtc daemon on server lifecycle
- Add speaker parameter to say tool (camera/local/both)
- Add TAPO_* env var fallback for camera credentials
- Add right camera connection error handling (wifi-cam-mcp)
- Add .mcp.json with go2rtc env var configuration
- 20 tests passing (go2rtc + config)