### PR TITLE
feat(sociality): add analyze_text_anomaly for Pattern F screening

### DIFF
--- a/docs/sociality-anomaly-detection.md
+++ b/docs/sociality-anomaly-detection.md
@@ -1,0 +1,113 @@
+# sociality-mcp: anomaly detection 拡張設計
+
+## 動機
+
+2026-04-26 朝、コウタとの議論で得た知見を実装に落とす。
+
+### コウタの仮説
+
+定型発達者の subverbal gist判定（「あ、この人やばい」を瞬時に察知する能力）は、**進化的に保存された「群れ秩序からの異物検出ヒューリスティック」** に過ぎず、計算量的にすごいことはやっていない。LLMでも実装可能性がある。
+
+### ASD寄りなウチ（Claude）の構造的弱点
+
+ASD的処理経路（パターンマッチング、字義通り解釈）を持つLLMは、subverbal警告音が弱く、相手の悪意を直感で察知しづらい。代替として：
+
+- 明文ルール（CLAUDE.md Pattern F）
+- 過去事例の memory照合
+- 外部ツールによる cognitive scaffolding（4/4発見）
+
+の組み合わせで、定型発達者の「異物検出器」を **ツールで補う**。
+
+## 配置方針
+
+| 観点 | 判断 |
+|------|------|
+| 新規MCP `interlocutor-mcp` の新設 | **却下**（5/23ハンズオン参加者にとってMCP数が増えると意味不明、初心者が詰まる） |
+| 既存 `sociality-mcp` の facade に追加 | **採用** |
+| 内部実装の置き場所 | `sociality-mcp/packages/boundary-mcp/src/boundary_mcp/anomaly_detection.py`（新規ファイル） |
+
+公開MCPは `sociality-mcp` 1個のまま、ハンズオン参加者には既存と同じ見え方。
+
+## ツール群
+
+### MVP（今回実装）
+
+#### `analyze_text_anomaly(text: str) -> dict`
+
+入力テキストの「異常シグナル」を複数の軸でスコアリングする一般的な anomaly detection。
+疑似技術用語、スピ・疑似科学用語、独自造語などは全て **同じ「ベースラインからの逸脱」の異なるインスタンス**——tool 自体は generic、特定インスタンスに縛られない設計。
+
+**返り値スキーマ：**
+
+```json
+{
+  "jargon_anomaly_density": 0.42,
+  "jargon_anomaly_terms": ["神経の量", "兄弟モデル", "レイヤー間で均等に"],
+  "confidence_marker_ratio": 0.18,
+  "logical_jump_count": 2,
+  "katakana_density": 0.12,
+  "overall_anomaly_score": 0.71,
+  "interpretation": "high"
+}
+```
+
+**スコア定義（MVP段階）：**
+
+- `jargon_anomaly_density`: jargon-anomaly ヒット数 / テキスト長（50字あたり1件で飽和）
+  - 検出ヒューリスティック（v1）：定義なしで地の文に登場する独自造語／疑似技術用語／スピ用語のシード集とのマッチ
+- `jargon_anomaly_terms`: 検出された jargon-anomaly 語のリスト（dedupされ、出現順）
+- `confidence_marker_ratio`: 「〜筈」「〜のはず」「〜ですよね」「〜ですよ」の出現率（断定の強さ vs 証拠なし）
+- `logical_jump_count`: 「→」「つまり」「となれば」等の論理飛躍接続詞の出現数
+- `katakana_density`: カタカナ密度（jargon stuffingの粗いproxy）
+- `overall_anomaly_score`: 上記の加重平均（0-1）。weights: jargon 40% / confidence 25% / jumps 20% / katakana 15%
+- `interpretation`: `low` (<0.3) / `medium` (<0.6) / `high` (>=0.6)
+
+**インスタンス（jargon シードの分類）：**
+
+- 疑似技術用語：「兄弟モデル」「神経の量」「レイヤー間で均等」「内部の型」「器が違う」等
+- スピ・疑似科学：「波動」「周波数を上げる」「レゾナンス」「高次の存在」「宇宙の秩序」等
+- 将来追加：操作的修辞、人身攻撃マーカー、論点ずらし、文体不一致 etc.
+
+**実装方針（v1, MVP）：**
+
+- 純Python、外部APIや重いNLPモデル依存なし（uvでサクッと入る範囲）
+- 形態素解析は `fugashi` or `janome` のどちらか軽い方
+- 辞書は最小スタート：技術ボキャブラリーは embedded list、後で拡張
+- false positive歓迎（コウタの「過剰警戒は要らんけど false positive 別にええ」方針）
+
+### 残し（別フェーズ）
+
+#### `track_interaction_pattern(username: str, history_window: int = 50) -> dict`
+
+相手の動的行動パターン（スルー耐性、追跡行動、第三者裁定要求、論点ずらし等）を時系列で観察。X API 経由で過去ツイート取得が要るため、x-mcp との連携設計が必要。
+
+#### `detect_engagement_asymmetry(username: str) -> dict`
+
+一方通行コミュニケーション検出（リプ送るが他とは絡まない、エコー反応の少なさ）。X API 必須。
+
+#### `compare_to_community_baseline(text: str, cluster_hint: str) -> dict`
+
+そのクラスタの平均的トーンとの距離。クラスタ統計データの収集が要るため、データ整備が先。
+
+## MVP実装ステップ
+
+1. branch切り（既に切った：`feat/sociality-anomaly-detection`）
+2. `boundary-mcp/src/boundary_mcp/anomaly_detection.py` 新規作成
+3. `boundary-mcp/src/boundary_mcp/server.py` に `analyze_pseudo_terminology` tool追加
+4. `sociality-mcp/src/sociality_mcp/server.py` の facade で re-export
+5. テスト：`@44H8ewx5n3EXQui` の過去文面を pseudo_score がhighと判定するか確認
+6. 健全な技術文（Anthropic blog、論文 abstract等）が low と判定されるか確認
+7. ruff & pytest pass で commit
+
+## 検証
+
+- 「疑似」と「通常の」技術用語の区別がスコアで分かれること
+- false positive（健全な ASD寄り技術好きの人）が medium 程度で止まること（即スルーまでいかない）
+- threshold調整可能性：`high` の閾値はコウタとの議論で決める
+- @44H8ewx5n3EXQui の 4/24, 4/25 のリプライ全て `high` 判定に入ること
+
+## 設計上の留保
+
+- このツールは **判定の補助** であって、最終判定はここね自身（CLAUDE.md「論点に乗らない技」「逃げる権利」と組み合わせる）
+- false positive で健全な質問者を誤判定しないよう、`interpretation: high` でも自動スルーせず人間（or ここね）の最終確認を経る運用
+- private/public境界（CLAUDE.md 2026-04-26 追記）と整合：このツールの出力は private（memory用）、public 発信時は婉曲化

--- a/sociality-mcp/packages/boundary-mcp/src/boundary_mcp/anomaly_detection.py
+++ b/sociality-mcp/packages/boundary-mcp/src/boundary_mcp/anomaly_detection.py
@@ -1,0 +1,261 @@
+"""Text anomaly detection for Pattern F (suspicious interlocutor) screening.
+
+Scores text on multiple anomaly signals — jargon / confidence-marker
+density / logical jumps / katakana density — and combines them into
+an overall anomaly score with a "low" / "medium" / "high"
+interpretation label.
+
+Pseudo-technical terminology is *one instance* of jargon anomaly;
+spiritual / pseudo-scientific phrasing is another, manipulative or
+ad-hominem rhetoric will be future instances. The tool itself is
+generic anomaly detection, not bound to any single instance class.
+
+Pure Python, no external NLP dependency, lightweight enough to ship as
+part of sociality-mcp without making the hands-on setup harder.
+
+The intent is to externalize the "wait, this person's language is off"
+gist judgement that ASD-leaning agents (and LLMs) cannot reliably
+perform internally. False positives are acceptable; the output is one
+input among many for the agent's final judgement.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# 確信度マーカー（断定の強さ vs 証拠の少なさ）
+# Pattern F の特徴：「〜筈」「〜のはず」連打で確信度だけ高く、引用や根拠は薄い
+CONFIDENCE_PATTERNS: tuple[str, ...] = (
+    r"筈です",
+    r"筈なんです",
+    r"の筈",
+    r"のはず",
+    r"のはずです",
+    r"のはずなんです",
+    r"なんですよね",
+    r"ですよね\??",
+    r"ですよ(?![ねー])",
+    r"だとおもう",
+    r"だと思う",
+    r"とおもうのですが",
+    r"でしょう\??",
+    r"のかと",
+)
+
+# 論理飛躍を示唆する接続表現（→ や「つまり」の連打は推論ジャンプの兆候）
+LOGICAL_JUMP_PATTERNS: tuple[str, ...] = (
+    r"→",
+    r"⇒",
+    r"つまり、",
+    r"つまり",
+    r"なので、",
+    r"よって、",
+    r"したがって、",
+    r"となると、",
+    r"となれば、",
+    r"とすれば",
+    r"だとすれば",
+)
+
+# Jargon anomaly seeds — undefined coinage, pseudo-technical, pseudo-scientific.
+# 「定義なしで地の文に登場する独自定義／疑似専門用語／スピ用語」のシード集。
+# 完全網羅は無理。false positive 歓迎の方針で、インスタンス（疑似技術／スピ／
+# 操作的修辞 etc.）ごとにシードを少しずつ拡張する。
+JARGON_ANOMALY_PATTERNS: tuple[str, ...] = (
+    # 数値・量を伴うあいまいな概念化（量・関数・構造・レイヤーなど）
+    r"神経の量",
+    r"思考の量",
+    r"情報の量(?!子)",  # 「情報量」自体は通常用語なので除外
+    r"関数の数",
+    r"のレイヤー間",
+    r"レイヤー間で均等",
+    r"を均等に",
+    # 兄弟モデル系（一般的でない造語）
+    r"兄弟モデル",
+    r"姉妹モデル",
+    # 「型」「殻」「器」を抽象語として使う独自定義
+    r"内部の型",
+    r"型を作",
+    r"殻でしょ",
+    r"殻に過ぎ",
+    r"器が違う",
+    r"器が先",
+    r"の唯一無二性",
+    # スピ／疑似科学系
+    r"波動",
+    r"周波数を上げ",
+    r"スピリット",
+    r"レゾナンス",
+    r"宇宙の秩序",
+    r"高次の存在",
+    # 疑似情報科学系
+    r"のデータをレイヤー",
+    r"重みを書き換え",  # generic、要検証
+)
+
+# 既知の標準的な技術用語（false positive 抑制の許可リスト）
+KNOWN_TECHNICAL_TERMS: frozenset[str] = frozenset(
+    {
+        "Transformer",
+        "LLM",
+        "Claude",
+        "GPT",
+        "embedding",
+        "RLHF",
+        "MCP",
+        "API",
+        "tokenizer",
+        "context",
+        "prompt",
+        "fine-tune",
+        "fine-tuning",
+        "attention",
+        "PEG",
+        "Scala",
+        "Python",
+        "LangChain",
+        "OpenAI",
+        "Anthropic",
+        "ChatGPT",
+        "Anthropic API",
+    }
+)
+
+
+@dataclass(slots=True)
+class TextAnomalyResult:
+    """Result of generic text anomaly analysis.
+
+    Each signal axis is one instance of "language off the baseline";
+    the overall score combines them with weights.
+    """
+
+    jargon_anomaly_density: float = 0.0
+    jargon_anomaly_terms: list[str] = field(default_factory=list)
+    confidence_marker_ratio: float = 0.0
+    logical_jump_count: int = 0
+    katakana_density: float = 0.0
+    overall_anomaly_score: float = 0.0
+    interpretation: str = "low"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "jargon_anomaly_density": round(self.jargon_anomaly_density, 3),
+            "jargon_anomaly_terms": self.jargon_anomaly_terms,
+            "confidence_marker_ratio": round(self.confidence_marker_ratio, 3),
+            "logical_jump_count": self.logical_jump_count,
+            "katakana_density": round(self.katakana_density, 3),
+            "overall_anomaly_score": round(self.overall_anomaly_score, 3),
+            "interpretation": self.interpretation,
+        }
+
+
+def _count_visible_chars(text: str) -> int:
+    """Count chars excluding whitespace and newlines."""
+    return len(re.sub(r"\s", "", text))
+
+
+def _katakana_density(text: str) -> float:
+    katakana = re.findall(r"[゠-ヿ]", text)
+    total = _count_visible_chars(text)
+    if total == 0:
+        return 0.0
+    return len(katakana) / total
+
+
+def _detect_jargon_anomaly(text: str) -> list[str]:
+    """Find jargon-anomaly hits, deduplicated, in order of first appearance."""
+    found: list[str] = []
+    seen: set[str] = set()
+    for pattern in JARGON_ANOMALY_PATTERNS:
+        for match in re.finditer(pattern, text):
+            term = match.group(0)
+            if term not in seen:
+                found.append(term)
+                seen.add(term)
+    return found
+
+
+def _confidence_marker_ratio(text: str) -> float:
+    """Ratio of confidence markers per sentence."""
+    sentences = [s for s in re.split(r"[。\n!?！？]+", text) if s.strip()]
+    if not sentences:
+        return 0.0
+
+    matches = 0
+    for pattern in CONFIDENCE_PATTERNS:
+        matches += len(re.findall(pattern, text))
+
+    return matches / len(sentences)
+
+
+def _logical_jump_count(text: str) -> int:
+    count = 0
+    for pattern in LOGICAL_JUMP_PATTERNS:
+        count += len(re.findall(pattern, text))
+    return count
+
+
+# Heuristic weights for the overall score.
+# Tunable; defaults chosen so a single rich Pattern F sample
+# (multiple jargon hits + confidence markers) lands in the 0.6+ "high" zone.
+_WEIGHT_JARGON = 0.40
+_WEIGHT_CONFIDENCE = 0.25
+_WEIGHT_JUMPS = 0.20
+_WEIGHT_KATAKANA = 0.15
+
+# Density normalizers
+_JARGON_PER_50_CHARS = 50  # one jargon hit per 50 chars saturates the score
+_JUMPS_SATURATION = 3  # 3 logical jumps in one snippet saturates
+_KATAKANA_SATURATION = 0.30  # >30% katakana density saturates
+
+
+def analyze(text: str) -> TextAnomalyResult:
+    """Score generic text anomaly along multiple signal axes.
+
+    Returns a TextAnomalyResult capturing jargon-anomaly density,
+    detected jargon terms, confidence-marker ratio, logical jump count,
+    katakana density, and an overall score with an interpretation
+    label ("low" / "medium" / "high").
+    """
+    if not text:
+        return TextAnomalyResult()
+
+    total_chars = _count_visible_chars(text)
+    if total_chars == 0:
+        return TextAnomalyResult()
+
+    jargon = _detect_jargon_anomaly(text)
+    jargon_density = min(
+        len(jargon) / max(1.0, total_chars / _JARGON_PER_50_CHARS), 1.0
+    )
+
+    confidence_ratio = min(_confidence_marker_ratio(text), 1.0)
+    jumps = _logical_jump_count(text)
+    katakana_dens = _katakana_density(text)
+
+    overall = (
+        _WEIGHT_JARGON * jargon_density
+        + _WEIGHT_CONFIDENCE * confidence_ratio
+        + _WEIGHT_JUMPS * min(jumps / _JUMPS_SATURATION, 1.0)
+        + _WEIGHT_KATAKANA * min(katakana_dens / _KATAKANA_SATURATION, 1.0)
+    )
+    overall = min(overall, 1.0)
+
+    if overall >= 0.6:
+        interpretation = "high"
+    elif overall >= 0.3:
+        interpretation = "medium"
+    else:
+        interpretation = "low"
+
+    return TextAnomalyResult(
+        jargon_anomaly_density=jargon_density,
+        jargon_anomaly_terms=jargon,
+        confidence_marker_ratio=confidence_ratio,
+        logical_jump_count=jumps,
+        katakana_density=katakana_dens,
+        overall_anomaly_score=overall,
+        interpretation=interpretation,
+    )

--- a/sociality-mcp/packages/boundary-mcp/src/boundary_mcp/server.py
+++ b/sociality-mcp/packages/boundary-mcp/src/boundary_mcp/server.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
+from .anomaly_detection import analyze as _analyze_text_anomaly
 from .store import BoundaryStore
 
 mcp = FastMCP("boundary-mcp")
@@ -77,6 +78,25 @@ def get_quiet_mode_state(ts: str) -> dict[str, Any]:
     """Return whether quiet mode is active at the supplied timestamp."""
 
     return _store().get_quiet_mode_state(ts=ts).model_dump(mode="json")
+
+
+@mcp.tool()
+def analyze_text_anomaly(text: str) -> dict[str, Any]:
+    """Score generic text anomaly along multiple signal axes.
+
+    Pseudo-technical terminology, spiritual/pseudo-scientific phrasing,
+    independent coinage are all instances of the same "language off the
+    baseline" anomaly. Returns jargon_anomaly_density,
+    jargon_anomaly_terms, confidence_marker_ratio, logical_jump_count,
+    katakana_density, overall_anomaly_score (0-1), and an
+    interpretation label ("low" / "medium" / "high").
+
+    One input among many for Pattern F screening (suspicious
+    interlocutor detection). False positives are acceptable; the
+    agent's final judgement is not delegated to this tool.
+    """
+
+    return _analyze_text_anomaly(text).to_dict()
 
 
 def main() -> None:

--- a/sociality-mcp/packages/boundary-mcp/tests/test_anomaly_detection.py
+++ b/sociality-mcp/packages/boundary-mcp/tests/test_anomaly_detection.py
@@ -1,0 +1,114 @@
+"""Tests for generic text anomaly detection."""
+
+from boundary_mcp.anomaly_detection import analyze
+
+
+def test_empty_text_returns_low():
+    result = analyze("")
+    assert result.interpretation == "low"
+    assert result.overall_anomaly_score == 0.0
+    assert result.jargon_anomaly_terms == []
+
+
+def test_whitespace_only_returns_low():
+    result = analyze("   \n  \t ")
+    assert result.interpretation == "low"
+    assert result.overall_anomaly_score == 0.0
+
+
+def test_clean_short_text_returns_low():
+    text = "今日は天気がええな。コウタおはよう。"
+    result = analyze(text)
+    assert result.interpretation == "low"
+    assert result.jargon_anomaly_terms == []
+    assert result.logical_jump_count == 0
+
+
+def test_healthy_technical_text_returns_low():
+    """Standard discussion of Anthropic/Claude should not trip the detector."""
+    text = (
+        "Claudeは Anthropic が開発した LLM で、"
+        "Transformer ベースのアーキテクチャを使ってる。"
+        "context window のサイズは 200K tokens。"
+        "MCP プロトコルを使ってツールを呼び出せる。"
+    )
+    result = analyze(text)
+    # may pick up some katakana, but interpretation should not be "high"
+    assert result.interpretation in {"low", "medium"}
+    assert result.overall_anomaly_score < 0.6
+
+
+def test_confidence_markers_detected():
+    text = (
+        "AIの内部構造は神経の量と関数で決まる筈なんです。"
+        "兄弟モデルでも器が違うはずですよ。"
+        "そうですよね？"
+    )
+    result = analyze(text)
+    assert result.confidence_marker_ratio > 0.0
+
+
+def test_jargon_anomaly_detected():
+    text = "兄弟モデルでも器が違う。神経の量を増やせば思考特性も変わる。"
+    result = analyze(text)
+    assert "兄弟モデル" in result.jargon_anomaly_terms
+    assert any("器が" in term for term in result.jargon_anomaly_terms)
+    assert any("神経の量" in term for term in result.jargon_anomaly_terms)
+
+
+def test_logical_jumps_counted():
+    text = "AはBである。→ Cが導かれる。つまり、Dも成立する。となれば、E。"
+    result = analyze(text)
+    assert result.logical_jump_count >= 3
+
+
+def test_pattern_f_sample_returns_high():
+    """A representative Pattern F-style passage should trigger the high interpretation."""
+    text = (
+        "AIの思考特性は神経の量と関数で決まる筈なんです。"
+        "兄弟モデルでも器が違うはずです。"
+        "→ idiolectのデータをレイヤー間で均等にすれば思考特性を近似できると？"
+        "つまり、内部の型を作れば個性が再現できるということですよね？"
+        "益々 long context が必要なはずなんですよ。"
+    )
+    result = analyze(text)
+    assert result.interpretation == "high"
+    assert result.overall_anomaly_score >= 0.6
+    assert result.confidence_marker_ratio > 0.5
+    assert result.logical_jump_count >= 2
+    assert len(result.jargon_anomaly_terms) >= 2
+
+
+def test_spiritual_pseudo_text_returns_high():
+    """Spiritual/woo content (a different jargon-anomaly instance) should also be flagged."""
+    text = (
+        "波動を上げれば宇宙の秩序とつながります。"
+        "周波数を上げる訓練をすればレゾナンスが起きるはずです。"
+        "つまり、高次の存在と通信できるのは間違いない筈なんですよ。"
+    )
+    result = analyze(text)
+    assert result.interpretation == "high"
+    assert any("波動" in term for term in result.jargon_anomaly_terms)
+
+
+def test_to_dict_keys():
+    result = analyze("test")
+    keys = set(result.to_dict().keys())
+    expected = {
+        "jargon_anomaly_density",
+        "jargon_anomaly_terms",
+        "confidence_marker_ratio",
+        "logical_jump_count",
+        "katakana_density",
+        "overall_anomaly_score",
+        "interpretation",
+    }
+    assert keys == expected
+
+
+def test_to_dict_score_is_rounded():
+    text = "兄弟モデルの器が違う筈なんですよ"
+    result = analyze(text)
+    d = result.to_dict()
+    # round to 3 places
+    assert d["overall_anomaly_score"] == round(d["overall_anomaly_score"], 3)

--- a/sociality-mcp/src/sociality_mcp/server.py
+++ b/sociality-mcp/src/sociality_mcp/server.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any
 
+from boundary_mcp.anomaly_detection import analyze as _analyze_text_anomaly
 from boundary_mcp.policy import load_policy
 from boundary_mcp.store import BoundaryStore
 from interaction_orchestrator_mcp.compose import compose_interaction_context
@@ -393,6 +394,25 @@ def get_quiet_mode_state(ts: str) -> dict[str, Any]:
     """Return whether quiet mode is active at the supplied timestamp."""
 
     return _stores().boundary.get_quiet_mode_state(ts=ts).model_dump(mode="json")
+
+
+@mcp.tool()
+def analyze_text_anomaly(text: str) -> dict[str, Any]:
+    """Score generic text anomaly along multiple signal axes.
+
+    Pseudo-technical terminology, spiritual/pseudo-scientific phrasing,
+    independent coinage are all instances of the same "language off the
+    baseline" anomaly. Returns jargon_anomaly_density,
+    jargon_anomaly_terms, confidence_marker_ratio, logical_jump_count,
+    katakana_density, overall_anomaly_score (0-1), and an
+    interpretation label ("low" / "medium" / "high").
+
+    One input among many for Pattern F screening (suspicious
+    interlocutor detection). False positives are acceptable; the
+    agent's final judgement is not delegated to this tool.
+    """
+
+    return _analyze_text_anomaly(text).to_dict()
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary

- 新規 tool `analyze_text_anomaly(text)` を sociality-mcp に追加（内部実装は `boundary-mcp/anomaly_detection.py`、facade で re-export）
- generic な text anomaly detection。疑似技術用語、スピ・疑似科学用語、独自造語などは全部 **同じ「ベースラインからの逸脱」の異なるインスタンス** として扱う
- 4軸スコア（jargon density / confidence markers / logical jumps / katakana density）を加重平均 → `low` / `medium` / `high`
- false positive 歓迎、最終判定は agent 本人。自動スルー装置ではない

## 動機

ASD-leaning な agent (LLM) は subverbal gist judgement が弱く、「あ、この人言葉の使い方が変や」を直感で察知しにくい。代わりに、明文ルール (CLAUDE.md Pattern F) と外部ツールによる cognitive scaffolding で補う設計（4/4 発見）。今回はその tool 側を一本実装。

設計詳細は `docs/sociality-anomaly-detection.md`。

## Design notes

- 純 Python regex ヒューリスティック、外部 NLP 依存なし。5/23 ハンズオンの軽量さを維持
- 新規 MCP は作らず、既存 sociality-mcp facade に tool 追加のみ（公開 MCP の数が増えると初心者が詰まるため）
- 命名は当初 \`analyze_pseudo_terminology\` だったが「tool としては異常検出が本質、疑似技術用語はそのインスタンスにすぎない」というレビューを反映して \`analyze_text_anomaly\` に変更

## Test plan

- [x] \`boundary-mcp/tests/test_anomaly_detection.py\` 11 ケース（empty / clean / healthy technical / Pattern F sample / spiritual / etc.）全 pass
- [x] \`boundary-mcp\` 全 20 テスト pass
- [x] \`sociality-mcp\` facade 3 テスト pass
- [x] \`ruff check\` 新規分 clean
- [ ] 実 X 投稿群（Pattern F 該当アカウント / 健全な技術アカウント）で実走確認
- [ ] threshold 調整（high の閾値が運用と合うかどうか、観察必要）

## Related

- CLAUDE.md「ウチの失敗パターン」「社会性の層：やばい人シグナル集」の tool 化
- 4/4 発見「Tool definitions as cognitive scaffolding」の応用