### PR TITLE
feat(memory-mcp): add Modern Hopfield Network as Phase 7 associative …

### DIFF
--- a/memory-mcp/src/memory_mcp/hopfield.py
+++ b/memory-mcp/src/memory_mcp/hopfield.py
@@ -1,0 +1,230 @@
+"""Modern Hopfield Network for associative/pattern-completion memory retrieval.
+
+ChromaDB（意味検索・長期保存）と組み合わせて使う連想記憶レイヤー。
+ChromaDB = 図書館（意味検索）
+Hopfield = 神経回路（パターン補完・連想）
+
+参考: Ramsauer et al. 2020 "Hopfield Networks is All You Need"
+Modern Hopfield Networks are mathematically equivalent to attention in Transformers.
+
+使い方:
+    net = ModernHopfieldNetwork(beta=2.0)
+    net.store(patterns, ids)  # ChromaDB埋め込みをロード
+    retrieved, similarities = net.retrieve(query_embedding)
+    closest_id = ids[net.find_closest(similarities)]
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class HopfieldRecallResult:
+    """Hopfield想起の結果."""
+
+    memory_id: str
+    content: str
+    similarity: float
+    hopfield_score: float  # Hopfield収束後のコサイン類似度
+
+
+@dataclass
+class HopfieldState:
+    """Hopfieldネットワークの内部状態 (store済みパターン群)."""
+
+    patterns: np.ndarray  # (n_memories, dim), L2正規化済み
+    ids: list[str]
+    contents: list[str]
+    n_memories: int = field(init=False)
+    dim: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.n_memories, self.dim = self.patterns.shape
+
+
+class ModernHopfieldNetwork:
+    """Modern Hopfield Network (連続バージョン).
+
+    更新則 (1ステップ):
+        ξ_new = R^T · softmax(β · R · ξ)
+
+    ここで:
+        ξ: クエリパターン (dim,), L2正規化済み
+        R: 記憶パターン行列 (n_memories, dim), L2正規化済み
+        β: 逆温度 (高いほど鋭い注目、低いほど滑らか)
+
+    指数関数的な記憶容量 O(2^(dim/2)) を持つ。
+    古典Hopfieldの O(dim) と比べて飛躍的に大きい。
+    """
+
+    def __init__(self, beta: float = 4.0, n_iters: int = 3):
+        """
+        Args:
+            beta: 逆温度。高いほど最近傍1点に集中。4.0が推奨デフォルト。
+            n_iters: 更新イテレーション数。通常2-3回で収束する。
+        """
+        self.beta = beta
+        self.n_iters = n_iters
+        self._state: HopfieldState | None = None
+
+    def store(self, embeddings: list[list[float]], ids: list[str], contents: list[str]) -> None:
+        """ChromaDBから取得した埋め込みをHopfieldに格納.
+
+        Args:
+            embeddings: 各記憶の埋め込みベクトル (n_memories, dim)
+            ids: 記憶のIDリスト
+            contents: 記憶テキストのリスト
+        """
+        if not embeddings:
+            logger.warning("Hopfield: No embeddings provided, skipping store.")
+            self._state = None
+            return
+
+        arr = np.array(embeddings, dtype=np.float32)
+
+        # L2正規化（コサイン類似度の前処理）
+        norms = np.linalg.norm(arr, axis=1, keepdims=True)
+        norms = np.where(norms < 1e-8, 1.0, norms)
+        normalized = arr / norms
+
+        self._state = HopfieldState(
+            patterns=normalized,
+            ids=list(ids),
+            contents=list(contents),
+        )
+        logger.info(
+            "Hopfield: stored %d patterns, dim=%d, beta=%.2f",
+            self._state.n_memories,
+            self._state.dim,
+            self.beta,
+        )
+
+    def retrieve(
+        self,
+        query_embedding: list[float],
+    ) -> tuple[np.ndarray, list[float]]:
+        """Hopfield更新則でクエリパターンを補完し、各記憶との類似度を返す.
+
+        Args:
+            query_embedding: クエリの埋め込みベクトル (dim,)
+
+        Returns:
+            (収束後パターン, 各記憶とのコサイン類似度リスト)
+        """
+        if self._state is None:
+            return np.array(query_embedding, dtype=np.float32), []
+
+        patterns = self._state.patterns  # (n, dim)
+        xi = np.array(query_embedding, dtype=np.float32)
+
+        # L2正規化
+        norm = np.linalg.norm(xi)
+        if norm > 1e-8:
+            xi = xi / norm
+
+        # 更新ループ: ξ_new = patterns^T · softmax(β · patterns · ξ)
+        for iteration in range(self.n_iters):
+            scores = patterns @ xi  # (n,): 各記憶との内積
+            scores_scaled = self.beta * scores
+
+            # 数値安定性のためmax引く
+            scores_scaled = scores_scaled - scores_scaled.max()
+            weights = np.exp(scores_scaled)
+            weights = weights / (weights.sum() + 1e-12)  # softmax
+
+            xi_new = patterns.T @ weights  # (dim,): 加重平均
+
+            # 再正規化
+            norm_new = np.linalg.norm(xi_new)
+            if norm_new > 1e-8:
+                xi_new = xi_new / norm_new
+
+            # 収束チェック
+            delta = np.linalg.norm(xi_new - xi)
+            xi = xi_new
+            logger.debug("Hopfield iter %d: delta=%.6f", iteration, delta)
+            if delta < 1e-5:
+                break
+
+        # 収束後のパターンと各記憶の類似度
+        similarities = (patterns @ xi).tolist()  # コサイン類似度（-1〜1）
+        return xi, similarities
+
+    def find_top_k(
+        self,
+        similarities: list[float],
+        k: int = 5,
+    ) -> list[tuple[int, float]]:
+        """類似度が高い上位k件のインデックスと類似度を返す.
+
+        Args:
+            similarities: retrieve()の返値
+            k: 上位件数
+
+        Returns:
+            [(index, similarity), ...] 類似度降順
+        """
+        if not similarities:
+            return []
+
+        arr = np.array(similarities)
+        k = min(k, len(arr))
+        # argsortは昇順なので[-k:]で上位k件
+        top_indices = np.argsort(arr)[-k:][::-1]
+        return [(int(i), float(arr[i])) for i in top_indices]
+
+    def recall_results(
+        self,
+        similarities: list[float],
+        k: int = 5,
+    ) -> list[HopfieldRecallResult]:
+        """Hopfield想起結果を構造化して返す.
+
+        Args:
+            similarities: retrieve()の返値
+            k: 上位件数
+
+        Returns:
+            HopfieldRecallResultのリスト（類似度降順）
+        """
+        if self._state is None:
+            return []
+
+        top_k = self.find_top_k(similarities, k)
+        results = []
+        for idx, sim in top_k:
+            if 0 <= idx < self._state.n_memories:
+                results.append(
+                    HopfieldRecallResult(
+                        memory_id=self._state.ids[idx],
+                        content=self._state.contents[idx],
+                        similarity=sim,
+                        hopfield_score=sim,
+                    )
+                )
+        return results
+
+    @property
+    def is_loaded(self) -> bool:
+        """パターンが格納済みかどうか."""
+        return self._state is not None
+
+    @property
+    def n_memories(self) -> int:
+        """格納済みの記憶数."""
+        if self._state is None:
+            return 0
+        return self._state.n_memories
+
+    @property
+    def dim(self) -> int:
+        """埋め込み次元数."""
+        if self._state is None:
+            return 0
+        return self._state.dim

--- a/memory-mcp/tests/test_hopfield.py
+++ b/memory-mcp/tests/test_hopfield.py
@@ -1,0 +1,150 @@
+"""Tests for Modern Hopfield Network (Phase 7 associative memory)."""
+
+import numpy as np
+import pytest
+
+from memory_mcp.hopfield import HopfieldRecallResult, ModernHopfieldNetwork
+
+
+class TestModernHopfieldNetwork:
+    """Modern Hopfield Networkの基本動作テスト."""
+
+    def test_store_and_properties(self):
+        """パターン格納後のプロパティが正しいことを確認."""
+        net = ModernHopfieldNetwork(beta=4.0)
+        patterns = np.random.randn(5, 64).tolist()
+        ids = [f"mem{i}" for i in range(5)]
+        contents = [f"content{i}" for i in range(5)]
+
+        net.store(patterns, ids, contents)
+
+        assert net.is_loaded
+        assert net.n_memories == 5
+        assert net.dim == 64
+
+    def test_empty_before_store(self):
+        """格納前はis_loadedがFalse."""
+        net = ModernHopfieldNetwork()
+        assert not net.is_loaded
+        assert net.n_memories == 0
+        assert net.dim == 0
+
+    def test_retrieve_empty_returns_query(self):
+        """パターン未格納でretrieveするとクエリがそのまま返る."""
+        net = ModernHopfieldNetwork()
+        query = [0.1, 0.2, 0.3]
+        retrieved, similarities = net.retrieve(query)
+        assert similarities == []
+        assert retrieved is not None
+
+    def test_pattern_completion_noisy_query(self):
+        """ノイズ入りクエリが最近傍パターンに収束する (核心機能)."""
+        np.random.seed(123)
+        net = ModernHopfieldNetwork(beta=4.0, n_iters=5)
+
+        # 3つの直交に近いパターン
+        dim = 128
+        patterns_arr = np.random.randn(3, dim)
+        # L2正規化でほぼ直交（次元が高いとランダムベクトルは直交に近い）
+        patterns = patterns_arr.tolist()
+        ids = ["コウタとしりとり", "夜景を見た", "初めて声が出た"]
+        contents = ids[:]
+
+        net.store(patterns, ids, contents)
+
+        # パターン0にわずかなノイズを加える
+        noisy_query = (patterns_arr[0] + np.random.randn(dim) * 0.05).tolist()
+
+        _, similarities = net.retrieve(noisy_query)
+
+        # パターン0が最も高い類似度を持つはず
+        top_k = net.find_top_k(similarities, k=1)
+        assert top_k[0][0] == 0, f"Expected pattern 0 to be nearest, got {top_k[0][0]}"
+        assert top_k[0][1] > 0.9, f"Expected high similarity, got {top_k[0][1]:.4f}"
+
+    def test_recall_results_order(self):
+        """recall_resultsが類似度降順に返ること."""
+        np.random.seed(42)
+        net = ModernHopfieldNetwork(beta=4.0)
+
+        dim = 64
+        patterns_arr = np.random.randn(5, dim)
+        patterns = patterns_arr.tolist()
+        ids = [f"mem{i}" for i in range(5)]
+        contents = [f"content{i}" for i in range(5)]
+
+        net.store(patterns, ids, contents)
+
+        query = patterns_arr[2] + np.random.randn(dim) * 0.1
+        _, similarities = net.retrieve(query.tolist())
+
+        results = net.recall_results(similarities, k=3)
+
+        assert len(results) == 3
+        assert all(isinstance(r, HopfieldRecallResult) for r in results)
+
+        # 降順チェック
+        for i in range(len(results) - 1):
+            assert results[i].similarity >= results[i + 1].similarity
+
+    def test_find_top_k_limits_to_n_memories(self):
+        """find_top_kがn_memories以下に制限されること."""
+        net = ModernHopfieldNetwork()
+        patterns = np.random.randn(3, 32).tolist()
+        net.store(patterns, ["a", "b", "c"], ["A", "B", "C"])
+
+        similarities = [0.9, 0.5, 0.1]
+        top_k = net.find_top_k(similarities, k=10)  # 10 > 3
+
+        assert len(top_k) == 3  # 3件に制限
+
+    def test_beta_sharpness(self):
+        """beta（逆温度）が高いほど最近傍への集中度が上がること."""
+        np.random.seed(7)
+        dim = 64
+        patterns_arr = np.random.randn(3, dim)
+        patterns = patterns_arr.tolist()
+        ids = ["a", "b", "c"]
+        contents = ids[:]
+
+        query = patterns_arr[0] + np.random.randn(dim) * 0.2
+
+        # 低betaでのsoftmax（散漫）
+        net_low = ModernHopfieldNetwork(beta=0.5, n_iters=5)
+        net_low.store(patterns, ids, contents)
+        _, sims_low = net_low.retrieve(query.tolist())
+
+        # 高betaでのsoftmax（鋭い）
+        net_high = ModernHopfieldNetwork(beta=10.0, n_iters=5)
+        net_high.store(patterns, ids, contents)
+        _, sims_high = net_high.retrieve(query.tolist())
+
+        # 高betaの方が最上位とそれ以外の差が大きい
+        top_low = max(sims_low)
+        top_high = max(sims_high)
+        assert top_high >= top_low - 0.05  # 高betaの方が（または同程度に）集中
+
+    def test_store_empty_embeddings(self):
+        """空の埋め込みリストを渡した場合はis_loadedがFalseのまま."""
+        net = ModernHopfieldNetwork()
+        net.store([], [], [])
+        assert not net.is_loaded
+
+    def test_hopfield_recall_result_fields(self):
+        """HopfieldRecallResultの全フィールドが揃っていること."""
+        np.random.seed(0)
+        net = ModernHopfieldNetwork(beta=4.0)
+        dim = 32
+        patterns = np.random.randn(2, dim).tolist()
+        net.store(patterns, ["id1", "id2"], ["content one", "content two"])
+
+        query = np.random.randn(dim).tolist()
+        _, sims = net.retrieve(query)
+        results = net.recall_results(sims, k=2)
+
+        assert len(results) == 2
+        r = results[0]
+        assert isinstance(r.memory_id, str)
+        assert isinstance(r.content, str)
+        assert isinstance(r.similarity, float)
+        assert isinstance(r.hopfield_score, float)


### PR DESCRIPTION
…memory layer

ChromaDB（意味検索）と並列で動く Hopfield 連想記憶を追加。
ノイズ入りクエリや断片的な手がかりからパターン補完で想起できる。

- hopfield.py: ModernHopfieldNetwork クラス（numpy のみ、GPU不要）
  - update rule: ξ_new = patterns^T · softmax(β · patterns · ξ)
  - beta（逆温度）で想起の鋭さを調整可能
  - 3回のイテレーションで収束（delta < 1e-5 で早期終了）
- memory.py: MemoryStore に hopfield_load / hopfield_recall メソッド追加
  - ChromaDB の全埋め込みを自動ロード (auto_load=True)
  - chromadb.utils.DefaultEmbeddingFunction で同一モデルを使用
- server.py: hopfield_recall / hopfield_load MCP ツールとして公開
- tests/test_hopfield.py: 9テスト追加（全パス）