### PR TITLE
fix: use smartwatch-generic cache path for companion HR

### DIFF
--- a/.claude/hooks/garmin-hr-cache.sh
+++ b/.claude/hooks/garmin-hr-cache.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 # garmin-hr-cache.sh — Fetch latest heart rate from Garmin and cache it
 # Run via cron every 5 minutes: */5 * * * * /path/to/garmin-hr-cache.sh
-# Writes latest HR to /tmp/garmin_hr_latest.txt for interoception.sh to read
+# Writes latest HR to /tmp/sw_hr_latest.txt (smartwatch-generic cache path
+# shared with other smartwatch integrations) for interoception.sh to read.
+#
+# The repo root of garmin-health-mcp is taken from GARMIN_MCP_DIR env var,
+# falling back to $HOME/repo/garmin-health-mcp.
 
-CACHE_FILE="/tmp/garmin_hr_latest.txt"
-GARMIN_MCP_DIR="/Users/mizushima/repo/garmin-health-mcp"
+CACHE_FILE="/tmp/sw_hr_latest.txt"
+GARMIN_MCP_DIR="${GARMIN_MCP_DIR:-$HOME/repo/garmin-health-mcp}"
 export PATH="/opt/homebrew/bin:$PATH"
 
 cd "$GARMIN_MCP_DIR" || exit 1

--- a/.claude/hooks/interoception.sh
+++ b/.claude/hooks/interoception.sh
@@ -6,11 +6,13 @@
 
 STATE_FILE="/tmp/interoception_state.json"
 
-# Garmin heart rate cache (updated by garmin-hr-cache.sh cron job)
-GARMIN_HR_FILE="/tmp/garmin_hr_latest.txt"
-GARMIN_HR=""
-if [ -f "$GARMIN_HR_FILE" ]; then
-    GARMIN_HR=$(cat "$GARMIN_HR_FILE" 2>/dev/null)
+# Smartwatch heart rate cache (updated by any smartwatch integration's cron job)
+# The file path is smartwatch-generic; Garmin / Apple Watch / Fitbit integrations
+# are expected to write their latest HR to the same location.
+SW_HR_FILE="/tmp/sw_hr_latest.txt"
+COMPANION_HR=""
+if [ -f "$SW_HR_FILE" ]; then
+    COMPANION_HR=$(cat "$SW_HR_FILE" 2>/dev/null)
 fi
 
 # state file がなければフォールバック（デーモン未起動時）
@@ -19,8 +21,8 @@ if [ ! -f "$STATE_FILE" ]; then
     CURRENT_DOW=$(date '+%a')
     CURRENT_DATE=$(date '+%Y-%m-%d')
     HR_PART=""
-    if [ -n "$GARMIN_HR" ]; then
-        HR_PART=" companion_hr=${GARMIN_HR}"
+    if [ -n "$COMPANION_HR" ]; then
+        HR_PART=" companion_hr=${COMPANION_HR}"
     fi
     echo "[interoception] time=${CURRENT_TIME} day=${CURRENT_DOW} date=${CURRENT_DATE}${HR_PART} (heartbeat daemon not running)"
     exit 0
@@ -65,7 +67,7 @@ try:
         f\"uptime={now.get('uptime_min', '?')}min\",
         f\"heartbeats={len(window)}\",
     ]
-    companion = '${GARMIN_HR}'
+    companion = '${COMPANION_HR}'
     if companion:
         parts.append(f\"companion_hr={companion}\")
     print('[interoception] ' + ' '.join(parts))


### PR DESCRIPTION
## Summary

companion HR の cache path を Garmin 固有（\`/tmp/garmin_hr_latest.txt\`）から、スマートウォッチ汎用（\`/tmp/sw_hr_latest.txt\`）に変更します。

- **\`garmin-hr-cache.sh\`**: 書き込み先を \`/tmp/sw_hr_latest.txt\` に変更。ハードコードされていた \`GARMIN_MCP_DIR\` を環境変数対応にしつつ、デフォルトを \`\$HOME/repo/garmin-health-mcp\` に。
- **\`interoception.sh\`**: 読み込み先を同パスに。変数名も \`GARMIN_HR\` → \`COMPANION_HR\` に汎用化。

## Why

今は Garmin しか実装がないが、将来 Apple Watch / Fitbit / 他のスマートウォッチから同じ方式で companion HR を供給したい時、interoception 側が「どの smartwatch から来たか」を気にせず共通 cache を読むだけで済むようにしたい。

ペアとなる [garmin-health-mcp 側の PR](https://github.com/lifemate-ai/garmin-health-mcp) で、同じ \`/tmp/sw_hr_latest.txt\` に書き出すよう同期修正予定。

## Test plan

- [x] \`echo "85bpm@18:53" > /tmp/sw_hr_latest.txt\` してから \`bash .claude/hooks/interoception.sh\` で出力に \`companion_hr=85bpm@18:53\` が入る
- [x] \`bash .claude/hooks/garmin-hr-cache.sh\` 実行時に新 path に書く（API が失敗すれば既存値保護）