### PR TITLE
fix: portable heartbeat install + cache/companion_hr fixes

### DIFF
--- a/.claude/hooks/com.embodied-claude.heartbeat.plist
+++ b/.claude/hooks/com.embodied-claude.heartbeat.plist
@@ -7,7 +7,7 @@
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/bash</string>
-		<string>/Users/kota.mizushima/repo/embodied-claude/.claude/hooks/heartbeat-daemon.sh</string>
+		<string>__EMBODIED_CLAUDE_ROOT__/.claude/hooks/heartbeat-daemon.sh</string>
 	</array>
 	<key>StartInterval</key>
 	<integer>5</integer>

--- a/.claude/hooks/garmin-hr-cache.sh
+++ b/.claude/hooks/garmin-hr-cache.sh
@@ -15,7 +15,7 @@ if [ -f "$GARMIN_MCP_DIR/.env" ]; then
 fi
 
 # Call garmin-connect to get today's heart rate and extract latest value
-node -e "
+HR_RESULT=$(node -e "
 const GarminConnect = require('garmin-connect');
 const { GarminConnect: GC } = GarminConnect;
 const { readFileSync, existsSync } = require('fs');
@@ -48,4 +48,9 @@ const { homedir } = require('os');
   }
   if (out) console.log(out);
 })().catch(() => {});
-" 2>/dev/null | grep -oE '[0-9]+bpm(@[0-9:]+|\(resting\))?' | tail -1 > "$CACHE_FILE"
+" 2>/dev/null | grep -oE '[0-9]+bpm(@[0-9:]+|\(resting\))?' | tail -1)
+
+# Only overwrite cache if we got data
+if [ -n "$HR_RESULT" ]; then
+    echo "$HR_RESULT" > "$CACHE_FILE"
+fi

--- a/.claude/hooks/install-heartbeat.sh
+++ b/.claude/hooks/install-heartbeat.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# install-heartbeat.sh - heartbeat-daemon の launchd 登録を行う
+#
+# このスクリプトは embodied-claude リポジトリのルートを自動検出し、
+# plist template のプレースホルダ (__EMBODIED_CLAUDE_ROOT__) を置換して
+# ~/Library/LaunchAgents/com.embodied-claude.heartbeat.plist に配置、
+# launchctl で load する。
+#
+# 使い方:
+#   bash .claude/hooks/install-heartbeat.sh           # install & load
+#   bash .claude/hooks/install-heartbeat.sh --uninstall  # unload & remove
+
+set -e
+
+HOOKS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HOOKS_DIR/../.." && pwd)"
+TEMPLATE="$HOOKS_DIR/com.embodied-claude.heartbeat.plist"
+TARGET_DIR="$HOME/Library/LaunchAgents"
+TARGET="$TARGET_DIR/com.embodied-claude.heartbeat.plist"
+
+uninstall() {
+    if [ -f "$TARGET" ]; then
+        launchctl unload "$TARGET" 2>/dev/null || true
+        rm -f "$TARGET"
+        echo "[install-heartbeat] unloaded and removed: $TARGET"
+    else
+        echo "[install-heartbeat] not installed: $TARGET"
+    fi
+}
+
+if [ "$1" = "--uninstall" ]; then
+    uninstall
+    exit 0
+fi
+
+case "$(uname -s)" in
+    Darwin) ;;
+    *)
+        echo "[install-heartbeat] このスクリプトは macOS (launchd) 専用です" >&2
+        echo "[install-heartbeat] Linux では systemd user timer を使ってください" >&2
+        exit 1
+        ;;
+esac
+
+if [ ! -f "$TEMPLATE" ]; then
+    echo "[install-heartbeat] template not found: $TEMPLATE" >&2
+    exit 1
+fi
+
+mkdir -p "$TARGET_DIR"
+
+# __EMBODIED_CLAUDE_ROOT__ を実パスに置換
+sed "s|__EMBODIED_CLAUDE_ROOT__|${REPO_ROOT}|g" "$TEMPLATE" > "$TARGET"
+
+# すでに load されていたら unload してから load し直す
+launchctl unload "$TARGET" 2>/dev/null || true
+launchctl load "$TARGET"
+
+echo "[install-heartbeat] installed: $TARGET"
+echo "[install-heartbeat] repo root:  $REPO_ROOT"
+echo "[install-heartbeat] 動作確認: ls /tmp/interoception_state.json"

--- a/.claude/hooks/interoception.sh
+++ b/.claude/hooks/interoception.sh
@@ -65,6 +65,9 @@ try:
         f\"uptime={now.get('uptime_min', '?')}min\",
         f\"heartbeats={len(window)}\",
     ]
+    companion = '${GARMIN_HR}'
+    if companion:
+        parts.append(f\"companion_hr={companion}\")
     print('[interoception] ' + ' '.join(parts))
 except Exception as e:
     print(f'[interoception] error reading state: {e}', file=sys.stderr)


### PR DESCRIPTION
## Summary

- **plist をテンプレート化 + install script 追加**: `ProgramArguments` の絶対パスを `__EMBODIED_CLAUDE_ROOT__` プレースホルダに置き換え、install-heartbeat.sh で各環境の実パスに置換して `~/Library/LaunchAgents/` に配置する方式に変更。
- **`garmin-hr-cache.sh` の保護**: node 実行失敗時に pipe 経由で空のキャッシュを書き込んでしまう問題を修正。`HR_RESULT` 変数に受けて、空でない時のみキャッシュに書き込む。
- **`interoception.sh` に companion_hr 対応**: state-file ベースの新フォーマット出力でも、`/tmp/garmin_hr_latest.txt` があれば `companion_hr=XX` を末尾に付ける。無ければスキップ。

## Why

- plist にハードコードされたパスは特定環境に依存していて portable じゃなかった。
- heartbeat daemon が起動していない時、interoception は fallback 出力に切り替わるが、そこでは companion_hr が付いていたのに state-file 出力には付いていなかった。2つの経路で表記が揃うようにした。
- Garmin API が一時的に失敗した時、cache が空文字で上書きされて companion_hr が消えていた。

## Install

```bash
bash .claude/hooks/install-heartbeat.sh            # install & load
bash .claude/hooks/install-heartbeat.sh --uninstall # unload & remove
```

## Test plan

- [x] `install-heartbeat.sh` を任意の clone 先で実行して `/tmp/interoception_state.json` が作られる
- [x] `bash .claude/hooks/garmin-hr-cache.sh` で `/tmp/garmin_hr_latest.txt` が HR に更新される
- [x] `bash .claude/hooks/interoception.sh` の出力に `companion_hr=...` が付く
- [x] interoception フックの実出力が `time=... phase=evening arousal=... companion_hr=XXbpm@...` 形式で流れる