### PR TITLE
feat(memory): default visual memory resolution to full_hd

### DIFF
--- a/memory-mcp/src/memory_mcp/image_utils.py
+++ b/memory-mcp/src/memory_mcp/image_utils.py
@@ -73,14 +73,22 @@ def resolve_resolution(resolution: str | None) -> tuple[int, int]:
 
     Returns:
         (max_width, max_height) タプル
+
+    Note:
+        デフォルトは full_hd (1920x1080)。観察記憶は一次資料として
+        最高解像度で保存し、後で再評価できるようにする方針。
+        容量を抑えたい場合は明示的に "low"/"medium"/"high" を指定する。
     """
     if resolution is None:
-        return RESOLUTION_PRESETS["medium"]
-    return RESOLUTION_PRESETS.get(resolution, RESOLUTION_PRESETS["medium"])
+        return RESOLUTION_PRESETS["full_hd"]
+    return RESOLUTION_PRESETS.get(resolution, RESOLUTION_PRESETS["full_hd"])
 
 
 def resolve_quality(resolution: str | None) -> int:
-    """解像度プリセットに応じたJPEG品質を返す."""
+    """解像度プリセットに応じたJPEG品質を返す.
+
+    デフォルトは full_hd (quality 85)。
+    """
     if resolution is None:
-        return QUALITY_PRESETS["medium"]
-    return QUALITY_PRESETS.get(resolution, QUALITY_PRESETS["medium"])
+        return QUALITY_PRESETS["full_hd"]
+    return QUALITY_PRESETS.get(resolution, QUALITY_PRESETS["full_hd"])

--- a/memory-mcp/src/memory_mcp/sensory.py
+++ b/memory-mcp/src/memory_mcp/sensory.py
@@ -46,7 +46,7 @@ class SensoryIntegration:
             importance: 重要度（1-5）
             category: カテゴリ
             auto_describe: 画像説明を自動生成（Phase 4.3では未実装）
-            resolution: 画像解像度プリセット ("low"/"medium"/"high", デフォルト: "medium")
+            resolution: 画像解像度プリセット ("low"/"medium"/"high"/"full_hd", デフォルト: "full_hd")
 
         Returns:
             保存された記憶

--- a/memory-mcp/src/memory_mcp/server.py
+++ b/memory-mcp/src/memory_mcp/server.py
@@ -440,8 +440,8 @@ class MemoryMCPServer:
                             },
                             "resolution": {
                                 "type": "string",
-                                "description": "Image resolution for memory storage: 'low' (160x120), 'medium' (320x240, default), 'high' (640x480), 'full_hd' (1920x1080)",
-                                "default": "medium",
+                                "description": "Image resolution for memory storage: 'low' (160x120), 'medium' (320x240), 'high' (640x480), 'full_hd' (1920x1080, default)",
+                                "default": "full_hd",
                                 "enum": ["low", "medium", "high", "full_hd"],
                             },
                         },

--- a/memory-mcp/tests/test_image_utils.py
+++ b/memory-mcp/tests/test_image_utils.py
@@ -113,11 +113,14 @@ class TestResolveResolution:
     def test_high(self):
         assert resolve_resolution("high") == (640, 480)
 
-    def test_none_defaults_to_medium(self):
-        assert resolve_resolution(None) == (320, 240)
+    def test_full_hd(self):
+        assert resolve_resolution("full_hd") == (1920, 1080)
 
-    def test_unknown_defaults_to_medium(self):
-        assert resolve_resolution("ultra") == (320, 240)
+    def test_none_defaults_to_full_hd(self):
+        assert resolve_resolution(None) == (1920, 1080)
+
+    def test_unknown_defaults_to_full_hd(self):
+        assert resolve_resolution("ultra") == (1920, 1080)
 
     def test_presets_dict(self):
         assert len(RESOLUTION_PRESETS) == 4


### PR DESCRIPTION
## Summary
- `save_visual_memory` のデフォルト解像度を `medium` (320x240) から `full_hd` (1920x1080) に変更
- 観察記憶は一次資料として最高解像度で保存し、後で再評価できるようにする方針

## Why

視覚記憶は「観察対象の一次資料」としての価値が大きい。現状デフォルトの `medium` (320x240) は、カメラが実際に撮影している 1920x1080 から大幅に情報を落とす。一度落とした解像度は recall 時には戻せず、不可逆。

実例として、ベランダから波雲の壮観な雲海を撮影した際、デフォルトの `medium` でディテールを失う事例が出た。

## Changes
- `resolve_resolution(None)` と `resolve_quality(None)` のデフォルトを `medium` → `full_hd` に
- 不明な解像度名のフォールバックも `medium` → `full_hd` に
- Tool schema (`server.py`) の `default` を `"full_hd"` に、description も更新
- `sensory.py` の docstring を更新
- テスト更新：
  - `test_none_defaults_to_medium` → `test_none_defaults_to_full_hd`
  - `test_unknown_defaults_to_medium` → `test_unknown_defaults_to_full_hd`
  - `test_full_hd` を新規追加

## Backward compatibility
- 呼び出し側で `low`/`medium`/`high` を明示指定すれば従来通り
- 既に保存済みの記憶（base64 embedded）には影響なし

## Future considerations
- ストレージ増加が顕在化したら、古い記憶を low/medium に再圧縮する migration ツールを別途検討

## Test plan
- [x] `uv run ruff check .` 通過
- [x] `uv run pytest tests/test_image_utils.py -v` 全 14 テスト pass
- [x] レビュアー側で実際に save_visual_memory を呼んでデフォルトが full_hd で保存されることを確認
- [x] Tool schema の default が MCP クライアントから正しく見えることを確認

> 注: `tests/test_sensory.py` の一部テストが環境依存（`/mnt` パスや HuggingFace キャッシュ）で fail するが、これは本変更とは無関係。

🤖 Generated with [Claude Code](https://claude.com/claude-code)