### PR TITLE
feat(wifi-cam-mcp): ローカルPCマイク対応をlistenツールに追加

### DIFF
--- a/wifi-cam-mcp/src/wifi_cam_mcp/config.py
+++ b/wifi-cam-mcp/src/wifi_cam_mcp/config.py
@@ -108,12 +108,17 @@ class ServerConfig:
     name: str = "wifi-cam-mcp"
     version: str = "0.1.0"
     capture_dir: str = "/tmp/wifi-cam-mcp"
+    mic_source: str = "camera"  # "camera" (RTSP) or "local" (PC microphone)
 
     @classmethod
     def from_env(cls) -> "ServerConfig":
         """Create config from environment variables."""
+        mic_source = os.getenv("MIC_SOURCE", "camera").lower()
+        if mic_source not in ("camera", "local"):
+            raise ValueError(f"Invalid MIC_SOURCE '{mic_source}'. Must be 'camera' or 'local'.")
         return cls(
             name=os.getenv("MCP_SERVER_NAME", "wifi-cam-mcp"),
             version=os.getenv("MCP_SERVER_VERSION", "0.1.0"),
             capture_dir=os.getenv("CAPTURE_DIR", "/tmp/wifi-cam-mcp"),
+            mic_source=mic_source,
         )

--- a/wifi-cam-mcp/src/wifi_cam_mcp/server.py
+++ b/wifi-cam-mcp/src/wifi_cam_mcp/server.py
@@ -465,7 +465,9 @@ class CameraMCPServer:
                     case "listen":
                         duration = min(arguments.get("duration", 5), 30)
                         transcribe = arguments.get("transcribe", True)
-                        result = await self._camera.listen_audio(duration, transcribe)
+                        result = await self._camera.listen_audio(
+                            duration, transcribe, self._server_config.mic_source
+                        )
 
                         response_text = (
                             f"Recorded {result.duration}s of audio at {result.timestamp}\n"


### PR DESCRIPTION
## Summary

- `MIC_SOURCE` 環境変数（`camera` | `local`）でlistenツールの音声入力ソースを切り替えられるようにした
- `local` に設定するとカメラのRTSPマイクの代わりにPCの内蔵マイクを使用する
- macOSでは `ffmpeg -f avfoundation`、Linuxでは `ffmpeg -f alsa` を使用

## Motivation

カメラのマイクはノイズが多かったり、カメラの設置場所によっては音声認識の精度が落ちる場合がある。PCの内蔵マイクを使うことで、より高品質な音声入力が可能になる。

## Usage

`.mcp.json` の環境変数に追加するだけで切り替え可能：

```json
"wifi-cam": {
  "env": {
    "MIC_SOURCE": "local"
  }
}
```

デフォルトは `"camera"`（従来通り）なので、既存の設定への影響はない。