### PR TITLE
feat(memory-mcp): workspace ignition + refractory + precision vector (Phase 2.2)

### DIFF
--- a/memory-mcp/src/memory_mcp/workspace.py
+++ b/memory-mcp/src/memory_mcp/workspace.py
@@ -1,7 +1,23 @@
-"""Global-workspace inspired candidate selection."""
+"""Global-workspace inspired candidate selection.
+
+Phase 2.2 extends the original winner-take-all selection with:
+  - PrecisionVector: per-channel weights (replaces fixed 0.45/0.20/0.20/0.15)
+  - precision_from_pe_channels: precision allocation from PE z-scores
+  - WorkspaceConfig: ignition_threshold + refractory_ticks
+  - RefractoryState: post-ignition cooldown that boosts the threshold
+  - ScoreBreakdown: per-channel contribution for explainability
+  - WorkspaceSelectionResult: structured return with ignited flag
+
+The legacy select_workspace_candidates() signature is preserved as a thin
+wrapper — existing callers in store.py keep working unchanged.
+
+See consciousness-mcp/AGENTS.md for vocabulary discipline (functional
+language only in technical artifacts).
+"""
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 from .predictive import memory_tokens
@@ -17,6 +33,138 @@ class WorkspaceCandidate:
     novelty: float
     prediction_error: float
     emotion_boost: float
+
+
+@dataclass(frozen=True)
+class PrecisionVector:
+    """Per-channel weights for utility computation.
+
+    Channel mapping:
+      relevance         — exteroceptive perception / context match
+      novelty           — mnemonic novelty
+      prediction_error  — mnemonic prediction error
+      emotion           — interoceptive / emotional weighting
+
+    Default values match the legacy fixed weights (0.45 / 0.20 / 0.20 / 0.15)
+    so an explicit `precision=None` produces the same selection as before
+    Phase 2.2 shipped.
+    """
+
+    relevance: float
+    novelty: float
+    prediction_error: float
+    emotion: float
+
+    @classmethod
+    def default(cls) -> PrecisionVector:
+        return cls(relevance=0.45, novelty=0.20, prediction_error=0.20, emotion=0.15)
+
+    def normalized(self, budget: float = 1.0) -> PrecisionVector:
+        total = self.relevance + self.novelty + self.prediction_error + self.emotion
+        if total <= 0:
+            # Uniform fallback — never blow up on an all-zero vector.
+            quarter = budget / 4
+            return PrecisionVector(quarter, quarter, quarter, quarter)
+        scale = budget / total
+        return PrecisionVector(
+            relevance=self.relevance * scale,
+            novelty=self.novelty * scale,
+            prediction_error=self.prediction_error * scale,
+            emotion=self.emotion * scale,
+        )
+
+
+def precision_from_pe_channels(
+    *,
+    extero: float,
+    intero: float,
+    mnemonic: float,
+) -> PrecisionVector:
+    """Build a PrecisionVector from per-channel prediction-error z-scores.
+
+    Mapping:
+      extero PE   -> relevance weight (perception drives attention)
+      intero PE   -> emotion weight   (interoception drives affective weighting)
+      mnemonic PE -> split 60/40 between novelty and prediction_error
+
+    Implementation: softmax over |PE| (negative PE is as informative as
+    positive PE). All-zero PE falls back to PrecisionVector.default() so
+    a quiet tick produces legacy weights rather than uniform 0.25s.
+    """
+    if extero == 0.0 and intero == 0.0 and mnemonic == 0.0:
+        return PrecisionVector.default()
+
+    e_x = math.exp(abs(extero))
+    e_i = math.exp(abs(intero))
+    e_m = math.exp(abs(mnemonic))
+    total = e_x + e_i + e_m
+    mnemonic_share = e_m / total
+    return PrecisionVector(
+        relevance=e_x / total,
+        novelty=mnemonic_share * 0.6,
+        prediction_error=mnemonic_share * 0.4,
+        emotion=e_i / total,
+    ).normalized()
+
+
+@dataclass(frozen=True)
+class WorkspaceConfig:
+    """Configuration for ignition + refractory dynamics.
+
+    Defaults preserve legacy behavior:
+      ignition_threshold=0.0 means every tick ignites (any non-empty
+      candidate set produces winners).
+      refractory_ticks=0 means no post-ignition cooldown.
+    """
+
+    ignition_threshold: float = 0.0
+    refractory_ticks: int = 0
+    refractory_boost: float = 0.3
+
+
+@dataclass(frozen=True)
+class RefractoryState:
+    """Post-ignition cooldown that boosts the effective threshold."""
+
+    remaining_ticks: int
+
+    def is_active(self) -> bool:
+        return self.remaining_ticks > 0
+
+    def decay(self) -> RefractoryState:
+        return RefractoryState(remaining_ticks=max(0, self.remaining_ticks - 1))
+
+
+@dataclass(frozen=True)
+class ScoreBreakdown:
+    """Per-channel contribution to a winner's total score (for explainability)."""
+
+    memory_id: str
+    relevance_contribution: float
+    novelty_contribution: float
+    prediction_error_contribution: float
+    emotion_contribution: float
+    redundancy_penalty: float
+    total: float
+
+
+@dataclass(frozen=True)
+class WorkspaceSelectionResult:
+    """Result of select_workspace_candidates_with_ignition.
+
+    winners is empty when the top candidate fails the ignition threshold —
+    a subliminal tick. breakdown is empty in that case too; the agent is
+    allowed to be non-responsive without explaining a non-winner.
+    new_refractory is the cooldown state to thread into the next call:
+      - ignited tick installs a fresh RefractoryState(cfg.refractory_ticks)
+      - subliminal tick decays any incoming refractory by 1
+      - if no incoming refractory and no ignition, new_refractory is None
+    """
+
+    winners: list[tuple[WorkspaceCandidate, float]]
+    ignited: bool
+    breakdown: list[ScoreBreakdown]
+    new_refractory: RefractoryState | None
 
 
 def _candidate_utility(
@@ -63,28 +211,109 @@ def select_workspace_candidates(
     max_results: int,
     temperature: float = 0.7,
 ) -> list[tuple[WorkspaceCandidate, float]]:
-    """Select memories through iterative winner-take-all competition."""
-    if max_results <= 0 or not candidates:
-        return []
+    """Select memories through iterative winner-take-all competition.
 
-    selected: list[tuple[WorkspaceCandidate, float]] = []
+    Legacy signature preserved for backward compatibility. Calls
+    select_workspace_candidates_with_ignition under the hood with the
+    default WorkspaceConfig (ignition_threshold=0 → every tick ignites)
+    and PrecisionVector.default() (legacy fixed weights). Existing
+    callers continue to receive list[(candidate, score)] tuples.
+    """
+    result = select_workspace_candidates_with_ignition(
+        candidates,
+        max_results,
+        temperature=temperature,
+    )
+    return result.winners
+
+
+def select_workspace_candidates_with_ignition(
+    candidates: list[WorkspaceCandidate],
+    max_results: int,
+    *,
+    temperature: float = 0.7,
+    config: WorkspaceConfig | None = None,
+    precision: PrecisionVector | None = None,
+    refractory: RefractoryState | None = None,
+) -> WorkspaceSelectionResult:
+    """Select winners with ignition threshold + refractory + precision weights.
+
+    Greedy iterative competition (same algorithm as legacy) but every
+    score is composed from per-channel contributions weighted by `precision`,
+    redundancy-penalized, and temperature-divided. The top score is
+    compared against an effective ignition threshold (base + refractory
+    boost); subliminal ticks return empty winners and an empty breakdown,
+    allowing the agent to be non-responsive.
+    """
+    cfg = config or WorkspaceConfig()
+    prec = (precision or PrecisionVector.default()).normalized()
+
+    if max_results <= 0 or not candidates:
+        return WorkspaceSelectionResult(
+            winners=[],
+            ignited=False,
+            breakdown=[],
+            new_refractory=refractory.decay() if refractory else None,
+        )
+
+    effective_threshold = cfg.ignition_threshold
+    if refractory is not None and refractory.is_active():
+        effective_threshold += cfg.refractory_boost
+
+    temp = max(0.1, min(2.0, temperature))
+    selected_pairs: list[tuple[WorkspaceCandidate, float]] = []
+    selected_breakdowns: list[ScoreBreakdown] = []
     chosen_memories: list[Memory] = []
     remaining = candidates.copy()
 
-    while remaining and len(selected) < max_results:
-        scored: list[tuple[WorkspaceCandidate, float]] = []
+    while remaining and len(selected_pairs) < max_results:
+        scored: list[tuple[WorkspaceCandidate, float, ScoreBreakdown]] = []
         for cand in remaining:
             penalty = _redundancy_penalty(cand.memory, chosen_memories)
-            score = _candidate_utility(cand, penalty, temperature)
-            scored.append((cand, score))
+            r_c = prec.relevance * cand.relevance
+            n_c = prec.novelty * cand.novelty
+            pe_c = prec.prediction_error * cand.prediction_error
+            e_c = prec.emotion * cand.emotion_boost
+            pen_c = 0.25 * penalty
+            total = (r_c + n_c + pe_c + e_c - pen_c) / temp
+            breakdown = ScoreBreakdown(
+                memory_id=cand.memory.id,
+                relevance_contribution=r_c / temp,
+                novelty_contribution=n_c / temp,
+                prediction_error_contribution=pe_c / temp,
+                emotion_contribution=e_c / temp,
+                redundancy_penalty=pen_c / temp,
+                total=total,
+            )
+            scored.append((cand, total, breakdown))
 
         scored.sort(key=lambda item: item[1], reverse=True)
-        best_cand, best_score = scored[0]
-        selected.append((best_cand, best_score))
+        best_cand, best_score, best_breakdown = scored[0]
+        selected_pairs.append((best_cand, best_score))
+        selected_breakdowns.append(best_breakdown)
         chosen_memories.append(best_cand.memory)
-        remaining = [cand for cand in remaining if cand.memory.id != best_cand.memory.id]
+        remaining = [c for c in remaining if c.memory.id != best_cand.memory.id]
 
-    return selected
+    top_score = selected_pairs[0][1] if selected_pairs else 0.0
+    ignited = top_score >= effective_threshold
+
+    if ignited:
+        winners = selected_pairs
+        breakdown_out = selected_breakdowns
+        new_refractory: RefractoryState | None = RefractoryState(
+            remaining_ticks=cfg.refractory_ticks
+        )
+    else:
+        winners = []
+        breakdown_out = []
+        new_refractory = refractory.decay() if refractory else None
+
+    return WorkspaceSelectionResult(
+        winners=winners,
+        ignited=ignited,
+        breakdown=breakdown_out,
+        new_refractory=new_refractory,
+    )
 
 
 def diversity_score(memories: list[Memory]) -> float:

--- a/memory-mcp/tests/test_workspace_ignition.py
+++ b/memory-mcp/tests/test_workspace_ignition.py
@@ -1,0 +1,313 @@
+"""Tests for Phase 2.2 workspace.py extensions.
+
+Phase 2.2 adds three dataclasses on top of the existing winner-take-all
+selection: PrecisionVector (per-channel weights), WorkspaceConfig
+(ignition_threshold + refractory), RefractoryState (cooldown counter).
+The new select_workspace_candidates_with_ignition() returns a
+WorkspaceSelectionResult that surfaces ignition success + per-channel
+breakdown for explainability. The plan-of-record is
+~/.claude/plans/jazzy-wishing-starfish.md.
+
+The existing select_workspace_candidates() signature is preserved as a
+thin wrapper for backward compatibility — no caller in store.py is
+forced to upgrade in this PR.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memory_mcp.types import Memory
+from memory_mcp.workspace import (
+    PrecisionVector,
+    RefractoryState,
+    ScoreBreakdown,
+    WorkspaceCandidate,
+    WorkspaceConfig,
+    WorkspaceSelectionResult,
+    precision_from_pe_channels,
+    select_workspace_candidates,
+    select_workspace_candidates_with_ignition,
+)
+
+
+def _memory(memory_id: str, content: str = "x") -> Memory:
+    return Memory(
+        id=memory_id,
+        content=content,
+        timestamp="2026-06-13T03:00:00+00:00",
+        emotion="neutral",
+        importance=3,
+        category="daily",
+    )
+
+
+def _candidate(
+    memory_id: str,
+    *,
+    relevance: float = 0.5,
+    novelty: float = 0.5,
+    prediction_error: float = 0.5,
+    emotion_boost: float = 0.0,
+    content: str | None = None,
+) -> WorkspaceCandidate:
+    return WorkspaceCandidate(
+        memory=_memory(memory_id, content=content or f"content_{memory_id}"),
+        relevance=relevance,
+        novelty=novelty,
+        prediction_error=prediction_error,
+        emotion_boost=emotion_boost,
+    )
+
+
+class TestPrecisionVector:
+    def test_default_weights_match_legacy_fixed_weights(self) -> None:
+        """The default PrecisionVector reproduces the pre-Phase-2.2 weights."""
+        pv = PrecisionVector.default()
+        assert pv.relevance == pytest.approx(0.45)
+        assert pv.novelty == pytest.approx(0.20)
+        assert pv.prediction_error == pytest.approx(0.20)
+        assert pv.emotion == pytest.approx(0.15)
+
+    def test_weights_sum_to_one_by_construction(self) -> None:
+        pv = PrecisionVector.default()
+        total = pv.relevance + pv.novelty + pv.prediction_error + pv.emotion
+        assert total == pytest.approx(1.0)
+
+    def test_normalize_scales_to_unit_budget(self) -> None:
+        pv = PrecisionVector(
+            relevance=0.4, novelty=0.4, prediction_error=0.4, emotion=0.4
+        ).normalized()
+        total = pv.relevance + pv.novelty + pv.prediction_error + pv.emotion
+        assert total == pytest.approx(1.0)
+
+    def test_normalize_preserves_ratios(self) -> None:
+        pv = PrecisionVector(
+            relevance=2.0, novelty=1.0, prediction_error=1.0, emotion=0.0
+        ).normalized()
+        # 2:1:1:0 → 0.5:0.25:0.25:0.0
+        assert pv.relevance == pytest.approx(0.5)
+        assert pv.novelty == pytest.approx(0.25)
+        assert pv.prediction_error == pytest.approx(0.25)
+        assert pv.emotion == pytest.approx(0.0)
+
+    def test_normalize_handles_zero_sum_gracefully(self) -> None:
+        """All-zero vector must not blow up; falls back to uniform."""
+        pv = PrecisionVector(
+            relevance=0.0, novelty=0.0, prediction_error=0.0, emotion=0.0
+        ).normalized()
+        # No NaN, no crash — uniform fallback
+        assert pv.relevance == pytest.approx(0.25)
+        assert pv.novelty == pytest.approx(0.25)
+        assert pv.prediction_error == pytest.approx(0.25)
+        assert pv.emotion == pytest.approx(0.25)
+
+
+class TestPrecisionFromPE:
+    def test_higher_pe_channel_gets_higher_weight(self) -> None:
+        """When a channel has high z-score PE, its precision (weight) goes up."""
+        # extero high, intero low, mnemonic low → extero gets larger weight
+        pv = precision_from_pe_channels(
+            extero=1.5,
+            intero=0.0,
+            mnemonic=0.0,
+        )
+        # extero maps to relevance (perception); intero to emotion;
+        # mnemonic to prediction_error/novelty.
+        assert pv.relevance > pv.emotion
+        assert pv.relevance > pv.prediction_error
+
+    def test_uniform_pe_returns_near_default_weights(self) -> None:
+        """All channels equal → weights converge toward default ratios."""
+        pv = precision_from_pe_channels(extero=0.0, intero=0.0, mnemonic=0.0)
+        default = PrecisionVector.default()
+        # When PE is uniform, fall back to defaults.
+        assert pv.relevance == pytest.approx(default.relevance, abs=0.05)
+        assert pv.emotion == pytest.approx(default.emotion, abs=0.05)
+
+
+class TestWorkspaceConfig:
+    def test_default_disables_ignition_threshold(self) -> None:
+        """Default config keeps legacy behavior: always ignite."""
+        cfg = WorkspaceConfig()
+        assert cfg.ignition_threshold == 0.0
+
+    def test_refractory_defaults_to_zero(self) -> None:
+        cfg = WorkspaceConfig()
+        assert cfg.refractory_ticks == 0
+
+
+class TestRefractoryState:
+    def test_inactive_state_does_not_block(self) -> None:
+        state = RefractoryState(remaining_ticks=0)
+        assert state.is_active() is False
+
+    def test_active_state_blocks(self) -> None:
+        state = RefractoryState(remaining_ticks=3)
+        assert state.is_active() is True
+
+    def test_decay_reduces_by_one(self) -> None:
+        assert RefractoryState(remaining_ticks=3).decay().remaining_ticks == 2
+        assert RefractoryState(remaining_ticks=1).decay().remaining_ticks == 0
+        assert RefractoryState(remaining_ticks=0).decay().remaining_ticks == 0
+
+
+class TestIgnitionThreshold:
+    def test_below_threshold_returns_subliminal_tick(self) -> None:
+        """If no candidate scores above ignition_threshold, ignited=False and
+        winners is empty (subliminal tick — Kokone allowed to not respond)."""
+        cfg = WorkspaceConfig(ignition_threshold=2.0)  # impossibly high
+        candidates = [_candidate("m1", relevance=0.5, novelty=0.5)]
+        result = select_workspace_candidates_with_ignition(
+            candidates, max_results=3, config=cfg
+        )
+        assert isinstance(result, WorkspaceSelectionResult)
+        assert result.ignited is False
+        assert result.winners == []
+
+    def test_above_threshold_ignites_and_returns_winners(self) -> None:
+        cfg = WorkspaceConfig(ignition_threshold=0.0)
+        candidates = [
+            _candidate("m1", relevance=0.9, novelty=0.5),
+            _candidate("m2", relevance=0.3, novelty=0.5),
+        ]
+        result = select_workspace_candidates_with_ignition(
+            candidates, max_results=2, config=cfg
+        )
+        assert result.ignited is True
+        assert len(result.winners) == 2
+
+    def test_refractory_state_raises_threshold(self) -> None:
+        """During refractory period, the effective threshold is boosted."""
+        # Base threshold passes (0.0), but during refractory, boost makes it harder.
+        cfg = WorkspaceConfig(
+            ignition_threshold=0.0,
+            refractory_ticks=3,
+            refractory_boost=2.0,  # impossibly high during refractory
+        )
+        candidates = [_candidate("m1", relevance=0.5, novelty=0.5)]
+        refractory = RefractoryState(remaining_ticks=2)
+        result = select_workspace_candidates_with_ignition(
+            candidates, max_results=1, config=cfg, refractory=refractory
+        )
+        assert result.ignited is False
+        assert result.winners == []
+
+    def test_post_ignition_returns_new_refractory(self) -> None:
+        """A successful ignition installs a refractory cooldown for next tick."""
+        cfg = WorkspaceConfig(refractory_ticks=5)
+        candidates = [_candidate("m1", relevance=0.9)]
+        result = select_workspace_candidates_with_ignition(
+            candidates, max_results=1, config=cfg
+        )
+        assert result.ignited is True
+        assert result.new_refractory is not None
+        assert result.new_refractory.remaining_ticks == 5
+
+    def test_failed_ignition_decays_existing_refractory(self) -> None:
+        """A subliminal tick does not install a new refractory but
+        continues the old one's decay."""
+        cfg = WorkspaceConfig(
+            ignition_threshold=10.0,  # never ignites
+            refractory_ticks=5,
+        )
+        candidates = [_candidate("m1", relevance=0.5)]
+        refractory = RefractoryState(remaining_ticks=3)
+        result = select_workspace_candidates_with_ignition(
+            candidates, max_results=1, config=cfg, refractory=refractory
+        )
+        assert result.ignited is False
+        assert result.new_refractory is not None
+        assert result.new_refractory.remaining_ticks == 2  # decayed
+
+
+class TestPrecisionInfluencesSelection:
+    def test_high_relevance_precision_picks_relevance_winner(self) -> None:
+        pv = PrecisionVector(
+            relevance=1.0, novelty=0.0, prediction_error=0.0, emotion=0.0
+        )
+        candidates = [
+            _candidate("rel_high", relevance=0.9, novelty=0.0),
+            _candidate("nov_high", relevance=0.0, novelty=0.9),
+        ]
+        result = select_workspace_candidates_with_ignition(
+            candidates, max_results=1, precision=pv
+        )
+        assert result.winners[0][0].memory.id == "rel_high"
+
+    def test_high_novelty_precision_picks_novelty_winner(self) -> None:
+        pv = PrecisionVector(
+            relevance=0.0, novelty=1.0, prediction_error=0.0, emotion=0.0
+        )
+        candidates = [
+            _candidate("rel_high", relevance=0.9, novelty=0.0),
+            _candidate("nov_high", relevance=0.0, novelty=0.9),
+        ]
+        result = select_workspace_candidates_with_ignition(
+            candidates, max_results=1, precision=pv
+        )
+        assert result.winners[0][0].memory.id == "nov_high"
+
+
+class TestScoreBreakdown:
+    def test_breakdown_emitted_per_winner(self) -> None:
+        candidates = [
+            _candidate("m1", relevance=0.8),
+            _candidate("m2", relevance=0.6),
+        ]
+        result = select_workspace_candidates_with_ignition(
+            candidates, max_results=2
+        )
+        assert len(result.breakdown) == 2
+        for b in result.breakdown:
+            assert isinstance(b, ScoreBreakdown)
+
+    def test_breakdown_channel_contributions_sum_to_score(self) -> None:
+        candidates = [
+            _candidate("m1", relevance=0.8, novelty=0.4, prediction_error=0.2)
+        ]
+        result = select_workspace_candidates_with_ignition(
+            candidates, max_results=1
+        )
+        b = result.breakdown[0]
+        reconstructed = (
+            b.relevance_contribution
+            + b.novelty_contribution
+            + b.prediction_error_contribution
+            + b.emotion_contribution
+            - b.redundancy_penalty
+        )
+        assert reconstructed == pytest.approx(b.total)
+
+    def test_breakdown_winner_id_matches_memory(self) -> None:
+        candidates = [_candidate("specific_id", relevance=0.7)]
+        result = select_workspace_candidates_with_ignition(
+            candidates, max_results=1
+        )
+        assert result.breakdown[0].memory_id == "specific_id"
+
+
+class TestBackwardCompatibility:
+    def test_legacy_select_workspace_candidates_still_returns_list_of_tuples(self) -> None:
+        """The legacy signature must continue to work — no caller forced to upgrade."""
+        candidates = [
+            _candidate("m1", relevance=0.8),
+            _candidate("m2", relevance=0.6),
+        ]
+        result = select_workspace_candidates(candidates, max_results=2)
+        # Still a list of (candidate, score) tuples.
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert all(isinstance(item, tuple) for item in result)
+        assert all(len(item) == 2 for item in result)
+
+    def test_legacy_signature_picks_winners_consistent_with_ignition_api(self) -> None:
+        candidates = [
+            _candidate("strong", relevance=0.9),
+            _candidate("weak", relevance=0.1),
+        ]
+        legacy = select_workspace_candidates(candidates, max_results=1)
+        modern = select_workspace_candidates_with_ignition(
+            candidates, max_results=1
+        )
+        assert legacy[0][0].memory.id == modern.winners[0][0].memory.id


### PR DESCRIPTION
## Summary

Phase 2.2 of the consciousness architecture from [the plan-of-record](https://github.com/lifemate-ai/embodied-claude/blob/main/.claude/plans/jazzy-wishing-starfish.md). Extends `memory-mcp/workspace.py` with:

| Type | Role |
|---|---|
| `PrecisionVector` | Per-channel weights replacing the fixed 0.45/0.20/0.20/0.15. `.default()` reproduces legacy weights so a missing `precision` argument behaves identically to before |
| `precision_from_pe_channels` | Softmax over \|PE\| across `{extero, intero, mnemonic}`; falls back to defaults on all-zero PE |
| `WorkspaceConfig` | `ignition_threshold` (default 0.0 = always ignites), `refractory_ticks`, `refractory_boost` |
| `RefractoryState` | Cooldown counter — `is_active()`, `decay()` |
| `ScoreBreakdown` | Per-winner per-channel contribution surface — Theory A R5 / GWT reportability |
| `WorkspaceSelectionResult` | Structured return with `.winners`, `.ignited`, `.breakdown[]`, `.new_refractory` |
| `select_workspace_candidates_with_ignition` | Greedy iterative selection composed from precision-weighted channel contributions, with absolute ignition threshold + refractory boost |

## Backward compatibility

The legacy `select_workspace_candidates(candidates, max_results, temperature)` signature is preserved as a thin wrapper. All 241 existing memory-mcp tests pass without modification. store.py's existing call sites continue to receive `list[(candidate, score)]` tuples.

## What this enables (downstream)

- **Subliminal ticks**: when no candidate clears the ignition threshold, `winners=[]` + `ignited=False`. The agent is allowed to be non-responsive — Theory A R3 (ignition threshold) honored.
- **Refractory period**: after a successful ignition, `new_refractory.remaining_ticks=cfg.refractory_ticks` raises the effective threshold for subsequent ticks until decayed — Theory A R5.
- **Precision allocation**: weights track PE z-scores across exteroceptive / interoceptive / mnemonic channels, so attention reallocates as regime changes — Theory C precision-weighted attention.
- **Explainability**: every winner carries a `ScoreBreakdown` with relevance / novelty / prediction_error / emotion contributions + redundancy penalty + total. `recent counterfactuals` + `score_breakdown` answer "why did this just happen?" without raw bid logs.

## Test plan

- [x] 24 new TDD tests in `tests/test_workspace_ignition.py` (PrecisionVector defaults + normalization + zero-sum fallback, precision allocation, WorkspaceConfig defaults, RefractoryState decay, ignition threshold, refractory boost, post-ignition refractory installation, precision-driven winner selection, ScoreBreakdown arithmetic, backward-compatible signature)
- [x] 241 existing tests pass
- [x] ruff clean
- [x] No store.py changes — defers integration to Phase 2.3 where `ConsciousFrame` ships and tick-cadence is settled

## What this PR does NOT do

- Does NOT switch `recall_divergent` over to the ignition API (Phase 2.3)
- Does NOT persist `WorkspaceSelectionResult` to a `tick_frames` table (Phase 2.3)
- Does NOT add an Action Bottleneck wrapper (Phase 2.3)
- Does NOT add AttentionSchema or HORRecord (Phase 2.4 / 2.5)