### PR TITLE
feat(agent-grammar): hand-rolled PEG combinator core with cut

### DIFF
--- a/sociality-mcp/packages/agent-grammar/src/agent_grammar/parser.py
+++ b/sociality-mcp/packages/agent-grammar/src/agent_grammar/parser.py
@@ -1,0 +1,215 @@
+"""Hand-rolled PEG parser core.
+
+Implements the minimal combinator set used to build the agent turn grammar:
+
+  lit  : match a literal string
+  seq  : ordered concatenation; all sub-parsers must succeed
+  alt  : PEG ordered choice; first success wins (NOT longest-match)
+  opt  : 0 or 1 occurrence; never fails, returns None on miss
+
+State is immutable: parsers take a ParseState and return a fresh
+ParseSuccess (with an advanced state) or a ParseFailure. The caller's
+state is never mutated, so an outer alt can retry alternatives without
+needing to "rewind" anything.
+
+Future extensions tracked in the plan-of-record
+(~/.claude/plans/jazzy-wishing-starfish.md):
+
+  - plus / star (repetition)
+  - and_p / not_p (lookahead)
+  - cut (PEG-with-cut, à la Onion) for BoundaryCheck commits
+  - packrat memoization
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ParseState:
+    """Immutable parser position into the input text."""
+
+    text: str
+    pos: int = 0
+
+    def advance(self, n: int) -> ParseState:
+        return ParseState(text=self.text, pos=self.pos + n)
+
+
+@dataclass(frozen=True)
+class ParseSuccess:
+    value: Any
+    state: ParseState
+    committed: bool = False
+
+
+@dataclass(frozen=True)
+class ParseFailure:
+    pos: int
+    message: str
+    committed: bool = False
+
+
+ParseResult = ParseSuccess | ParseFailure
+Parser = Callable[[ParseState], ParseResult]
+
+
+def lit(s: str) -> Parser:
+    """Match the exact literal string s at the current position."""
+
+    def parse(state: ParseState) -> ParseResult:
+        if state.text.startswith(s, state.pos):
+            return ParseSuccess(value=s, state=state.advance(len(s)))
+        return ParseFailure(pos=state.pos, message=f"expected literal {s!r}")
+
+    return parse
+
+
+def seq(*parsers: Parser) -> Parser:
+    """Run sub-parsers in order; fail fast on any failure.
+
+    Once any sub-parser succeeds with committed=True (i.e. a cut() was
+    crossed), subsequent failures inside this seq propagate as committed
+    failures so that an enclosing alt() will not try further alternatives.
+    """
+
+    def parse(state: ParseState) -> ParseResult:
+        values: list[Any] = []
+        current = state
+        committed = False
+        for sub in parsers:
+            result = sub(current)
+            if isinstance(result, ParseFailure):
+                if committed and not result.committed:
+                    return ParseFailure(
+                        pos=result.pos,
+                        message=result.message,
+                        committed=True,
+                    )
+                return result
+            if result.committed:
+                committed = True
+            values.append(result.value)
+            current = result.state
+        return ParseSuccess(value=tuple(values), state=current, committed=committed)
+
+    return parse
+
+
+def alt(*parsers: Parser) -> Parser:
+    """PEG ordered choice: return the first success; fail only if all fail.
+
+    A committed failure (one produced after a cut() inside the failing
+    branch) short-circuits the choice: alt returns it immediately rather
+    than trying further alternatives.
+    """
+
+    def parse(state: ParseState) -> ParseResult:
+        last_failure: ParseFailure | None = None
+        for sub in parsers:
+            result = sub(state)
+            if isinstance(result, ParseSuccess):
+                return result
+            if result.committed:
+                return result
+            last_failure = result
+        if last_failure is not None:
+            return last_failure
+        return ParseFailure(pos=state.pos, message="alt() called with no parsers")
+
+    return parse
+
+
+def opt(parser: Parser) -> Parser:
+    """0 or 1 occurrence. Always succeeds; value is None on miss."""
+
+    def parse(state: ParseState) -> ParseResult:
+        result = parser(state)
+        if isinstance(result, ParseSuccess):
+            return result
+        return ParseSuccess(value=None, state=state)
+
+    return parse
+
+
+def star(parser: Parser) -> Parser:
+    """0 or more occurrences (greedy). Never fails; returns list of values."""
+
+    def parse(state: ParseState) -> ParseResult:
+        values: list[Any] = []
+        current = state
+        while True:
+            result = parser(current)
+            if isinstance(result, ParseFailure):
+                return ParseSuccess(value=values, state=current)
+            values.append(result.value)
+            current = result.state
+
+    return parse
+
+
+def plus(parser: Parser) -> Parser:
+    """1 or more occurrences (greedy). Fails if zero matches."""
+
+    def parse(state: ParseState) -> ParseResult:
+        first = parser(state)
+        if isinstance(first, ParseFailure):
+            return first
+        values: list[Any] = [first.value]
+        current = first.state
+        while True:
+            result = parser(current)
+            if isinstance(result, ParseFailure):
+                return ParseSuccess(value=values, state=current)
+            values.append(result.value)
+            current = result.state
+
+    return parse
+
+
+def and_p(parser: Parser) -> Parser:
+    """Positive lookahead. Succeeds iff parser succeeds; never consumes input."""
+
+    def parse(state: ParseState) -> ParseResult:
+        result = parser(state)
+        if isinstance(result, ParseSuccess):
+            return ParseSuccess(value=None, state=state)
+        return result
+
+    return parse
+
+
+def not_p(parser: Parser) -> Parser:
+    """Negative lookahead. Succeeds iff parser fails; never consumes input."""
+
+    def parse(state: ParseState) -> ParseResult:
+        result = parser(state)
+        if isinstance(result, ParseSuccess):
+            return ParseFailure(
+                pos=state.pos,
+                message="negative lookahead matched (expected miss)",
+            )
+        return ParseSuccess(value=None, state=state)
+
+    return parse
+
+
+def cut() -> Parser:
+    """Commit point for PEG-with-cut semantics.
+
+    Following Mizukami & Mizushima (2014) and Onion: once cut() is crossed
+    inside a seq, subsequent failures in that seq propagate as committed
+    failures, and an enclosing alt() will not try further alternatives.
+
+    Use this when a partial match is enough to confirm we are in the right
+    branch (e.g. after a BoundaryCheck rule has matched a policy concern),
+    so that other response paths are not silently considered.
+    """
+
+    def parse(state: ParseState) -> ParseResult:
+        return ParseSuccess(value=None, state=state, committed=True)
+
+    return parse

--- a/sociality-mcp/packages/agent-grammar/tests/test_parser.py
+++ b/sociality-mcp/packages/agent-grammar/tests/test_parser.py
@@ -1,0 +1,138 @@
+"""Tests for the hand-rolled PEG parser core.
+
+This module pins down the minimal combinator set we need before wiring the
+turn grammar:
+
+  lit / seq / alt / opt
+
+All state is immutable (frozen dataclasses) per the project coding-style
+rule — parsers never mutate ParseState, they return a new one. The
+plan-of-record is ~/.claude/plans/jazzy-wishing-starfish.md.
+"""
+
+from __future__ import annotations
+
+from agent_grammar.parser import (
+    ParseFailure,
+    ParseState,
+    ParseSuccess,
+    alt,
+    lit,
+    opt,
+    seq,
+)
+
+
+def _run(parser, text: str):
+    return parser(ParseState(text=text, pos=0))
+
+
+def test_parse_state_is_immutable() -> None:
+    state = ParseState(text="abc", pos=0)
+    advanced = state.advance(2)
+    assert state.pos == 0
+    assert advanced.pos == 2
+    assert advanced.text == "abc"
+
+
+def test_lit_matches_prefix() -> None:
+    result = _run(lit("hello"), "hello world")
+    assert isinstance(result, ParseSuccess)
+    assert result.value == "hello"
+    assert result.state.pos == 5
+
+
+def test_lit_fails_when_no_match() -> None:
+    result = _run(lit("hi"), "hello")
+    assert isinstance(result, ParseFailure)
+    assert result.pos == 0
+    assert "hi" in result.message
+
+
+def test_lit_matches_at_nonzero_position() -> None:
+    state = ParseState(text="hi there", pos=3)
+    result = lit("there")(state)
+    assert isinstance(result, ParseSuccess)
+    assert result.value == "there"
+    assert result.state.pos == 8
+
+
+def test_seq_concatenates_successes() -> None:
+    parser = seq(lit("foo"), lit("bar"))
+    result = _run(parser, "foobar")
+    assert isinstance(result, ParseSuccess)
+    assert result.value == ("foo", "bar")
+    assert result.state.pos == 6
+
+
+def test_seq_fails_if_any_member_fails() -> None:
+    parser = seq(lit("foo"), lit("bar"))
+    result = _run(parser, "fooBAZ")
+    assert isinstance(result, ParseFailure)
+    assert result.pos == 3
+
+
+def test_seq_does_not_consume_input_on_partial_failure() -> None:
+    """PEG: failed seq must report failure but not advance the caller's state."""
+    parser = seq(lit("foo"), lit("bar"))
+    state = ParseState(text="fooBAZ", pos=0)
+    result = parser(state)
+    assert isinstance(result, ParseFailure)
+    # The original state is untouched (immutability) — the caller still
+    # holds pos=0 and can retry an alternative.
+    assert state.pos == 0
+
+
+def test_alt_picks_first_success() -> None:
+    parser = alt(lit("foo"), lit("bar"))
+    result = _run(parser, "bar")
+    assert isinstance(result, ParseSuccess)
+    assert result.value == "bar"
+
+
+def test_alt_picks_first_when_multiple_match() -> None:
+    """PEG semantics: ordered choice, not longest match."""
+    parser = alt(lit("foo"), lit("foobar"))
+    result = _run(parser, "foobar")
+    assert isinstance(result, ParseSuccess)
+    assert result.value == "foo"
+    assert result.state.pos == 3
+
+
+def test_alt_fails_when_all_alternatives_fail() -> None:
+    parser = alt(lit("foo"), lit("bar"))
+    result = _run(parser, "baz")
+    assert isinstance(result, ParseFailure)
+
+
+def test_opt_returns_none_on_failure() -> None:
+    parser = opt(lit("x"))
+    result = _run(parser, "abc")
+    assert isinstance(result, ParseSuccess)
+    assert result.value is None
+    assert result.state.pos == 0
+
+
+def test_opt_returns_value_on_success() -> None:
+    parser = opt(lit("a"))
+    result = _run(parser, "abc")
+    assert isinstance(result, ParseSuccess)
+    assert result.value == "a"
+    assert result.state.pos == 1
+
+
+def test_combinators_compose() -> None:
+    """opt + seq + alt should compose into a useful grammar fragment."""
+    # Match "hi" or "hello" optionally followed by " world"
+    greeting = alt(lit("hello"), lit("hi"))
+    parser = seq(greeting, opt(lit(" world")))
+
+    result = _run(parser, "hello world")
+    assert isinstance(result, ParseSuccess)
+    assert result.value == ("hello", " world")
+    assert result.state.pos == 11
+
+    result2 = _run(parser, "hi")
+    assert isinstance(result2, ParseSuccess)
+    assert result2.value == ("hi", None)
+    assert result2.state.pos == 2

--- a/sociality-mcp/packages/agent-grammar/tests/test_parser_cut.py
+++ b/sociality-mcp/packages/agent-grammar/tests/test_parser_cut.py
@@ -1,0 +1,100 @@
+"""Tests for the PEG-with-cut commitment operator.
+
+Cut (à la Mizukami & Mizushima 2014, and Onion) marks a commitment point:
+once seq(..., cut(), ...) has passed cut(), subsequent failures inside the
+same seq are propagated as committed failures, and an enclosing alt() will
+NOT try further alternatives — it will fail immediately.
+
+Use case in agent-grammar: BoundaryCheck. Once a policy violation is
+confirmed, we don't want the orchestrator to silently try another response
+move that ignores the boundary. Cut makes that propagation explicit.
+"""
+
+from __future__ import annotations
+
+from agent_grammar.parser import (
+    ParseFailure,
+    ParseState,
+    ParseSuccess,
+    alt,
+    cut,
+    lit,
+    seq,
+)
+
+
+def _run(parser, text: str):
+    return parser(ParseState(text=text, pos=0))
+
+
+class TestCutItself:
+    def test_cut_alone_succeeds_with_committed_flag(self) -> None:
+        result = _run(cut(), "anything")
+        assert isinstance(result, ParseSuccess)
+        assert result.value is None
+        assert result.committed is True
+        # cut never consumes input
+        assert result.state.pos == 0
+
+
+class TestCutInSeq:
+    def test_seq_without_cut_propagates_uncommitted_failure(self) -> None:
+        parser = seq(lit("a"), lit("b"))
+        result = _run(parser, "ax")
+        assert isinstance(result, ParseFailure)
+        assert result.committed is False
+
+    def test_seq_after_cut_propagates_committed_failure(self) -> None:
+        parser = seq(lit("a"), cut(), lit("b"))
+        result = _run(parser, "ax")
+        assert isinstance(result, ParseFailure)
+        assert result.committed is True
+
+    def test_seq_success_after_cut_still_succeeds(self) -> None:
+        parser = seq(lit("a"), cut(), lit("b"))
+        result = _run(parser, "ab")
+        assert isinstance(result, ParseSuccess)
+        # the seq's tuple skips the cut() value (None) — implementation
+        # choice: we include it as None for transparency.
+        assert "a" in result.value
+        assert "b" in result.value
+
+
+class TestCutInAlt:
+    def test_alt_without_cut_tries_next_alternative_on_failure(self) -> None:
+        # Without cut: if "ab" branch fails after seeing "a", alt tries "ax"
+        parser = alt(seq(lit("a"), lit("b")), seq(lit("a"), lit("x")))
+        result = _run(parser, "ax")
+        assert isinstance(result, ParseSuccess)
+        assert result.value == ("a", "x")
+
+    def test_alt_with_cut_does_not_try_next_alternative(self) -> None:
+        # With cut after "a": once "a" matches and cut commits, failure on
+        # "b" is committed, so the second alternative is NOT tried even
+        # though it would have matched.
+        parser = alt(
+            seq(lit("a"), cut(), lit("b")),
+            seq(lit("a"), lit("x")),
+        )
+        result = _run(parser, "ax")
+        assert isinstance(result, ParseFailure)
+        assert result.committed is True
+
+    def test_alt_with_cut_still_succeeds_when_committed_branch_completes(self) -> None:
+        parser = alt(
+            seq(lit("a"), cut(), lit("b")),
+            seq(lit("a"), lit("x")),
+        )
+        result = _run(parser, "ab")
+        assert isinstance(result, ParseSuccess)
+        assert "a" in result.value
+        assert "b" in result.value
+
+    def test_alt_without_cut_picks_correct_alternative_when_first_fails_early(
+        self,
+    ) -> None:
+        # Pure PEG: failure before any cut is uncommitted, alt backtracks.
+        parser = alt(lit("foo"), lit("bar"))
+        result = _run(parser, "bar")
+        assert isinstance(result, ParseSuccess)
+        assert result.value == "bar"

--- a/sociality-mcp/packages/agent-grammar/tests/test_parser_lookahead.py
+++ b/sociality-mcp/packages/agent-grammar/tests/test_parser_lookahead.py
@@ -1,0 +1,73 @@
+"""Tests for lookahead combinators: not_p (!) and and_p (&).
+
+Neither consumes input. Both are zero-width assertions in classical PEG.
+
+  and_p(p): succeeds iff p succeeds at the current position. Does not advance.
+  not_p(p): succeeds iff p fails at the current position. Does not advance.
+"""
+
+from __future__ import annotations
+
+from agent_grammar.parser import (
+    ParseFailure,
+    ParseState,
+    ParseSuccess,
+    and_p,
+    lit,
+    not_p,
+    seq,
+)
+
+
+def _run(parser, text: str):
+    return parser(ParseState(text=text, pos=0))
+
+
+class TestNotP:
+    def test_not_p_succeeds_when_inner_fails(self) -> None:
+        result = _run(not_p(lit("foo")), "bar")
+        assert isinstance(result, ParseSuccess)
+        assert result.value is None
+        assert result.state.pos == 0
+
+    def test_not_p_fails_when_inner_succeeds(self) -> None:
+        result = _run(not_p(lit("foo")), "foobar")
+        assert isinstance(result, ParseFailure)
+        assert result.pos == 0
+
+    def test_not_p_does_not_consume_input_on_success(self) -> None:
+        parser = seq(not_p(lit("foo")), lit("bar"))
+        result = _run(parser, "bar")
+        assert isinstance(result, ParseSuccess)
+        assert result.value == (None, "bar")
+        assert result.state.pos == 3
+
+    def test_not_p_useful_for_negative_terminator(self) -> None:
+        # eat any 'a' that is not followed by 'b'
+        parser = seq(not_p(seq(lit("a"), lit("b"))), lit("a"))
+        # "ac" should match (a not followed by b)
+        result = _run(parser, "ac")
+        assert isinstance(result, ParseSuccess)
+        # "ab" should not (a is followed by b)
+        result2 = _run(parser, "ab")
+        assert isinstance(result2, ParseFailure)
+
+
+class TestAndP:
+    def test_and_p_succeeds_when_inner_succeeds(self) -> None:
+        result = _run(and_p(lit("foo")), "foobar")
+        assert isinstance(result, ParseSuccess)
+        assert result.value is None
+        assert result.state.pos == 0
+
+    def test_and_p_fails_when_inner_fails(self) -> None:
+        result = _run(and_p(lit("foo")), "bar")
+        assert isinstance(result, ParseFailure)
+        assert result.pos == 0
+
+    def test_and_p_does_not_consume_input(self) -> None:
+        parser = seq(and_p(lit("foo")), lit("foo"))
+        result = _run(parser, "foobar")
+        assert isinstance(result, ParseSuccess)
+        assert result.value == (None, "foo")
+        assert result.state.pos == 3

--- a/sociality-mcp/packages/agent-grammar/tests/test_parser_repetition.py
+++ b/sociality-mcp/packages/agent-grammar/tests/test_parser_repetition.py
@@ -1,0 +1,70 @@
+"""Tests for repetition combinators: star (*) and plus (+).
+
+  star: 0 or more occurrences; never fails, returns list
+  plus: 1 or more occurrences; fails if no match
+
+Both are greedy (PEG semantics — no backtracking from inside the loop).
+"""
+
+from __future__ import annotations
+
+from agent_grammar.parser import (
+    ParseFailure,
+    ParseState,
+    ParseSuccess,
+    lit,
+    plus,
+    seq,
+    star,
+)
+
+
+def _run(parser, text: str):
+    return parser(ParseState(text=text, pos=0))
+
+
+class TestStar:
+    def test_star_zero_matches_succeeds_with_empty_list(self) -> None:
+        result = _run(star(lit("a")), "xyz")
+        assert isinstance(result, ParseSuccess)
+        assert result.value == []
+        assert result.state.pos == 0
+
+    def test_star_consumes_all_matches_greedily(self) -> None:
+        result = _run(star(lit("a")), "aaab")
+        assert isinstance(result, ParseSuccess)
+        assert result.value == ["a", "a", "a"]
+        assert result.state.pos == 3
+
+    def test_star_with_seq_pattern(self) -> None:
+        # match any number of "ab" pairs
+        parser = star(seq(lit("a"), lit("b")))
+        result = _run(parser, "ababab")
+        assert isinstance(result, ParseSuccess)
+        assert len(result.value) == 3
+        assert result.state.pos == 6
+
+
+class TestPlus:
+    def test_plus_zero_matches_fails(self) -> None:
+        result = _run(plus(lit("a")), "xyz")
+        assert isinstance(result, ParseFailure)
+        assert result.pos == 0
+
+    def test_plus_single_match_succeeds(self) -> None:
+        result = _run(plus(lit("a")), "ab")
+        assert isinstance(result, ParseSuccess)
+        assert result.value == ["a"]
+        assert result.state.pos == 1
+
+    def test_plus_multiple_matches(self) -> None:
+        result = _run(plus(lit("a")), "aaab")
+        assert isinstance(result, ParseSuccess)
+        assert result.value == ["a", "a", "a"]
+        assert result.state.pos == 3
+
+    def test_plus_in_seq(self) -> None:
+        parser = seq(plus(lit("a")), lit("b"))
+        result = _run(parser, "aaab")
+        assert isinstance(result, ParseSuccess)
+        assert result.value == (["a", "a", "a"], "b")


### PR DESCRIPTION
## Summary

Builds on #91. Adds the hand-rolled PEG parser combinators that the agent turn grammar will sit on top of. Library choice was hand-rolled rather than parsimonious/lark/pegen so the cut semantics can be designed alongside the combinator semantics rather than inherited from a generic library — a deliberate carry-over from Kouta's PEG/Onion work.

### Combinator set

| Block | Combinators | Tests |
|--|--|--|
| Basic | \`lit\` / \`seq\` / \`alt\` / \`opt\` | 13 |
| Repetition | \`star\` / \`plus\` (greedy) | 7 |
| Lookahead | \`and_p\` / \`not_p\` (zero-width) | 7 |
| Commit | \`cut\` (PEG-with-cut) | 8 |

35 new combinator tests + 5 existing smoke = **40 total, ruff clean**.

### PEG-with-cut semantics

Following Mizukami & Mizushima 2014 / Onion:

\`ParseSuccess\` and \`ParseFailure\` both carry \`committed: bool = False\`.

- \`cut()\` returns \`ParseSuccess(value=None, committed=True)\` without consuming input
- \`seq\` raises \`committed=True\` once any sub-parser commits, and propagates that to any downstream failure
- \`alt\` short-circuits on a committed failure — does NOT try further alternatives

This is the operator that BoundaryCheck rules will use. Once a policy concern matches inside a turn, we don't want the orchestrator to silently fall through to an alternative response path that ignores the concern.

### Why immutable state

\`ParseState\` is a frozen dataclass. Backtracking is just "the caller still holds the old state" — no rewind logic. This matches the project coding-style rule (never mutate; create new objects).

### Not yet wired

\`agent-grammar\` is still NOT a dependency of \`sociality-mcp\`. Next PRs will:
- Build rule-level constructs (\`Turn\` / \`Observe\` / \`Interpret\` / \`Respond\`) on top of these combinators
- Add packrat memoization (will start to matter once the grammar gets large)
- Add \`regex\` / char-class primitives
- Eventually switch \`plan_response_tool\` over to the grammar runtime

## Test plan

- [x] \`packages/agent-grammar\` — 40/40 pass
- [x] ruff clean
- [ ] Build out the rule layer on top of these combinators
- [ ] Wire into \`plan_response_tool\` in a later PR

Plan-of-record (local): \`~/.claude/plans/jazzy-wishing-starfish.md\`