### PR TITLE
feat(memory-mcp): pre-warm embedding model in install-mcps.sh

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -22,10 +22,7 @@
     },
     "memory": {
       "command": "uv",
-      "args": ["run", "--directory", "memory-mcp", "memory-mcp"],
-      "env": {
-        "HF_HOME": "/path/to/.cache/huggingface"
-      }
+      "args": ["run", "--directory", "memory-mcp", "memory-mcp"]
     },
     "system-temperature": {
       "command": "uv",

--- a/scripts/install-mcps.sh
+++ b/scripts/install-mcps.sh
@@ -9,6 +9,7 @@
 #   - `tts-mcp` uses `--extra all` so both ElevenLabs and VOICEVOX integrations are pulled in.
 #   - `wifi-cam-mcp` uses `--extra transcribe` so Whisper-based speech recognition is available.
 #   - `sociality-mcp` is a uv workspace; its `packages/*` sub-MCPs are resolved automatically.
+#   - `memory-mcp` pre-downloads its embedding model so the first remember() doesn't lazy-fail.
 
 set -euo pipefail
 
@@ -38,6 +39,22 @@ extras_for() {
   esac
 }
 
+warm_for() {
+  case "$1" in
+    memory-mcp)
+      echo "    ↳ pre-downloading embedding model (honors \$MEMORY_EMBEDDING_MODEL)"
+      (cd memory-mcp && uv run python -c "
+from memory_mcp.config import MemoryConfig
+from memory_mcp.embedding import E5EmbeddingFunction
+model = MemoryConfig.from_env().embedding_model
+print(f'  warming {model}')
+E5EmbeddingFunction(model)._load_model()
+print('  done')
+")
+      ;;
+  esac
+}
+
 for dir in "${MCP_DIRS[@]}"; do
   if [ ! -f "$dir/pyproject.toml" ]; then
     echo "⚠️  skipping $dir (no pyproject.toml)"
@@ -47,6 +64,7 @@ for dir in "${MCP_DIRS[@]}"; do
   echo ""
   echo "==> $dir  (uv sync $extra $DEV_FLAG)"
   (cd "$dir" && uv sync $extra $DEV_FLAG)
+  warm_for "$dir"
 done
 
 echo ""


### PR DESCRIPTION
## Summary

- `scripts/install-mcps.sh` now pre-downloads memory-mcp's embedding model right after `uv sync`, so the first `remember()` call on a fresh machine doesn't lazy-fail (or stall while a large model downloads inside an MCP request)
- Honors `\$MEMORY_EMBEDDING_MODEL` via `MemoryConfig.from_env()`
- `.mcp.json.example`: drop the `HF_HOME` hint from the `memory` entry now that the model is pre-fetched during install, and `HF_HOME` isn't required for the default cache location

## Test plan

- [x] `bash -n scripts/install-mcps.sh` (syntax check passes)
- [x] Run `scripts/install-mcps.sh` on a clean checkout (no `~/.cache/huggingface/...`) and confirm the warming step logs `warming <model>` / `done`
- [x] Verify memory-mcp's first `remember()` no longer triggers a model download