### PR TITLE
fix(memory-mcp): make consolidation tz-aware to handle mixed naive/aware timestamps

### DIFF
--- a/memory-mcp/src/memory_mcp/consolidation.py
+++ b/memory-mcp/src/memory_mcp/consolidation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -39,7 +39,7 @@ class ConsolidationEngine:
         max_replay_events: int = 200,
         link_update_strength: float = 0.2,
     ) -> ConsolidationStats:
-        cutoff = datetime.now() - timedelta(hours=max(1, window_hours))
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=max(1, window_hours))
         recent = await store.list_recent(limit=max(max_replay_events * 2, 50))
         recent = [m for m in recent if self._is_after(m, cutoff)]
 
@@ -89,4 +89,6 @@ class ConsolidationEngine:
             timestamp = datetime.fromisoformat(memory.timestamp)
         except ValueError:
             return False
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
         return timestamp >= cutoff

--- a/memory-mcp/src/memory_mcp/store.py
+++ b/memory-mcp/src/memory_mcp/store.py
@@ -7,7 +7,7 @@ import json
 import math
 import sqlite3
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 import numpy as np
@@ -150,11 +150,15 @@ def calculate_time_decay(
     half_life_days: float = 30.0,
 ) -> float:
     if now is None:
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
     try:
         memory_time = datetime.fromisoformat(timestamp)
     except ValueError:
         return 1.0
+    if memory_time.tzinfo is None:
+        memory_time = memory_time.replace(tzinfo=timezone.utc)
     age_seconds = (now - memory_time).total_seconds()
     if age_seconds < 0:
         return 1.0
@@ -660,7 +664,7 @@ class MemoryStore:
         )
 
         scored_results: list[ScoredMemory] = []
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
 
         for memory, semantic_distance in pairs:
             time_decay = (


### PR DESCRIPTION
## Summary
- `consolidate_memories` failed with `TypeError: can't compare offset-naive and offset-aware datetimes` when memory timestamps carried timezone info (e.g. `+09:00`) but the cutoff/now were naive
- Fixed `consolidation.py` and `store.py` to normalize datetimes to tz-aware (UTC) before comparison

## Affected paths
- `ConsolidationEngine._is_after` in `memory-mcp/src/memory_mcp/consolidation.py`
- `calculate_time_decay` in `memory-mcp/src/memory_mcp/store.py`
- `search()` time decay scoring in `memory-mcp/src/memory_mcp/store.py`

## Fix
- Use `datetime.now(timezone.utc)` for cutoff/now
- Normalize `fromisoformat()` results: replace `tzinfo=timezone.utc` when naive

## Test plan
- [ ] Run `consolidate_memories` with `window_hours=24` against a memory.db containing mixed naive/aware timestamps (previously failed)
- [ ] Confirm time-decay scoring still works for both naive and aware timestamps
- [ ] Existing memory-mcp tests pass

## Background
Found while running manual `consolidate_memories(window_hours=24)` — `window_hours=6` happened to skip the aware records and succeeded, but 24h hit them and threw.