### PR TITLE
fix: add day/date to interoception hook fallback

### DIFF
--- a/.claude/hooks/interoception.sh
+++ b/.claude/hooks/interoception.sh
@@ -9,7 +9,9 @@ STATE_FILE="/tmp/interoception_state.json"
 # state file がなければフォールバック（デーモン未起動時）
 if [ ! -f "$STATE_FILE" ]; then
     CURRENT_TIME=$(date '+%H:%M:%S')
-    echo "[interoception] time=${CURRENT_TIME} (heartbeat daemon not running)"
+    CURRENT_DOW=$(date '+%a')
+    CURRENT_DATE=$(date '+%Y-%m-%d')
+    echo "[interoception] time=${CURRENT_TIME} day=${CURRENT_DOW} date=${CURRENT_DATE} (heartbeat daemon not running)"
     exit 0
 fi
 


### PR DESCRIPTION
## Summary

- When heartbeat daemon is not running, the interoception hook now outputs `day=Wed date=2026-02-18` alongside `time=02:59:28`
- Prevents incorrect day-of-week inference (e.g. saying "Tuesday" when it's actually Wednesday)

## Before
```
[interoception] time=02:58:08 (heartbeat daemon not running)
```

## After
```
[interoception] time=02:59:28 day=水 date=2026-02-18 (heartbeat daemon not running)
```