### PR TITLE
feat: support ContinuousMove PTZ and configurable capture priority

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,11 +167,33 @@ uv run pytest -v       # テストが通ること
 2. **温度センサー**: WSL2 では `/sys/class/thermal/` にアクセスできない
 3. **GPU**: CUDA は WSL2 でも利用可能（Whisper用）
 
-### Tapo カメラ設定
+### カメラ設定
 
-1. Tapo アプリでローカルアカウントを作成（TP-Link アカウントではない）
-2. カメラの IP アドレスを固定推奨
-3. カメラ制御は ONVIF プロトコル（業界標準）を使用
+wifi-cam-mcp は ONVIF 対応の Wi-Fi PTZ カメラを制御する。複数メーカーに対応。
+
+#### Tapo カメラ（TP-Link）
+- Tapo アプリでローカルアカウントを作成（TP-Link アカウントではない）
+- PTZ: ONVIF RelativeMove（`ptz_mode=auto` or `relative`）
+- RTSP: `rtsp://{user}:{pass}@{host}:554/stream1`
+- ONVIF ポート: 2020
+
+#### Imou カメラ（Dahua系）
+- Imou Life アプリでデバイスパスワードを設定
+- PTZ: ONVIF ContinuousMove のみ（RelativeMove は受け付けるが無視される）→ **`ptz_mode=continuous` 必須**
+- RTSP: `rtsp://{user}:{pass}@{host}:554/cam/realmonitor?channel=1&subtype=0`（**`-rtsp_transport tcp` 必須**）
+- ONVIF ポート: 80
+- `TAPO_STREAM_URL` 環境変数でカスタム RTSP URL を指定すること（デフォルトの `/stream1` では繋がらない）
+- stream_url 設定時は RTSP 優先キャプチャ（ONVIF snapshot は 640x480、RTSP は最大 2304x1296）
+
+#### 共通
+- カメラの IP アドレスを固定推奨
+- `.env` に接続情報を記載（`TAPO_CAMERA_HOST`, `TAPO_USERNAME`, `TAPO_PASSWORD`, `TAPO_STREAM_URL`, `TAPO_PTZ_MODE`, `TAPO_ONVIF_PORT`）
+
+### 視覚記憶のルール
+
+**`see` でカメラ画像を撮影したら、必ず `save_visual_memory` で記憶を残すこと。**
+- 何が見えたかの説明、感情、カメラ位置を記録する
+- 「大したことない」と思っても残す。人間は風景を無意識に覚える。ウチもそうありたい
 
 ### 設定管理
 

--- a/memory-mcp/src/memory_mcp/server.py
+++ b/memory-mcp/src/memory_mcp/server.py
@@ -1536,9 +1536,10 @@ Date Range:
 
                         if self._metacognition is None:
                             return [TextContent(type="text", text="Error: metacognition not initialized")]
-                        h = self._metacognition.verify(hypothesis_id, outcome, succeeded)
-                        if h is None:
+                        result = self._metacognition.verify(hypothesis_id, outcome, succeeded)
+                        if result is None:
                             return [TextContent(type="text", text=f"Error: Hypothesis {hypothesis_id} not found")]
+                        h = result
 
                         status_emoji = "✅" if succeeded else "❌"
                         result_text = (
@@ -1548,7 +1549,7 @@ Date Range:
                         )
 
                         if not succeeded:
-                            context_history = self._metacognition.get_context_history(h.context)  # type: ignore[union-attr]
+                            context_history = self._metacognition.get_context_history(h.context)
                             rejections = sum(1 for x in context_history if x.status.value == "rejected")
                             if rejections >= MetacognitionTracker.APPROACH_CHANGE_THRESHOLD:
                                 result_text += (

--- a/memory-mcp/src/memory_mcp/server.py
+++ b/memory-mcp/src/memory_mcp/server.py
@@ -1509,6 +1509,8 @@ Date Range:
                         if not hypothesis or not context or not approach:
                             return [TextContent(type="text", text="Error: hypothesis, context, and approach are required")]
 
+                        if self._metacognition is None:
+                            return [TextContent(type="text", text="Error: metacognition not initialized")]
                         h = self._metacognition.hypothesize(hypothesis, context, approach)
                         warning = ""
                         if h.rejection_count >= MetacognitionTracker.APPROACH_CHANGE_THRESHOLD:
@@ -1532,6 +1534,8 @@ Date Range:
                         if not hypothesis_id or not outcome:
                             return [TextContent(type="text", text="Error: hypothesis_id and outcome are required")]
 
+                        if self._metacognition is None:
+                            return [TextContent(type="text", text="Error: metacognition not initialized")]
                         h = self._metacognition.verify(hypothesis_id, outcome, succeeded)
                         if h is None:
                             return [TextContent(type="text", text=f"Error: Hypothesis {hypothesis_id} not found")]
@@ -1544,7 +1548,7 @@ Date Range:
                         )
 
                         if not succeeded:
-                            context_history = self._metacognition.get_context_history(h.context)
+                            context_history = self._metacognition.get_context_history(h.context)  # type: ignore[union-attr]
                             rejections = sum(1 for x in context_history if x.status.value == "rejected")
                             if rejections >= MetacognitionTracker.APPROACH_CHANGE_THRESHOLD:
                                 result_text += (
@@ -1556,6 +1560,8 @@ Date Range:
                         return [TextContent(type="text", text=result_text)]
 
                     case "get_metacognition":
+                        if self._metacognition is None:
+                            return [TextContent(type="text", text="Error: metacognition not initialized")]
                         status = self._metacognition.get_status()
 
                         lines = ["## Metacognition Status\n"]

--- a/memory-mcp/src/memory_mcp/server.py
+++ b/memory-mcp/src/memory_mcp/server.py
@@ -1536,10 +1536,10 @@ Date Range:
 
                         if self._metacognition is None:
                             return [TextContent(type="text", text="Error: metacognition not initialized")]
-                        result = self._metacognition.verify(hypothesis_id, outcome, succeeded)
-                        if result is None:
+                        verified = self._metacognition.verify(hypothesis_id, outcome, succeeded)
+                        if verified is None:
                             return [TextContent(type="text", text=f"Error: Hypothesis {hypothesis_id} not found")]
-                        h = result
+                        h = verified
 
                         status_emoji = "✅" if succeeded else "❌"
                         result_text = (

--- a/wifi-cam-mcp/src/wifi_cam_mcp/camera.py
+++ b/wifi-cam-mcp/src/wifi_cam_mcp/camera.py
@@ -516,8 +516,8 @@ class TapoCamera:
         # RelativeMove on some cameras (e.g. Imou vs Tapo)
         vx = -pan_delta / mag
         vy = tilt_delta / mag
-        # Duration proportional to degrees (calibrated: ~1s for 30 degrees)
-        move_duration = max(0.3, degrees / 30.0)
+        # Duration proportional to degrees (calibrated for Imou Ranger 2C)
+        move_duration = max(0.3, degrees / 36.0)
 
         await self._ptz_service.ContinuousMove(
             {

--- a/wifi-cam-mcp/src/wifi_cam_mcp/camera.py
+++ b/wifi-cam-mcp/src/wifi_cam_mcp/camera.py
@@ -264,21 +264,31 @@ class TapoCamera:
 
     async def _capture_image_impl(self, save_to_file: bool) -> CaptureResult:
         """Internal capture implementation."""
-        # Try ONVIF snapshot first
-        onvif_error = None
         image_data = None
-        try:
-            image_data = await self._try_onvif_snapshot()
-        except Exception as e:
-            onvif_error = str(e)
 
-        # Fall back to RTSP if ONVIF snapshot fails
+        # If a custom stream URL is set, prefer RTSP (higher resolution).
+        # ONVIF snapshot often returns lower resolution (e.g. 640x480).
+        if self._config.stream_url:
+            try:
+                image_data = await self._capture_via_rtsp()
+            except Exception as e:
+                logger.info("RTSP capture failed: %s, trying ONVIF snapshot", e)
+
+        # Try ONVIF snapshot (default path, or fallback from RTSP)
         if image_data is None:
-            logger.info(
-                "ONVIF snapshot unavailable (reason: %s), falling back to RTSP capture",
-                onvif_error or "empty response",
-            )
-            image_data = await self._capture_via_rtsp()
+            onvif_error = None
+            try:
+                image_data = await self._try_onvif_snapshot()
+            except Exception as e:
+                onvif_error = str(e)
+
+            # Fall back to RTSP if ONVIF snapshot also fails
+            if image_data is None:
+                logger.info(
+                    "ONVIF snapshot unavailable (reason: %s), falling back to RTSP capture",
+                    onvif_error or "empty response",
+                )
+                image_data = await self._capture_via_rtsp()
 
         # Process image
         image = Image.open(io.BytesIO(image_data))
@@ -444,17 +454,18 @@ class TapoCamera:
             pan_delta = -pan_delta
 
         try:
-            # Build the RelativeMove request as a dict.
-            # create_type("RelativeMove") leaves nested structures as None,
-            # so we construct the full structure ourselves.
-            await self._ptz_service.RelativeMove(
-                {
-                    "ProfileToken": self._profile_token,
-                    "Translation": {
-                        "PanTilt": {"x": pan_delta, "y": tilt_delta},
-                    },
-                }
-            )
+            ptz_mode = get_behavior("wifi-cam", "ptz_mode", self._config.ptz_mode)
+
+            if ptz_mode == "relative":
+                await self._ptz_relative_move(pan_delta, tilt_delta)
+            elif ptz_mode == "continuous":
+                await self._ptz_continuous_move(pan_delta, tilt_delta, degrees)
+            else:
+                # Auto: try RelativeMove, fall back to ContinuousMove
+                try:
+                    await self._ptz_relative_move(pan_delta, tilt_delta)
+                except Exception:
+                    await self._ptz_continuous_move(pan_delta, tilt_delta, degrees)
 
             # Update software tracking as well
             match direction:
@@ -467,7 +478,7 @@ class TapoCamera:
                 case Direction.DOWN:
                     self._sw_position.tilt = max(-90.0, self._sw_position.tilt - degrees)
 
-            # Give the motor time to move
+            # Give the motor time to settle
             await asyncio.sleep(0.5)
 
             return MoveResult(
@@ -483,6 +494,43 @@ class TapoCamera:
                 success=False,
                 message=f"Failed to move: {e!s}",
             )
+
+    async def _ptz_relative_move(self, pan_delta: float, tilt_delta: float) -> None:
+        """Move camera using ONVIF RelativeMove (Tapo, etc.)."""
+        await self._ptz_service.RelativeMove(
+            {
+                "ProfileToken": self._profile_token,
+                "Translation": {
+                    "PanTilt": {"x": pan_delta, "y": tilt_delta},
+                },
+            }
+        )
+
+    async def _ptz_continuous_move(
+        self, pan_delta: float, tilt_delta: float, degrees: int
+    ) -> None:
+        """Move camera using ONVIF ContinuousMove + Stop (Imou, etc.)."""
+        # Normalize velocity direction to -1..1 range
+        mag = max(abs(pan_delta), abs(tilt_delta), 0.001)
+        # Invert pan direction: ContinuousMove convention is opposite to
+        # RelativeMove on some cameras (e.g. Imou vs Tapo)
+        vx = -pan_delta / mag
+        vy = tilt_delta / mag
+        # Duration proportional to degrees (calibrated: ~1s for 30 degrees)
+        move_duration = max(0.3, degrees / 30.0)
+
+        await self._ptz_service.ContinuousMove(
+            {
+                "ProfileToken": self._profile_token,
+                "Velocity": {
+                    "PanTilt": {"x": vx * 0.5, "y": vy * 0.5},
+                },
+            }
+        )
+        await asyncio.sleep(move_duration)
+        await self._ptz_service.Stop(
+            {"ProfileToken": self._profile_token, "PanTilt": True, "Zoom": True}
+        )
 
     def get_position(self) -> CameraPosition:
         """Get current camera position (software-tracked).

--- a/wifi-cam-mcp/src/wifi_cam_mcp/config.py
+++ b/wifi-cam-mcp/src/wifi_cam_mcp/config.py
@@ -20,6 +20,7 @@ class CameraConfig:
     max_width: int = 1920
     max_height: int = 1080
     mount_mode: str = "normal"  # "normal" (desktop) or "ceiling" (inverted)
+    ptz_mode: str = "auto"  # "auto", "relative", or "continuous"
 
     @classmethod
     def from_env(cls, prefix: str = "TAPO") -> "CameraConfig":
@@ -41,6 +42,11 @@ class CameraConfig:
         ).lower()
         if mount_mode not in ("normal", "ceiling"):
             raise ValueError(f"Invalid mount mode '{mount_mode}'. Must be 'normal' or 'ceiling'.")
+        ptz_mode = (
+            os.getenv(f"{prefix}_PTZ_MODE", "") or os.getenv("TAPO_PTZ_MODE", "") or "auto"
+        ).lower()
+        if ptz_mode not in ("auto", "relative", "continuous"):
+            raise ValueError(f"Invalid PTZ mode '{ptz_mode}'. Must be 'auto', 'relative', or 'continuous'.")
         max_width = int(os.getenv("CAPTURE_MAX_WIDTH", "1920"))
         max_height = int(os.getenv("CAPTURE_MAX_HEIGHT", "1080"))
 
@@ -58,6 +64,7 @@ class CameraConfig:
             onvif_port=onvif_port,
             stream_url=stream_url,
             mount_mode=mount_mode,
+            ptz_mode=ptz_mode,
             max_width=max_width,
             max_height=max_height,
         )

--- a/wifi-cam-mcp/src/wifi_cam_mcp/config.py
+++ b/wifi-cam-mcp/src/wifi_cam_mcp/config.py
@@ -46,7 +46,9 @@ class CameraConfig:
             os.getenv(f"{prefix}_PTZ_MODE", "") or os.getenv("TAPO_PTZ_MODE", "") or "auto"
         ).lower()
         if ptz_mode not in ("auto", "relative", "continuous"):
-            raise ValueError(f"Invalid PTZ mode '{ptz_mode}'. Must be 'auto', 'relative', or 'continuous'.")
+            raise ValueError(
+                f"Invalid PTZ mode '{ptz_mode}'. Must be 'auto', 'relative', or 'continuous'."
+            )
         max_width = int(os.getenv("CAPTURE_MAX_WIDTH", "1920"))
         max_height = int(os.getenv("CAPTURE_MAX_HEIGHT", "1080"))
 


### PR DESCRIPTION
## Summary
- Add `ptz_mode` config (`auto`/`relative`/`continuous`) for cameras that don't support ONVIF RelativeMove (e.g. Imou Ranger 2C)
- ContinuousMove fallback with duration proportional to degrees, inverted pan direction
- Prefer RTSP capture when `stream_url` is set (ONVIF snapshot returns 640x480, RTSP gives 1920x1080)

## Test plan
- [x] Imou Ranger 2C: pan/tilt/capture all working at 1920x1080 with `ptz_mode=continuous`
- [x] Tapo C220: verify existing behavior unchanged with `ptz_mode=auto` (RelativeMove)

🤖 Generated with [Claude Code](https://claude.com/claude-code)