### PR TITLE
feat: individual-kernel Phase 2.3 — ConsciousFrame + ActionBottleneck

### DIFF
--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/bottleneck.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/bottleneck.py
@@ -1,0 +1,118 @@
+"""ActionBottleneck — one external action per tick (Phase 2.3).
+
+Critique B finding 1 of the plan-of-record is decisive: LLM verbal output
+must become a first-class gated action, otherwise the unity invariant of
+"one externally visible effect per tick" leaks. The bottleneck enforces
+that on the data layer.
+
+Behavior:
+  - First commit_action() for a tick_id succeeds, installs
+    tick_frames.chosen_action_ref, and returns CommitActionResult(ok=True,
+    deferred=False).
+  - Second (and later) commit_action() calls for the same tick_id are
+    deferred: they return CommitActionResult(ok=False, deferred=True) and
+    write a counterfactuals row with source='attention_lost_bid', keyed by
+    tick_id. The first action's chosen_action_ref is never overwritten.
+  - Internal cognition (recall, hypothesize, reflect_attention_schema,
+    introspect) is intentionally NOT routed through here — the bottleneck
+    only governs externally-visible action. Free internal access stays free.
+
+See consciousness-mcp/AGENTS.md for vocabulary discipline.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+from social_core.db import SocialDB
+
+from individual_kernel_mcp.counterfactual import (
+    CounterfactualInput,
+    CounterfactualStore,
+)
+from individual_kernel_mcp.frame import TickFrameStore
+
+
+class CommitActionResult(BaseModel):
+    """Result of ActionBottleneck.commit_action().
+
+    ok=True, deferred=False  -> action installed as chosen_action_ref
+    ok=False, deferred=True  -> deferred to next tick + counterfactual recorded
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    ok: bool
+    deferred: bool
+    tick_id: str
+    action_ref: str
+    counterfactual_id: str | None = None
+
+
+class ActionBottleneck:
+    """Single-action-per-tick gate over tick_frames.chosen_action_ref."""
+
+    def __init__(
+        self,
+        *,
+        db: SocialDB,
+        frame_store: TickFrameStore,
+        counterfactual_store: CounterfactualStore,
+    ) -> None:
+        self._db = db
+        self._frames = frame_store
+        self._cfs = counterfactual_store
+
+    def commit_action(
+        self,
+        *,
+        tick_id: str,
+        action_ref: str,
+        action_payload: dict | None = None,
+        person_id: str | None = None,
+    ) -> CommitActionResult:
+        row = self._db.fetchone(
+            "SELECT chosen_action_ref FROM tick_frames WHERE tick_id = ?",
+            (tick_id,),
+        )
+        if row is None:
+            raise ValueError(
+                f"tick_frame {tick_id!r} does not exist; "
+                f"record the frame via TickFrameStore before committing an action."
+            )
+
+        existing = row["chosen_action_ref"]
+        if existing is not None and existing != "":
+            # Second (or later) attempt — defer + record counterfactual.
+            cf = self._cfs.record(
+                CounterfactualInput(
+                    tick_id=tick_id,
+                    person_id=person_id,
+                    chosen_action_ref=existing,
+                    rejected_action=action_ref,
+                    rejected_action_payload=action_payload or {},
+                    reason=(
+                        "action bottleneck: another action already committed this tick"
+                    ),
+                    source="attention_lost_bid",
+                    evidence_type="remembered",
+                )
+            )
+            return CommitActionResult(
+                ok=False,
+                deferred=True,
+                tick_id=tick_id,
+                action_ref=action_ref,
+                counterfactual_id=cf.counterfactual_id,
+            )
+
+        # First commit for this tick — install chosen_action_ref.
+        self._db.execute(
+            "UPDATE tick_frames SET chosen_action_ref = ? WHERE tick_id = ?",
+            (action_ref, tick_id),
+        )
+        return CommitActionResult(
+            ok=True,
+            deferred=False,
+            tick_id=tick_id,
+            action_ref=action_ref,
+        )

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/frame.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/frame.py
@@ -1,0 +1,233 @@
+"""ConsciousFrame + TickFrameStore — Phase 2.3 canonical per-tick record.
+
+A ConsciousFrame is the per-tick record of "what was online in the workspace":
+which memories won, which desire was dominant, what the attention target was,
+whether the tick ignited or was subliminal, and what action (if any) was
+committed. Storage-rich, prompt-poor: FKs to existing source tables, no
+payload duplication.
+
+Backs the consciousness architecture's Phase 2.3 from the plan-of-record
+at ~/.claude/plans/jazzy-wishing-starfish.md. The frame's
+winning_memory_ids[] entries are EpistemicClaim-projectable refs (Phase 1
+integration). prediction_error channels {extero, intero, mnemonic} align
+with the Phase 2.2 PrecisionVector mapping.
+
+See consciousness-mcp/AGENTS.md for vocabulary discipline.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+from social_core.db import SocialDB
+from social_core.time import utc_now
+
+Reportability = Literal["mentionable", "background_only", "do_not_surface"]
+
+
+class PredictionErrorChannels(BaseModel):
+    """Per-channel prediction error magnitudes (z-scored or raw).
+
+    Mapping mirrors workspace.py's precision_from_pe_channels:
+      extero  — exteroceptive perception PE
+      intero  — interoceptive (body/desire) PE
+      mnemonic — memory / association PE
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    extero: float = 0.0
+    intero: float = 0.0
+    mnemonic: float = 0.0
+
+
+class ConsciousFrameInput(BaseModel):
+    """Payload for recording a tick frame.
+
+    FK-only by design: winning_memory_ids are refs into memory-mcp,
+    attention_target_ref is a tool/target name, dominant_desire is a
+    desire name, chosen_action_ref is an action-id from the bottleneck.
+    The frame never stores memory payloads or rich state — those live
+    in their source tables and are joined when needed.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    ts: str | None = None
+    person_id: str | None = None
+    ignited: bool = False
+    conflicted: bool = False
+    attention_target_ref: str | None = None
+    dominant_desire: str | None = None
+    winning_memory_ids: list[str] = Field(default_factory=list)
+    prediction_error: PredictionErrorChannels = Field(
+        default_factory=PredictionErrorChannels
+    )
+    affect_summary: str | None = None
+    chosen_action_ref: str | None = None
+    reportability: Reportability = "mentionable"
+
+
+class ConsciousFrame(BaseModel):
+    """Persisted tick frame, returned by TickFrameStore."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    tick_id: str
+    ts: str
+    person_id: str | None = None
+    ignited: bool = False
+    conflicted: bool = False
+    attention_target_ref: str | None = None
+    dominant_desire: str | None = None
+    winning_memory_ids: list[str] = Field(default_factory=list)
+    prediction_error: PredictionErrorChannels = Field(
+        default_factory=PredictionErrorChannels
+    )
+    affect_summary: str | None = None
+    chosen_action_ref: str | None = None
+    reportability: Reportability = "mentionable"
+    created_at: str
+
+
+class TickFrameStore:
+    """SQLite-backed store for ConsciousFrame rows over tick_frames table."""
+
+    def __init__(self, db: SocialDB) -> None:
+        self._db = db
+
+    def record(self, payload: ConsciousFrameInput) -> ConsciousFrame:
+        tick_id = f"tick_{secrets.token_urlsafe(12)}"
+        ts = payload.ts or utc_now()
+        created_at = utc_now()
+        winning_json = json.dumps(payload.winning_memory_ids, ensure_ascii=False)
+        pe_json = json.dumps(
+            payload.prediction_error.model_dump(), ensure_ascii=False
+        )
+
+        self._db.execute(
+            """
+            INSERT INTO tick_frames(
+                tick_id, ts, person_id, ignited, conflicted,
+                attention_target_ref, dominant_desire,
+                winning_memory_ids_json, prediction_error_json,
+                affect_summary, chosen_action_ref, reportability, created_at
+            ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                tick_id,
+                ts,
+                payload.person_id,
+                1 if payload.ignited else 0,
+                1 if payload.conflicted else 0,
+                payload.attention_target_ref,
+                payload.dominant_desire,
+                winning_json,
+                pe_json,
+                payload.affect_summary,
+                payload.chosen_action_ref,
+                payload.reportability,
+                created_at,
+            ),
+        )
+
+        return ConsciousFrame(
+            tick_id=tick_id,
+            ts=ts,
+            person_id=payload.person_id,
+            ignited=payload.ignited,
+            conflicted=payload.conflicted,
+            attention_target_ref=payload.attention_target_ref,
+            dominant_desire=payload.dominant_desire,
+            winning_memory_ids=payload.winning_memory_ids,
+            prediction_error=payload.prediction_error,
+            affect_summary=payload.affect_summary,
+            chosen_action_ref=payload.chosen_action_ref,
+            reportability=payload.reportability,
+            created_at=created_at,
+        )
+
+    def get_by_tick_id(self, tick_id: str) -> ConsciousFrame | None:
+        row = self._db.fetchone(
+            """
+            SELECT tick_id, ts, person_id, ignited, conflicted,
+                   attention_target_ref, dominant_desire,
+                   winning_memory_ids_json, prediction_error_json,
+                   affect_summary, chosen_action_ref, reportability, created_at
+            FROM tick_frames WHERE tick_id = ?
+            """,
+            (tick_id,),
+        )
+        if row is None:
+            return None
+        return self._row_to_frame(row)
+
+    def query(
+        self,
+        *,
+        since: str | None = None,
+        reportability: Reportability | None = None,
+        person_id: str | None = None,
+        ignited_only: bool = False,
+        limit: int = 50,
+    ) -> list[ConsciousFrame]:
+        clauses: list[str] = []
+        params: list[object] = []
+        if since is not None:
+            clauses.append("ts >= ?")
+            params.append(since)
+        if reportability is not None:
+            clauses.append("reportability = ?")
+            params.append(reportability)
+        if person_id is not None:
+            clauses.append("person_id = ?")
+            params.append(person_id)
+        if ignited_only:
+            clauses.append("ignited = 1")
+
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        params.append(limit)
+
+        rows = self._db.fetchall(
+            f"""
+            SELECT tick_id, ts, person_id, ignited, conflicted,
+                   attention_target_ref, dominant_desire,
+                   winning_memory_ids_json, prediction_error_json,
+                   affect_summary, chosen_action_ref, reportability, created_at
+            FROM tick_frames
+            {where}
+            ORDER BY ts DESC, created_at DESC
+            LIMIT ?
+            """,
+            tuple(params),
+        )
+        return [self._row_to_frame(row) for row in rows]
+
+    @staticmethod
+    def _row_to_frame(row) -> ConsciousFrame:
+        try:
+            winning_ids = json.loads(row["winning_memory_ids_json"] or "[]")
+        except json.JSONDecodeError:
+            winning_ids = []
+        try:
+            pe_raw = json.loads(row["prediction_error_json"] or "{}")
+        except json.JSONDecodeError:
+            pe_raw = {}
+        return ConsciousFrame(
+            tick_id=row["tick_id"],
+            ts=row["ts"],
+            person_id=row["person_id"],
+            ignited=bool(row["ignited"]),
+            conflicted=bool(row["conflicted"]),
+            attention_target_ref=row["attention_target_ref"],
+            dominant_desire=row["dominant_desire"],
+            winning_memory_ids=winning_ids,
+            prediction_error=PredictionErrorChannels(**pe_raw),
+            affect_summary=row["affect_summary"],
+            chosen_action_ref=row["chosen_action_ref"],
+            reportability=row["reportability"],
+            created_at=row["created_at"],
+        )

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_bottleneck.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_bottleneck.py
@@ -1,0 +1,173 @@
+"""Tests for ActionBottleneck — one external action per tick (Phase 2.3).
+
+The bottleneck is THE load-bearing piece per critique B finding 1 of the
+plan-of-record: LLM verbal output becomes a first-class gated action,
+side-channeling is closed. Second-action attempts in the same tick_id are
+deferred and recorded as counterfactuals with source='attention_lost_bid'.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from individual_kernel_mcp.bottleneck import (
+    ActionBottleneck,
+    CommitActionResult,
+)
+from individual_kernel_mcp.counterfactual import CounterfactualStore
+from individual_kernel_mcp.frame import (
+    ConsciousFrameInput,
+    TickFrameStore,
+)
+
+
+@pytest.fixture
+def bottleneck(social_db):
+    frames = TickFrameStore(social_db)
+    cfs = CounterfactualStore(social_db)
+    return ActionBottleneck(
+        db=social_db,
+        frame_store=frames,
+        counterfactual_store=cfs,
+    )
+
+
+@pytest.fixture
+def fresh_tick(social_db):
+    frames = TickFrameStore(social_db)
+    frame = frames.record(ConsciousFrameInput(person_id="kouta", ignited=True))
+    return frame.tick_id
+
+
+class TestFirstCommit:
+    def test_first_commit_succeeds(self, bottleneck, fresh_tick) -> None:
+        result = bottleneck.commit_action(
+            tick_id=fresh_tick, action_ref="say_hello"
+        )
+        assert isinstance(result, CommitActionResult)
+        assert result.ok is True
+        assert result.deferred is False
+        assert result.tick_id == fresh_tick
+        assert result.action_ref == "say_hello"
+        assert result.counterfactual_id is None
+
+    def test_first_commit_persists_chosen_action_ref(
+        self, bottleneck, fresh_tick, social_db
+    ) -> None:
+        bottleneck.commit_action(tick_id=fresh_tick, action_ref="say_hello")
+        row = social_db.fetchone(
+            "SELECT chosen_action_ref FROM tick_frames WHERE tick_id = ?",
+            (fresh_tick,),
+        )
+        assert row["chosen_action_ref"] == "say_hello"
+
+
+class TestSecondCommit:
+    def test_second_commit_is_deferred(self, bottleneck, fresh_tick) -> None:
+        bottleneck.commit_action(tick_id=fresh_tick, action_ref="first_action")
+        result = bottleneck.commit_action(
+            tick_id=fresh_tick, action_ref="second_action"
+        )
+        assert result.ok is False
+        assert result.deferred is True
+        assert result.action_ref == "second_action"
+        assert result.counterfactual_id is not None
+
+    def test_second_commit_writes_counterfactual(
+        self, bottleneck, fresh_tick, social_db
+    ) -> None:
+        bottleneck.commit_action(tick_id=fresh_tick, action_ref="first_action")
+        bottleneck.commit_action(tick_id=fresh_tick, action_ref="second_action")
+        row = social_db.fetchone(
+            "SELECT * FROM counterfactuals WHERE tick_id = ? AND rejected_action = ?",
+            (fresh_tick, "second_action"),
+        )
+        assert row is not None
+        assert row["source"] == "attention_lost_bid"
+        assert row["evidence_type"] == "remembered"
+        assert row["chosen_action_ref"] == "first_action"
+
+    def test_second_commit_does_not_overwrite_chosen_action(
+        self, bottleneck, fresh_tick, social_db
+    ) -> None:
+        bottleneck.commit_action(tick_id=fresh_tick, action_ref="first_action")
+        bottleneck.commit_action(tick_id=fresh_tick, action_ref="second_action")
+        row = social_db.fetchone(
+            "SELECT chosen_action_ref FROM tick_frames WHERE tick_id = ?",
+            (fresh_tick,),
+        )
+        assert row["chosen_action_ref"] == "first_action"
+
+    def test_third_commit_also_deferred(
+        self, bottleneck, fresh_tick, social_db
+    ) -> None:
+        bottleneck.commit_action(tick_id=fresh_tick, action_ref="first")
+        r2 = bottleneck.commit_action(tick_id=fresh_tick, action_ref="second")
+        r3 = bottleneck.commit_action(tick_id=fresh_tick, action_ref="third")
+        assert r2.deferred is True
+        assert r3.deferred is True
+        # Both deferred actions get distinct counterfactual ids.
+        assert r2.counterfactual_id != r3.counterfactual_id
+        deferred_cfs = social_db.fetchall(
+            "SELECT rejected_action FROM counterfactuals WHERE tick_id = ?",
+            (fresh_tick,),
+        )
+        assert {row["rejected_action"] for row in deferred_cfs} == {
+            "second",
+            "third",
+        }
+
+
+class TestPayload:
+    def test_action_payload_persisted_in_counterfactual(
+        self, bottleneck, fresh_tick, social_db
+    ) -> None:
+        bottleneck.commit_action(tick_id=fresh_tick, action_ref="first")
+        bottleneck.commit_action(
+            tick_id=fresh_tick,
+            action_ref="second",
+            action_payload={"channel": "tts", "text": "hey"},
+        )
+        row = social_db.fetchone(
+            "SELECT rejected_action_payload_json FROM counterfactuals WHERE tick_id = ?",
+            (fresh_tick,),
+        )
+        assert '"channel"' in row["rejected_action_payload_json"]
+
+    def test_person_id_propagated_to_counterfactual(
+        self, bottleneck, fresh_tick, social_db
+    ) -> None:
+        bottleneck.commit_action(tick_id=fresh_tick, action_ref="first")
+        bottleneck.commit_action(
+            tick_id=fresh_tick,
+            action_ref="second",
+            person_id="kouta",
+        )
+        row = social_db.fetchone(
+            "SELECT person_id FROM counterfactuals WHERE tick_id = ?",
+            (fresh_tick,),
+        )
+        assert row["person_id"] == "kouta"
+
+
+class TestErrors:
+    def test_commit_to_nonexistent_tick_raises(self, bottleneck) -> None:
+        with pytest.raises(ValueError, match="does not exist"):
+            bottleneck.commit_action(
+                tick_id="tick_nonexistent_xyz", action_ref="say_hello"
+            )
+
+
+class TestIsolation:
+    def test_separate_ticks_do_not_interfere(self, social_db, bottleneck) -> None:
+        frames = TickFrameStore(social_db)
+        tick_a = frames.record(ConsciousFrameInput()).tick_id
+        tick_b = frames.record(ConsciousFrameInput()).tick_id
+
+        result_a = bottleneck.commit_action(tick_id=tick_a, action_ref="action_a")
+        result_b = bottleneck.commit_action(tick_id=tick_b, action_ref="action_b")
+
+        assert result_a.ok is True
+        assert result_b.ok is True
+        assert result_a.deferred is False
+        assert result_b.deferred is False

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_frame.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_frame.py
@@ -1,0 +1,213 @@
+"""Tests for ConsciousFrame + TickFrameStore (Phase 2.3).
+
+The frame is the canonical per-tick record of "what was online" in the
+workspace. It stores FKs and tags — payloads stay in their source tables.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from individual_kernel_mcp.frame import (
+    ConsciousFrame,
+    ConsciousFrameInput,
+    PredictionErrorChannels,
+    TickFrameStore,
+)
+
+
+def _minimal_input(**overrides) -> ConsciousFrameInput:
+    base = dict(
+        attention_target_ref="wifi_cam.see",
+        ignited=True,
+    )
+    base.update(overrides)
+    return ConsciousFrameInput(**base)
+
+
+class TestConsciousFrameInput:
+    def test_defaults(self) -> None:
+        payload = ConsciousFrameInput()
+        assert payload.ignited is False
+        assert payload.conflicted is False
+        assert payload.winning_memory_ids == []
+        assert payload.attention_target_ref is None
+        assert payload.dominant_desire is None
+        assert payload.reportability == "mentionable"
+
+    def test_rejects_extra_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            ConsciousFrameInput(unknown_field="oops")  # type: ignore[call-arg]
+
+    def test_rejects_unknown_reportability(self) -> None:
+        with pytest.raises(ValidationError):
+            ConsciousFrameInput(reportability="public")  # type: ignore[arg-type]
+
+    def test_reportability_values(self) -> None:
+        for r in ("mentionable", "background_only", "do_not_surface"):
+            p = ConsciousFrameInput(reportability=r)
+            assert p.reportability == r
+
+    def test_prediction_error_channels_default_zero(self) -> None:
+        payload = ConsciousFrameInput()
+        assert payload.prediction_error.extero == 0.0
+        assert payload.prediction_error.intero == 0.0
+        assert payload.prediction_error.mnemonic == 0.0
+
+    def test_prediction_error_rejects_extra_channels(self) -> None:
+        with pytest.raises(ValidationError):
+            PredictionErrorChannels(extero=0.5, weird_channel=1.0)  # type: ignore[call-arg]
+
+
+class TestRecord:
+    def test_record_assigns_tick_id(self, social_db) -> None:
+        store = TickFrameStore(social_db)
+        frame = store.record(_minimal_input())
+        assert frame.tick_id.startswith("tick_")
+
+    def test_record_persists_basic_fields(self, social_db) -> None:
+        store = TickFrameStore(social_db)
+        frame = store.record(
+            _minimal_input(
+                person_id="kouta",
+                dominant_desire="browse_curiosity",
+                affect_summary="calm focus",
+            )
+        )
+        row = social_db.fetchone(
+            "SELECT * FROM tick_frames WHERE tick_id = ?",
+            (frame.tick_id,),
+        )
+        assert row is not None
+        assert row["person_id"] == "kouta"
+        assert row["dominant_desire"] == "browse_curiosity"
+        assert row["affect_summary"] == "calm focus"
+        assert row["ignited"] == 1
+
+    def test_winning_memory_ids_serialized_as_json(self, social_db) -> None:
+        store = TickFrameStore(social_db)
+        store.record(
+            _minimal_input(winning_memory_ids=["mem_001", "mem_002", "mem_003"])
+        )
+        row = social_db.fetchone(
+            "SELECT winning_memory_ids_json FROM tick_frames LIMIT 1"
+        )
+        assert row is not None
+        assert "mem_001" in row["winning_memory_ids_json"]
+        assert "mem_003" in row["winning_memory_ids_json"]
+
+    def test_prediction_error_channels_serialized(self, social_db) -> None:
+        store = TickFrameStore(social_db)
+        store.record(
+            _minimal_input(
+                prediction_error=PredictionErrorChannels(
+                    extero=0.7, intero=0.2, mnemonic=0.4
+                )
+            )
+        )
+        row = social_db.fetchone(
+            "SELECT prediction_error_json FROM tick_frames LIMIT 1"
+        )
+        assert row is not None
+        assert "extero" in row["prediction_error_json"]
+
+    def test_conflicted_flag_persists(self, social_db) -> None:
+        store = TickFrameStore(social_db)
+        store.record(_minimal_input(conflicted=True))
+        row = social_db.fetchone("SELECT conflicted FROM tick_frames LIMIT 1")
+        assert row["conflicted"] == 1
+
+    def test_subliminal_tick_record(self, social_db) -> None:
+        """An ignited=False frame (subliminal tick) is still a recordable event."""
+        store = TickFrameStore(social_db)
+        frame = store.record(
+            ConsciousFrameInput(ignited=False, reportability="background_only")
+        )
+        assert frame.ignited is False
+        row = social_db.fetchone("SELECT * FROM tick_frames WHERE tick_id = ?", (frame.tick_id,))
+        assert row["ignited"] == 0
+
+
+class TestGetByTickId:
+    def test_returns_frame_when_found(self, social_db) -> None:
+        store = TickFrameStore(social_db)
+        recorded = store.record(
+            _minimal_input(winning_memory_ids=["mem_a", "mem_b"])
+        )
+        fetched = store.get_by_tick_id(recorded.tick_id)
+        assert fetched is not None
+        assert isinstance(fetched, ConsciousFrame)
+        assert fetched.tick_id == recorded.tick_id
+        assert fetched.winning_memory_ids == ["mem_a", "mem_b"]
+
+    def test_returns_none_when_not_found(self, social_db) -> None:
+        store = TickFrameStore(social_db)
+        assert store.get_by_tick_id("nonexistent_tick") is None
+
+    def test_round_trip_prediction_error(self, social_db) -> None:
+        store = TickFrameStore(social_db)
+        recorded = store.record(
+            _minimal_input(
+                prediction_error=PredictionErrorChannels(
+                    extero=0.7, intero=0.2, mnemonic=0.4
+                )
+            )
+        )
+        fetched = store.get_by_tick_id(recorded.tick_id)
+        assert fetched is not None
+        assert fetched.prediction_error.extero == pytest.approx(0.7)
+        assert fetched.prediction_error.intero == pytest.approx(0.2)
+        assert fetched.prediction_error.mnemonic == pytest.approx(0.4)
+
+
+class TestQuery:
+    def test_returns_most_recent_first(self, social_db) -> None:
+        store = TickFrameStore(social_db)
+        store.record(_minimal_input(ts="2026-06-13T00:00:00Z"))
+        store.record(_minimal_input(ts="2026-06-13T02:00:00Z"))
+        store.record(_minimal_input(ts="2026-06-13T01:00:00Z"))
+        results = store.query()
+        assert len(results) == 3
+        assert results[0].ts == "2026-06-13T02:00:00Z"
+        assert results[2].ts == "2026-06-13T00:00:00Z"
+
+    def test_filters_by_reportability(self, social_db) -> None:
+        store = TickFrameStore(social_db)
+        store.record(_minimal_input(reportability="mentionable"))
+        store.record(_minimal_input(reportability="background_only"))
+        store.record(_minimal_input(reportability="do_not_surface"))
+        results = store.query(reportability="do_not_surface")
+        assert len(results) == 1
+        assert results[0].reportability == "do_not_surface"
+
+    def test_ignited_only(self, social_db) -> None:
+        store = TickFrameStore(social_db)
+        store.record(_minimal_input(ignited=True))
+        store.record(ConsciousFrameInput(ignited=False))
+        store.record(_minimal_input(ignited=True))
+        results = store.query(ignited_only=True)
+        assert len(results) == 2
+        assert all(r.ignited for r in results)
+
+    def test_filters_by_person_id(self, social_db) -> None:
+        store = TickFrameStore(social_db)
+        store.record(_minimal_input(person_id="kouta"))
+        store.record(_minimal_input(person_id="someone_else"))
+        results = store.query(person_id="kouta")
+        assert len(results) == 1
+        assert results[0].person_id == "kouta"
+
+    def test_since_filter(self, social_db) -> None:
+        store = TickFrameStore(social_db)
+        store.record(_minimal_input(ts="2026-06-10T00:00:00Z"))
+        store.record(_minimal_input(ts="2026-06-12T00:00:00Z"))
+        results = store.query(since="2026-06-11T00:00:00Z")
+        assert len(results) == 1
+
+    def test_limit(self, social_db) -> None:
+        store = TickFrameStore(social_db)
+        for i in range(5):
+            store.record(_minimal_input(ts=f"2026-06-{10 + i:02d}T00:00:00Z"))
+        results = store.query(limit=2)
+        assert len(results) == 2

--- a/sociality-mcp/packages/social-core/src/social_core/migrations.py
+++ b/sociality-mcp/packages/social-core/src/social_core/migrations.py
@@ -95,6 +95,32 @@ CREATE INDEX IF NOT EXISTS idx_private_letters_person_ts
 """
 
 
+_MIGRATION_004_SQL = """
+CREATE TABLE IF NOT EXISTS tick_frames (
+    tick_id TEXT PRIMARY KEY,
+    ts TEXT NOT NULL,
+    person_id TEXT,
+    ignited INTEGER NOT NULL DEFAULT 0,
+    conflicted INTEGER NOT NULL DEFAULT 0,
+    attention_target_ref TEXT,
+    dominant_desire TEXT,
+    winning_memory_ids_json TEXT NOT NULL DEFAULT '[]',
+    prediction_error_json TEXT NOT NULL DEFAULT '{}',
+    affect_summary TEXT,
+    chosen_action_ref TEXT,
+    reportability TEXT NOT NULL DEFAULT 'mentionable',
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_tick_frames_ts
+    ON tick_frames(ts DESC, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_tick_frames_reportability
+    ON tick_frames(reportability, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_tick_frames_person
+    ON tick_frames(person_id, ts DESC);
+"""
+
+
 _MIGRATION_003_SQL = """
 CREATE TABLE IF NOT EXISTS counterfactuals (
     counterfactual_id TEXT PRIMARY KEY,
@@ -325,6 +351,10 @@ MIGRATIONS = [
     Migration(
         name="003_counterfactuals",
         sql=_MIGRATION_003_SQL,
+    ),
+    Migration(
+        name="004_tick_frames",
+        sql=_MIGRATION_004_SQL,
     ),
 ]
 

--- a/sociality-mcp/packages/social-core/tests/test_tick_frames_migration.py
+++ b/sociality-mcp/packages/social-core/tests/test_tick_frames_migration.py
@@ -1,0 +1,151 @@
+"""Tests for migration 004 — tick_frames table.
+
+tick_frames is the canonical per-tick record of "what was online" in the
+workspace. It stores FKs (memory ids, desire name, agent_state_summary_id,
+action ref) — not payloads — so the table stays storage-rich, prompt-poor.
+
+Backs Phase 2.3's TickFrameStore in consciousness-mcp/packages/
+individual-kernel-mcp.
+"""
+
+from __future__ import annotations
+
+from social_core.db import SocialDB
+from social_core.migrations import MIGRATIONS
+
+
+def test_tick_frames_table_created(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    tables = {
+        row["name"]
+        for row in db.fetchall("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert "tick_frames" in tables
+
+
+def test_tick_frames_columns(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    columns = {
+        row["name"] for row in db.fetchall("PRAGMA table_info(tick_frames)")
+    }
+    expected = {
+        "tick_id",
+        "ts",
+        "person_id",
+        "ignited",
+        "conflicted",
+        "attention_target_ref",
+        "dominant_desire",
+        "winning_memory_ids_json",
+        "prediction_error_json",
+        "affect_summary",
+        "chosen_action_ref",
+        "reportability",
+        "created_at",
+    }
+    assert expected <= columns, f"missing: {expected - columns}"
+
+
+def test_tick_frames_indexes(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    indexes = {
+        row["name"]
+        for row in db.fetchall(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='tick_frames'"
+        )
+    }
+    assert "idx_tick_frames_ts" in indexes
+    assert "idx_tick_frames_reportability" in indexes
+    assert "idx_tick_frames_person" in indexes
+
+
+def test_migration_004_registered(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    applied = {row["name"] for row in db.fetchall("SELECT name FROM schema_migrations")}
+    assert "004_tick_frames" in applied
+    assert len(applied) == len(MIGRATIONS)
+
+
+def test_tick_id_is_primary_key(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    rows = db.fetchall("PRAGMA table_info(tick_frames)")
+    pk_columns = [row["name"] for row in rows if row["pk"] > 0]
+    assert pk_columns == ["tick_id"]
+
+
+def test_tick_frames_insert_round_trip(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    db.execute(
+        """
+        INSERT INTO tick_frames(
+            tick_id, ts, person_id, ignited, conflicted,
+            attention_target_ref, dominant_desire,
+            winning_memory_ids_json, prediction_error_json,
+            affect_summary, chosen_action_ref, reportability, created_at
+        ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "tick_test_001",
+            "2026-06-13T03:00:00Z",
+            "kouta",
+            1,
+            0,
+            "wifi_cam.see",
+            "browse_curiosity",
+            '["mem_001", "mem_002"]',
+            '{"extero": 0.7, "intero": 0.2, "mnemonic": 0.4}',
+            "calm focus",
+            "act_001",
+            "mentionable",
+            "2026-06-13T03:00:00Z",
+        ),
+    )
+    row = db.fetchone(
+        "SELECT * FROM tick_frames WHERE tick_id = ?",
+        ("tick_test_001",),
+    )
+    assert row is not None
+    assert row["person_id"] == "kouta"
+    assert row["ignited"] == 1
+    assert row["dominant_desire"] == "browse_curiosity"
+    assert row["reportability"] == "mentionable"
+    assert "mem_001" in row["winning_memory_ids_json"]
+
+
+def test_tick_id_unique(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    db.execute(
+        """
+        INSERT INTO tick_frames(
+            tick_id, ts, ignited, conflicted, reportability, created_at
+        ) VALUES(?, ?, ?, ?, ?, ?)
+        """,
+        ("tick_dupe", "2026-06-13T03:00:00Z", 1, 0, "mentionable", "2026-06-13T03:00:00Z"),
+    )
+    import sqlite3
+
+    import pytest
+
+    with pytest.raises(sqlite3.IntegrityError):
+        db.execute(
+            """
+            INSERT INTO tick_frames(
+                tick_id, ts, ignited, conflicted, reportability, created_at
+            ) VALUES(?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "tick_dupe",
+                "2026-06-13T04:00:00Z",
+                1,
+                0,
+                "mentionable",
+                "2026-06-13T04:00:00Z",
+            ),
+        )


### PR DESCRIPTION
## Summary

Phase 2.3 of the consciousness architecture from [the plan-of-record](https://github.com/lifemate-ai/embodied-claude/blob/main/.claude/plans/jazzy-wishing-starfish.md). Builds on Phase 2.1 (#93 counterfactuals) + Phase 2.2 (#94 workspace ignition).

Two new modules in \`individual-kernel-mcp\` plus a social-core migration.

### What's new

| Module | Surface |
|---|---|
| \`social_core/migrations.py\` | migration 004 — \`tick_frames\` table |
| \`individual_kernel_mcp/frame.py\` | \`ConsciousFrame\`, \`ConsciousFrameInput\`, \`PredictionErrorChannels\`, \`TickFrameStore\` |
| \`individual_kernel_mcp/bottleneck.py\` | \`ActionBottleneck\`, \`CommitActionResult\` |

### Why this matters (critique B finding 1, the load-bearing piece)

The plan rejected GPT-5.5's multi-agent parliament because the unity locus must stay at "single LLM forward pass conditioned on CLAUDE.md". But that only holds if **every** externally-visible action — including verbal output — goes through one gate. Before this PR, \`plan_response\` could emit a primary_move, the LLM could speak, and a separate cron tick could ALSO emit something through TTS. The data layer had no record that "one tick = one external effect".

\`ActionBottleneck.commit_action()\` is that gate. Second + later attempts in the same \`tick_id\` are **deferred** and recorded as counterfactuals with source='attention_lost_bid' (the existing Phase 2.1 source, no new vocabulary). Internal cognition (recall, hypothesize, future introspect) is intentionally NOT routed through here — free internal access stays free.

### Phase integration

- **Phase 1**: \`winning_memory_ids[]\` entries are memory ids that round-trip naturally through \`EpistemicClaim\`
- **Phase 2.1**: deferred actions write to the existing \`counterfactuals\` table — no new source value
- **Phase 2.2**: \`PredictionErrorChannels {extero, intero, mnemonic}\` matches \`precision_from_pe_channels\`. \`ConsciousFrame.ignited\` flag aligns 1:1 with \`WorkspaceSelectionResult.ignited\`.

### Test plan

- [x] **31 new tests** (21 frame + 10 bottleneck)
- [x] **82 total individual-kernel-mcp tests pass** (was 51)
- [x] **34 total social-core tests pass** (was 27, +7 for migration 004)
- [x] ruff clean both packages
- [x] FK-only design verified: no payloads duplicated
- [x] Subliminal tick recordable (\`ignited=False\` + \`reportability='background_only'\`)
- [x] \`chosen_action_ref\` never overwritten by deferred attempts
- [x] Distinct counterfactual id per deferred attempt
- [x] Tick isolation: separate tick_ids do not interfere

### What this PR does NOT do (deferred)

- Does NOT expose \`TickFrameStore\` / \`ActionBottleneck\` via MCP tools yet — \`server.py\` extension waits until the full Phase 2.4/2.5 tool surface (introspect, reflect_attention_schema) is settled
- Does NOT wire \`recall_divergent\` to Phase 2.2's ignition API — Phase 2.3's frame data shape had to land first
- Does NOT implement \`AttentionSchema\` (Phase 2.4) or \`HORRecord\` / \`introspect()\` (Phase 2.5)