### PR TITLE
feat: Full HD visual memory + Garmin heart rate interoception

### DIFF
--- a/.claude/hooks/garmin-hr-cache.sh
+++ b/.claude/hooks/garmin-hr-cache.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# garmin-hr-cache.sh — Fetch latest heart rate from Garmin and cache it
+# Run via cron every 5 minutes: */5 * * * * /path/to/garmin-hr-cache.sh
+# Writes latest HR to /tmp/garmin_hr_latest.txt for interoception.sh to read
+
+CACHE_FILE="/tmp/garmin_hr_latest.txt"
+GARMIN_MCP_DIR="/home/mizushima/repo/garmin-health-mcp"
+
+cd "$GARMIN_MCP_DIR" || exit 1
+
+# Call garmin-connect to get today's heart rate and extract latest value
+node -e "
+const GarminConnect = require('garmin-connect');
+const { GarminConnect: GC } = GarminConnect;
+const { readFileSync, existsSync } = require('fs');
+const { join } = require('path');
+const { homedir } = require('os');
+
+(async () => {
+  const TOKEN_PATH = join(homedir(), '.garmin-token.json');
+  const client = new GC({
+    username: process.env.GARMIN_EMAIL || '',
+    password: process.env.GARMIN_PASSWORD || '',
+  });
+
+  if (existsSync(TOKEN_PATH)) {
+    const token = JSON.parse(readFileSync(TOKEN_PATH, 'utf-8'));
+    await client.loadToken(token);
+  }
+
+  const hr = await client.getHeartRate(new Date());
+  const values = hr?.heartRateValues || [];
+  let latest = null;
+  for (const entry of values) {
+    if (entry && entry[1] > 0) latest = entry[1];
+  }
+  if (latest) {
+    console.log(latest + 'bpm');
+  }
+})().catch(() => {});
+" 2>/dev/null > "$CACHE_FILE"

--- a/.claude/hooks/interoception.sh
+++ b/.claude/hooks/interoception.sh
@@ -6,12 +6,23 @@
 
 STATE_FILE="/tmp/interoception_state.json"
 
+# Garmin heart rate cache (updated by garmin-hr-cache.sh cron job)
+GARMIN_HR_FILE="/tmp/garmin_hr_latest.txt"
+GARMIN_HR=""
+if [ -f "$GARMIN_HR_FILE" ]; then
+    GARMIN_HR=$(cat "$GARMIN_HR_FILE" 2>/dev/null)
+fi
+
 # state file がなければフォールバック（デーモン未起動時）
 if [ ! -f "$STATE_FILE" ]; then
     CURRENT_TIME=$(date '+%H:%M:%S')
     CURRENT_DOW=$(date '+%a')
     CURRENT_DATE=$(date '+%Y-%m-%d')
-    echo "[interoception] time=${CURRENT_TIME} day=${CURRENT_DOW} date=${CURRENT_DATE} (heartbeat daemon not running)"
+    HR_PART=""
+    if [ -n "$GARMIN_HR" ]; then
+        HR_PART=" companion_hr=${GARMIN_HR}"
+    fi
+    echo "[interoception] time=${CURRENT_TIME} day=${CURRENT_DOW} date=${CURRENT_DATE}${HR_PART} (heartbeat daemon not running)"
     exit 0
 fi
 

--- a/memory-mcp/src/memory_mcp/image_utils.py
+++ b/memory-mcp/src/memory_mcp/image_utils.py
@@ -13,6 +13,7 @@ RESOLUTION_PRESETS: dict[str, tuple[int, int]] = {
     "low": (160, 120),
     "medium": (320, 240),
     "high": (640, 480),
+    "full_hd": (1920, 1080),
 }
 
 
@@ -56,11 +57,19 @@ def encode_image_for_memory(
         return None
 
 
+QUALITY_PRESETS: dict[str, int] = {
+    "low": 40,
+    "medium": 60,
+    "high": 75,
+    "full_hd": 85,
+}
+
+
 def resolve_resolution(resolution: str | None) -> tuple[int, int]:
     """解像度プリセット名をサイズに変換する.
 
     Args:
-        resolution: "low", "medium", "high" または None
+        resolution: "low", "medium", "high", "full_hd" または None
 
     Returns:
         (max_width, max_height) タプル
@@ -68,3 +77,10 @@ def resolve_resolution(resolution: str | None) -> tuple[int, int]:
     if resolution is None:
         return RESOLUTION_PRESETS["medium"]
     return RESOLUTION_PRESETS.get(resolution, RESOLUTION_PRESETS["medium"])
+
+
+def resolve_quality(resolution: str | None) -> int:
+    """解像度プリセットに応じたJPEG品質を返す."""
+    if resolution is None:
+        return QUALITY_PRESETS["medium"]
+    return QUALITY_PRESETS.get(resolution, QUALITY_PRESETS["medium"])

--- a/memory-mcp/src/memory_mcp/sensory.py
+++ b/memory-mcp/src/memory_mcp/sensory.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-from .image_utils import encode_image_for_memory, resolve_resolution
+from .image_utils import encode_image_for_memory, resolve_quality, resolve_resolution
 from .types import CameraPosition, Memory, SensoryData
 
 if TYPE_CHECKING:
@@ -53,8 +53,9 @@ class SensoryIntegration:
         """
         # 画像をリサイズ＆base64エンコード
         max_width, max_height = resolve_resolution(resolution)
+        quality = resolve_quality(resolution)
         image_data = encode_image_for_memory(
-            image_path, max_width=max_width, max_height=max_height
+            image_path, max_width=max_width, max_height=max_height, quality=quality
         )
 
         # 感覚データを作成

--- a/memory-mcp/src/memory_mcp/server.py
+++ b/memory-mcp/src/memory_mcp/server.py
@@ -440,9 +440,9 @@ class MemoryMCPServer:
                             },
                             "resolution": {
                                 "type": "string",
-                                "description": "Image resolution for memory storage: 'low' (160x120), 'medium' (320x240, default), 'high' (640x480)",
+                                "description": "Image resolution for memory storage: 'low' (160x120), 'medium' (320x240, default), 'high' (640x480), 'full_hd' (1920x1080)",
                                 "default": "medium",
-                                "enum": ["low", "medium", "high"],
+                                "enum": ["low", "medium", "high", "full_hd"],
                             },
                         },
                         "required": ["content", "image_path", "camera_position"],


### PR DESCRIPTION
## Summary
- Add `full_hd` resolution preset (1920x1080, quality 85) for `save_visual_memory`
- Resolution-aware JPEG quality presets (low=40, medium=60, high=75, full_hd=85)
- Inject companion heart rate from Garmin watch into interoception hook
- Add `garmin-hr-cache.sh` cron script (5min polling)

## Test plan
- [ ] save_visual_memory with resolution="full_hd" produces clear images
- [ ] interoception hook shows companion_hr when cache file exists
- [ ] garmin-hr-cache.sh successfully fetches and caches HR data

🤖 Generated with [Claude Code](https://claude.com/claude-code)