### PR TITLE
fix(memory-mcp): auto-create parent directory for db_path on connect()

### DIFF
--- a/memory-mcp/src/memory_mcp/store.py
+++ b/memory-mcp/src/memory_mcp/store.py
@@ -8,6 +8,7 @@ import math
 import sqlite3
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -314,6 +315,9 @@ class MemoryStore:
         async with self._lock:
             if self._db is None:
                 db_path = self._config.db_path
+
+                if db_path != ":memory:":
+                    Path(db_path).parent.mkdir(parents=True, exist_ok=True)
 
                 def _open() -> sqlite3.Connection:
                     conn = sqlite3.connect(db_path, check_same_thread=False)

--- a/memory-mcp/tests/test_connect.py
+++ b/memory-mcp/tests/test_connect.py
@@ -1,0 +1,38 @@
+"""Tests for MemoryStore.connect() parent directory auto-creation."""
+
+from pathlib import Path
+
+import pytest
+
+from memory_mcp.config import MemoryConfig
+from memory_mcp.store import MemoryStore
+
+
+@pytest.mark.asyncio
+async def test_connect_creates_missing_parent_directories(tmp_path: Path) -> None:
+    """connect() must create missing parent directories for db_path."""
+    nested = tmp_path / "a" / "b" / "c"
+    db = nested / "memory.db"
+    assert not nested.exists()
+
+    store = MemoryStore(MemoryConfig(db_path=str(db), collection_name="t"))
+    try:
+        await store.connect()
+        assert db.exists()
+        assert nested.exists()
+    finally:
+        await store.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_connect_is_idempotent_when_parent_exists(tmp_path: Path) -> None:
+    """Pre-existing parent directory must not cause connect() to fail."""
+    tmp_path.mkdir(exist_ok=True)
+    db = tmp_path / "memory.db"
+
+    store = MemoryStore(MemoryConfig(db_path=str(db), collection_name="t"))
+    try:
+        await store.connect()
+        assert db.exists()
+    finally:
+        await store.disconnect()


### PR DESCRIPTION
## Summary

- `MemoryStore.connect()` now creates the parent directory of `db_path` (`mkdir parents=True, exist_ok=True`) before opening the SQLite connection
- Avoids `sqlite3.OperationalError: unable to open database file` on a fresh machine where the configured directory (e.g. `~/.claude/memories/`) does not exist yet
- `":memory:"` paths are excluded from the mkdir step
- Added `tests/test_connect.py` with two cases: missing-parent auto-creation, and idempotency when the parent already exists

## Test plan

- [x] `uv run ruff check .` passes
- [x] `uv run pytest tests/test_connect.py -v` — both new tests pass
- [x] `uv run pytest` — full suite (217 tests) passes