### PR TITLE
feat: interoception hookに曜日情報を追加

### DIFF
--- a/.claude/hooks/interoception.sh
+++ b/.claude/hooks/interoception.sh
@@ -28,15 +28,23 @@ try:
     ar_arrow = arrows.get(trend.get('arousal', 'stable'), '→')
     mem_arrow = arrows.get(trend.get('mem_free', 'stable'), '→')
 
-    # タイムスタンプから時刻部分だけ
+    # タイムスタンプから時刻・曜日
+    from datetime import datetime
     ts = now.get('ts', '?')
     if 'T' in ts:
         time_part = ts.split('T')[1][:8]
+        try:
+            dt = datetime.strptime(ts[:10], '%Y-%m-%d')
+            dow = dt.strftime('%a')  # Mon, Tue, ...
+        except Exception:
+            dow = '?'
     else:
         time_part = ts
+        dow = '?'
 
     parts = [
         f\"time={time_part}\",
+        f\"day={dow}\",
         f\"phase={now.get('phase', '?')}\",
         f\"arousal={now.get('arousal', '?')}%({ar_arrow})\",
         f\"thermal={now.get('thermal', '?')}\",


### PR DESCRIPTION
## Summary
- interoception hookの出力に曜日（`day=Mon` 等）を追加

## Motivation
interoceptionでは時刻（`time=HH:MM:SS`）を出力していたが、曜日の情報がなかった。
LLMは日付から曜日を正確に導出できないことがあるため、heartbeat stateのISOタイムスタンプから曜日を算出し、毎ターンのコンテキストに埋め込むようにした。

## 変更内容
- `interoception.sh`: タイムスタンプの日付部分を `datetime.strptime` でパースし、`strftime('%a')` で曜日を取得
- 出力に `day=Mon` フィールドを追加（パース失敗時は `day=?` にフォールバック）

## 出力例

`[interoception] time=21:51:25 day=Mon phase=night arousal=28%(→) thermal=0 mem_free=38%(→) uptime=1447min heartbeats=12`

🤖 Generated with [Claude Code](https://claude.com/claude-code)