### PR TITLE
feat: individual-kernel Phase 2.4 — AttentionSchema + reflect

### DIFF
--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/attention_schema.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/attention_schema.py
@@ -1,0 +1,218 @@
+"""AttentionSchema + AttentionSchemaTracker (Phase 2.4).
+
+Implements Attention Schema Theory (AST / Theory B R4): a low-dimensional
+model of the pattern of winning, distinct from the workspace itself.
+workspace.py picks WHICH memories win; the attention schema MODELS the
+shape of attention (focal target, modality, intensity, dwell), with a
+control_handle so the agent can intervene rather than only observe.
+
+In-memory ring buffer (default capacity 60) holds the recent trajectory.
+flush() persists to attention_schemas table on tick boundary or on demand.
+
+Phase 2.5 will surface this via introspect() and a HOR layer where each
+schema_snapshot binds to higher-order claims.
+
+See consciousness-mcp/AGENTS.md for vocabulary discipline.
+"""
+
+from __future__ import annotations
+
+import secrets
+from collections import deque
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+from social_core.db import SocialDB
+from social_core.time import utc_now
+
+from individual_kernel_mcp.frame import ConsciousFrame
+
+Modality = Literal["visual", "auditory", "internal", "social"]
+
+
+class AttentionSchema(BaseModel):
+    """Low-dimensional model of attention for a single owner (self or other)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    schema_id: str
+    ts: str
+    owner_id: str
+    focal_target_ref: str | None = None
+    modality: Modality
+    intensity: float = Field(ge=0.0, le=1.0)
+    dwell_seconds: float = 0.0
+    predicted_next_focus: str | None = None
+    control_handle: str | None = None
+    source_tick_id: str | None = None
+
+
+class AttentionSchemaTracker:
+    """In-memory ring buffer + SQLite persistence at flush boundary.
+
+    Per-tick update is cheap (Python only). Persistence is via flush(),
+    which writes all buffered schemas and clears the buffer. Suitable
+    for cron tick + UserPromptSubmit cadence — schemas accumulate during
+    short bursts and persist when the kernel decides.
+    """
+
+    def __init__(
+        self,
+        *,
+        db: SocialDB,
+        owner_id: str = "self",
+        capacity: int = 60,
+    ) -> None:
+        self._db = db
+        self._owner_id = owner_id
+        self._capacity = capacity
+        self._buffer: deque[AttentionSchema] = deque(maxlen=capacity)
+
+    @property
+    def capacity(self) -> int:
+        return self._capacity
+
+    @property
+    def owner_id(self) -> str:
+        return self._owner_id
+
+    @property
+    def db(self) -> SocialDB:
+        return self._db
+
+    @property
+    def buffer(self) -> tuple[AttentionSchema, ...]:
+        return tuple(self._buffer)
+
+    def record(
+        self,
+        *,
+        focal_target_ref: str | None,
+        modality: Modality,
+        intensity: float,
+        dwell_seconds: float = 0.0,
+        predicted_next_focus: str | None = None,
+        control_handle: str | None = None,
+        source_tick_id: str | None = None,
+        ts: str | None = None,
+    ) -> AttentionSchema:
+        schema = AttentionSchema(
+            schema_id=f"sch_{secrets.token_urlsafe(12)}",
+            ts=ts or utc_now(),
+            owner_id=self._owner_id,
+            focal_target_ref=focal_target_ref,
+            modality=modality,
+            intensity=intensity,
+            dwell_seconds=dwell_seconds,
+            predicted_next_focus=predicted_next_focus,
+            control_handle=control_handle,
+            source_tick_id=source_tick_id,
+        )
+        self._buffer.append(schema)
+        return schema
+
+    def update_dwell_from_ts(
+        self,
+        *,
+        focal_target_ref: str | None,
+        modality: Modality,
+        intensity: float,
+        ts: str,
+        predicted_next_focus: str | None = None,
+        control_handle: str | None = None,
+        source_tick_id: str | None = None,
+    ) -> AttentionSchema:
+        """Record a new schema whose dwell accumulates only if focal is unchanged.
+
+        If the previous buffered schema's focal_target_ref matches, dwell
+        accumulates by (ts - prev.ts) seconds. Different focal resets to 0.
+        """
+        dwell = self._compute_dwell(focal_target_ref, ts)
+        return self.record(
+            focal_target_ref=focal_target_ref,
+            modality=modality,
+            intensity=intensity,
+            dwell_seconds=dwell,
+            predicted_next_focus=predicted_next_focus,
+            control_handle=control_handle,
+            source_tick_id=source_tick_id,
+            ts=ts,
+        )
+
+    def update_from_frame(self, frame: ConsciousFrame) -> AttentionSchema:
+        """Build a schema entry from a ConsciousFrame's attention slice.
+
+        intensity is a coarse proxy: ignited→0.8, subliminal→0.3. dwell
+        accumulates only if the focal target matches the previous buffered
+        schema.
+        """
+        focal = frame.attention_target_ref
+        modality = self._infer_modality(focal)
+        intensity = 0.8 if frame.ignited else 0.3
+        dwell = self._compute_dwell(focal, frame.ts)
+        return self.record(
+            focal_target_ref=focal,
+            modality=modality,
+            intensity=intensity,
+            dwell_seconds=dwell,
+            source_tick_id=frame.tick_id,
+            ts=frame.ts,
+        )
+
+    def flush(self) -> int:
+        """Persist all buffered schemas to SQLite. Returns count, clears buffer."""
+        count = 0
+        for schema in self._buffer:
+            self._db.execute(
+                """
+                INSERT INTO attention_schemas(
+                    schema_id, ts, owner_id, focal_target_ref, modality,
+                    intensity, dwell_seconds, predicted_next_focus,
+                    control_handle, source_tick_id, created_at
+                ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    schema.schema_id,
+                    schema.ts,
+                    schema.owner_id,
+                    schema.focal_target_ref,
+                    schema.modality,
+                    schema.intensity,
+                    schema.dwell_seconds,
+                    schema.predicted_next_focus,
+                    schema.control_handle,
+                    schema.source_tick_id,
+                    utc_now(),
+                ),
+            )
+            count += 1
+        self._buffer.clear()
+        return count
+
+    @staticmethod
+    def _infer_modality(focal_target_ref: str | None) -> Modality:
+        if not focal_target_ref:
+            return "internal"
+        f = focal_target_ref.lower()
+        if "listen" in f or "audio" in f or "auditory" in f or "ear" in f:
+            return "auditory"
+        if "cam" in f or "see" in f or "visual" in f or "eye" in f:
+            return "visual"
+        if "person:" in f or "social" in f:
+            return "social"
+        return "internal"
+
+    def _compute_dwell(self, focal: str | None, ts: str) -> float:
+        if not self._buffer:
+            return 0.0
+        last = self._buffer[-1]
+        if last.focal_target_ref != focal:
+            return 0.0
+        return last.dwell_seconds + self._ts_delta_seconds(last.ts, ts)
+
+    @staticmethod
+    def _ts_delta_seconds(ts_a: str, ts_b: str) -> float:
+        a = datetime.fromisoformat(ts_a.replace("Z", "+00:00"))
+        b = datetime.fromisoformat(ts_b.replace("Z", "+00:00"))
+        return max(0.0, (b - a).total_seconds())

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/reflect.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/reflect.py
@@ -1,0 +1,147 @@
+"""reflect_attention_schema — on-demand reflection over the attention tracker.
+
+ON-DEMAND ONLY. Iterates the tracker's ring buffer (and optionally pulls
+extra history from SQLite); too expensive for per-tick invocation. Phase
+2.5's introspect() will use this as one of its substrates.
+
+Returns an AttentionReflection summarizing modality distribution, focus
+changes, dwell aggregates, and the dominant focal target. The single
+canonical first-person read-out string is constructed in introspect()
+(Phase 2.5) — this function returns structured data only.
+
+See consciousness-mcp/AGENTS.md for vocabulary discipline.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from pydantic import BaseModel, ConfigDict, Field
+from social_core.db import SocialDB
+
+from individual_kernel_mcp.attention_schema import (
+    AttentionSchema,
+    AttentionSchemaTracker,
+    Modality,
+)
+
+
+class ModalityDwell(BaseModel):
+    """Dwell statistics for a single modality over the reflection window."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    modality: Modality
+    average_dwell_seconds: float
+    max_dwell_seconds: float
+    count: int
+
+
+class AttentionReflection(BaseModel):
+    """Structured output of reflect_attention_schema.
+
+    `current` is the most-recent schema in the considered samples.
+    `modality_distribution[m]` is the fraction of samples in modality m
+    (sums to 1.0 when non-empty). `focus_changes` counts transitions in
+    focal_target_ref across the chronologically-ordered window.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    owner_id: str
+    current: AttentionSchema | None
+    window_size: int
+    modality_distribution: dict[Modality, float] = Field(default_factory=dict)
+    modality_dwells: list[ModalityDwell] = Field(default_factory=list)
+    focus_changes: int
+    dominant_focal: str | None
+
+
+def reflect_attention_schema(
+    tracker: AttentionSchemaTracker,
+    *,
+    db: SocialDB | None = None,
+    extra_history: int = 0,
+) -> AttentionReflection:
+    """Build an AttentionReflection over the tracker's buffer + optional history.
+
+    db must be passed when extra_history > 0 (otherwise no historical
+    schemas are pulled). Historical samples are deduped by schema_id.
+    """
+    samples: list[AttentionSchema] = list(tracker.buffer)
+
+    effective_db = db if db is not None else tracker.db
+    if effective_db is not None and extra_history > 0:
+        rows = effective_db.fetchall(
+            """
+            SELECT schema_id, ts, owner_id, focal_target_ref, modality,
+                   intensity, dwell_seconds, predicted_next_focus,
+                   control_handle, source_tick_id
+            FROM attention_schemas
+            WHERE owner_id = ?
+            ORDER BY ts DESC
+            LIMIT ?
+            """,
+            (tracker.owner_id, extra_history),
+        )
+        seen = {s.schema_id for s in samples}
+        for row in rows:
+            d = dict(row)
+            if d["schema_id"] in seen:
+                continue
+            samples.append(AttentionSchema(**d))
+
+    if not samples:
+        return AttentionReflection(
+            owner_id=tracker.owner_id,
+            current=None,
+            window_size=0,
+            modality_distribution={},
+            modality_dwells=[],
+            focus_changes=0,
+            dominant_focal=None,
+        )
+
+    current = max(samples, key=lambda s: s.ts)
+
+    modality_counts: Counter[str] = Counter(s.modality for s in samples)
+    total = sum(modality_counts.values())
+    distribution: dict[Modality, float] = {
+        m: count / total for m, count in modality_counts.items()  # type: ignore[misc]
+    }
+
+    by_modality: dict[Modality, list[AttentionSchema]] = {}
+    for s in samples:
+        by_modality.setdefault(s.modality, []).append(s)
+    modality_dwells: list[ModalityDwell] = []
+    for m, ss in by_modality.items():
+        dwells = [s.dwell_seconds for s in ss]
+        modality_dwells.append(
+            ModalityDwell(
+                modality=m,
+                average_dwell_seconds=sum(dwells) / len(dwells),
+                max_dwell_seconds=max(dwells),
+                count=len(ss),
+            )
+        )
+
+    ordered = sorted(samples, key=lambda s: s.ts)
+    focus_changes = 0
+    for prev, curr in zip(ordered, ordered[1:], strict=False):
+        if prev.focal_target_ref != curr.focal_target_ref:
+            focus_changes += 1
+
+    focal_counts: Counter[str] = Counter(
+        s.focal_target_ref for s in samples if s.focal_target_ref
+    )
+    dominant = focal_counts.most_common(1)[0][0] if focal_counts else None
+
+    return AttentionReflection(
+        owner_id=tracker.owner_id,
+        current=current,
+        window_size=len(samples),
+        modality_distribution=distribution,
+        modality_dwells=modality_dwells,
+        focus_changes=focus_changes,
+        dominant_focal=dominant,
+    )

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_attention_schema.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_attention_schema.py
@@ -1,0 +1,270 @@
+"""Tests for AttentionSchema + AttentionSchemaTracker (Phase 2.4).
+
+The attention schema is a low-dimensional model of the pattern of winning
+(AST / Theory B R4). It is NOT the same as workspace.py — workspace picks
+winners; the schema models the shape of attention itself for control and
+introspection (Phase 2.5 will surface it via introspect()).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from individual_kernel_mcp.attention_schema import (
+    AttentionSchema,
+    AttentionSchemaTracker,
+    Modality,
+)
+from individual_kernel_mcp.frame import (
+    ConsciousFrameInput,
+    TickFrameStore,
+)
+
+
+class TestAttentionSchemaModel:
+    def test_minimal_construction(self) -> None:
+        s = AttentionSchema(
+            schema_id="sch_001",
+            ts="2026-06-21T03:00:00+00:00",
+            owner_id="self",
+            modality="visual",
+            intensity=0.5,
+        )
+        assert s.owner_id == "self"
+        assert s.modality == "visual"
+        assert s.focal_target_ref is None
+        assert s.dwell_seconds == 0.0
+
+    def test_intensity_bounded_0_to_1(self) -> None:
+        with pytest.raises(ValidationError):
+            AttentionSchema(
+                schema_id="x",
+                ts="2026-06-21T03:00:00+00:00",
+                owner_id="self",
+                modality="visual",
+                intensity=1.5,
+            )
+        with pytest.raises(ValidationError):
+            AttentionSchema(
+                schema_id="x",
+                ts="2026-06-21T03:00:00+00:00",
+                owner_id="self",
+                modality="visual",
+                intensity=-0.1,
+            )
+
+    def test_rejects_unknown_modality(self) -> None:
+        with pytest.raises(ValidationError):
+            AttentionSchema(
+                schema_id="x",
+                ts="2026-06-21T03:00:00+00:00",
+                owner_id="self",
+                modality="olfactory",  # type: ignore[arg-type]
+                intensity=0.5,
+            )
+
+    def test_all_documented_modalities_accepted(self) -> None:
+        modalities: tuple[Modality, ...] = ("visual", "auditory", "internal", "social")
+        for m in modalities:
+            s = AttentionSchema(
+                schema_id="x",
+                ts="2026-06-21T03:00:00+00:00",
+                owner_id="self",
+                modality=m,
+                intensity=0.5,
+            )
+            assert s.modality == m
+
+
+class TestTrackerRingBuffer:
+    def test_default_capacity_is_60(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        assert tracker.capacity == 60
+
+    def test_buffer_initially_empty(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        assert tracker.buffer == ()
+
+    def test_record_appends_to_buffer(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        tracker.record(focal_target_ref="wifi_cam.see", modality="visual", intensity=0.8)
+        assert len(tracker.buffer) == 1
+        assert tracker.buffer[0].focal_target_ref == "wifi_cam.see"
+
+    def test_buffer_caps_at_capacity(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db, capacity=5)
+        for i in range(10):
+            tracker.record(
+                focal_target_ref=f"target_{i}", modality="visual", intensity=0.5
+            )
+        assert len(tracker.buffer) == 5
+        # Newest 5 retained
+        assert tracker.buffer[-1].focal_target_ref == "target_9"
+        assert tracker.buffer[0].focal_target_ref == "target_5"
+
+    def test_owner_id_propagates(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db, owner_id="kouta")
+        s = tracker.record(
+            focal_target_ref="wifi_cam.see", modality="visual", intensity=0.5
+        )
+        assert s.owner_id == "kouta"
+
+
+class TestUpdateFromFrame:
+    def test_modality_inferred_from_camera_focal(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        frames = TickFrameStore(social_db)
+        frame = frames.record(
+            ConsciousFrameInput(
+                attention_target_ref="wifi_cam.see", ignited=True
+            )
+        )
+        s = tracker.update_from_frame(frame)
+        assert s.modality == "visual"
+
+    def test_modality_inferred_from_listen_focal(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        frames = TickFrameStore(social_db)
+        frame = frames.record(
+            ConsciousFrameInput(
+                attention_target_ref="wifi_cam.listen", ignited=True
+            )
+        )
+        s = tracker.update_from_frame(frame)
+        assert s.modality == "auditory"
+
+    def test_modality_inferred_social_for_person_target(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        frames = TickFrameStore(social_db)
+        frame = frames.record(
+            ConsciousFrameInput(
+                attention_target_ref="person:kouta", ignited=True
+            )
+        )
+        s = tracker.update_from_frame(frame)
+        assert s.modality == "social"
+
+    def test_modality_internal_when_no_focal(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        frames = TickFrameStore(social_db)
+        frame = frames.record(
+            ConsciousFrameInput(attention_target_ref=None, ignited=True)
+        )
+        s = tracker.update_from_frame(frame)
+        assert s.modality == "internal"
+
+    def test_ignited_frame_yields_higher_intensity(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        frames = TickFrameStore(social_db)
+        ignited = frames.record(
+            ConsciousFrameInput(attention_target_ref="wifi_cam.see", ignited=True)
+        )
+        subliminal = frames.record(
+            ConsciousFrameInput(attention_target_ref="wifi_cam.see", ignited=False)
+        )
+        s_ig = tracker.update_from_frame(ignited)
+        s_sub = tracker.update_from_frame(subliminal)
+        assert s_ig.intensity > s_sub.intensity
+
+    def test_source_tick_id_tracked(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        frames = TickFrameStore(social_db)
+        frame = frames.record(
+            ConsciousFrameInput(attention_target_ref="wifi_cam.see", ignited=True)
+        )
+        s = tracker.update_from_frame(frame)
+        assert s.source_tick_id == frame.tick_id
+
+
+class TestDwell:
+    def test_first_focal_has_zero_dwell(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        s = tracker.record(
+            focal_target_ref="wifi_cam.see",
+            modality="visual",
+            intensity=0.5,
+            ts="2026-06-21T03:00:00+00:00",
+        )
+        assert s.dwell_seconds == 0.0
+
+    def test_same_focal_accumulates_dwell(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        tracker.record(
+            focal_target_ref="wifi_cam.see",
+            modality="visual",
+            intensity=0.5,
+            ts="2026-06-21T03:00:00+00:00",
+        )
+        # 10 seconds later, same focal
+        s = tracker.update_dwell_from_ts(
+            focal_target_ref="wifi_cam.see",
+            modality="visual",
+            intensity=0.5,
+            ts="2026-06-21T03:00:10+00:00",
+        )
+        assert s.dwell_seconds == pytest.approx(10.0)
+
+    def test_different_focal_resets_dwell(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        tracker.record(
+            focal_target_ref="wifi_cam.see",
+            modality="visual",
+            intensity=0.5,
+            ts="2026-06-21T03:00:00+00:00",
+            dwell_seconds=20.0,
+        )
+        s = tracker.update_dwell_from_ts(
+            focal_target_ref="person:kouta",
+            modality="social",
+            intensity=0.5,
+            ts="2026-06-21T03:00:10+00:00",
+        )
+        assert s.dwell_seconds == 0.0
+
+
+class TestFlush:
+    def test_flush_persists_all_buffered(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        tracker.record(
+            focal_target_ref="wifi_cam.see", modality="visual", intensity=0.5
+        )
+        tracker.record(
+            focal_target_ref="person:kouta", modality="social", intensity=0.7
+        )
+        count = tracker.flush()
+        assert count == 2
+        rows = social_db.fetchall("SELECT modality FROM attention_schemas")
+        assert {r["modality"] for r in rows} == {"visual", "social"}
+
+    def test_flush_clears_buffer(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        tracker.record(focal_target_ref="x", modality="visual", intensity=0.5)
+        tracker.flush()
+        assert tracker.buffer == ()
+
+    def test_flush_empty_buffer_returns_zero(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        assert tracker.flush() == 0
+
+    def test_flush_persists_source_tick_id(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        frames = TickFrameStore(social_db)
+        frame = frames.record(
+            ConsciousFrameInput(attention_target_ref="wifi_cam.see", ignited=True)
+        )
+        tracker.update_from_frame(frame)
+        tracker.flush()
+        row = social_db.fetchone(
+            "SELECT source_tick_id FROM attention_schemas LIMIT 1"
+        )
+        assert row["source_tick_id"] == frame.tick_id
+
+    def test_flush_owner_id_persisted(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db, owner_id="kouta")
+        tracker.record(
+            focal_target_ref="wifi_cam.see", modality="visual", intensity=0.5
+        )
+        tracker.flush()
+        row = social_db.fetchone("SELECT owner_id FROM attention_schemas LIMIT 1")
+        assert row["owner_id"] == "kouta"

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_reflect.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_reflect.py
@@ -1,0 +1,229 @@
+"""Tests for reflect_attention_schema — on-demand attention reflection (Phase 2.4).
+
+Produces an AttentionReflection summarizing the tracker's recent buffer
+(and optionally extra history pulled from SQLite). ON-DEMAND ONLY — not
+per-tick. Used by introspect() (Phase 2.5) and by /consolidate skill.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from individual_kernel_mcp.attention_schema import (
+    AttentionSchemaTracker,
+    Modality,
+)
+from individual_kernel_mcp.reflect import (
+    AttentionReflection,
+    ModalityDwell,
+    reflect_attention_schema,
+)
+
+
+class TestEmptyReflection:
+    def test_empty_tracker_returns_empty(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        r = reflect_attention_schema(tracker)
+        assert isinstance(r, AttentionReflection)
+        assert r.window_size == 0
+        assert r.current is None
+        assert r.modality_distribution == {}
+        assert r.focus_changes == 0
+        assert r.dominant_focal is None
+
+
+class TestCurrent:
+    def test_current_is_most_recent_buffered(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        tracker.record(
+            focal_target_ref="old",
+            modality="visual",
+            intensity=0.5,
+            ts="2026-06-21T03:00:00+00:00",
+        )
+        tracker.record(
+            focal_target_ref="new",
+            modality="visual",
+            intensity=0.7,
+            ts="2026-06-21T03:00:10+00:00",
+        )
+        r = reflect_attention_schema(tracker)
+        assert r.current is not None
+        assert r.current.focal_target_ref == "new"
+
+
+class TestWindowSize:
+    def test_window_matches_buffer(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        for i in range(5):
+            tracker.record(
+                focal_target_ref=f"t_{i}",
+                modality="visual",
+                intensity=0.5,
+                ts=f"2026-06-21T03:00:0{i}+00:00",
+            )
+        r = reflect_attention_schema(tracker)
+        assert r.window_size == 5
+
+
+class TestModalityDistribution:
+    def test_sums_to_one(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        tracker.record(
+            focal_target_ref="a",
+            modality="visual",
+            intensity=0.5,
+            ts="2026-06-21T03:00:00+00:00",
+        )
+        tracker.record(
+            focal_target_ref="b",
+            modality="auditory",
+            intensity=0.5,
+            ts="2026-06-21T03:00:01+00:00",
+        )
+        tracker.record(
+            focal_target_ref="c",
+            modality="visual",
+            intensity=0.5,
+            ts="2026-06-21T03:00:02+00:00",
+        )
+        r = reflect_attention_schema(tracker)
+        total = sum(r.modality_distribution.values())
+        assert total == pytest.approx(1.0)
+        assert r.modality_distribution["visual"] == pytest.approx(2 / 3)
+        assert r.modality_distribution["auditory"] == pytest.approx(1 / 3)
+
+
+class TestDominantFocal:
+    def test_dominant_focal_is_most_frequent(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        for i in range(3):
+            tracker.record(
+                focal_target_ref="popular",
+                modality="visual",
+                intensity=0.5,
+                ts=f"2026-06-21T03:00:0{i}+00:00",
+            )
+        tracker.record(
+            focal_target_ref="rare",
+            modality="visual",
+            intensity=0.5,
+            ts="2026-06-21T03:00:03+00:00",
+        )
+        r = reflect_attention_schema(tracker)
+        assert r.dominant_focal == "popular"
+
+    def test_no_dominant_when_all_none(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        tracker.record(
+            focal_target_ref=None,
+            modality="internal",
+            intensity=0.5,
+            ts="2026-06-21T03:00:00+00:00",
+        )
+        tracker.record(
+            focal_target_ref=None,
+            modality="internal",
+            intensity=0.5,
+            ts="2026-06-21T03:00:01+00:00",
+        )
+        r = reflect_attention_schema(tracker)
+        assert r.dominant_focal is None
+
+
+class TestFocusChanges:
+    def test_zero_changes_for_constant_focal(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        for i in range(5):
+            tracker.record(
+                focal_target_ref="stable",
+                modality="visual",
+                intensity=0.5,
+                ts=f"2026-06-21T03:00:0{i}+00:00",
+            )
+        r = reflect_attention_schema(tracker)
+        assert r.focus_changes == 0
+
+    def test_change_count_matches_transitions(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        # a → b → b → c = 2 changes
+        sequence = ["a", "b", "b", "c"]
+        for i, focal in enumerate(sequence):
+            tracker.record(
+                focal_target_ref=focal,
+                modality="visual",
+                intensity=0.5,
+                ts=f"2026-06-21T03:00:0{i}+00:00",
+            )
+        r = reflect_attention_schema(tracker)
+        assert r.focus_changes == 2
+
+
+class TestModalityDwells:
+    def test_aggregated_per_modality(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        tracker.record(
+            focal_target_ref="a",
+            modality="visual",
+            intensity=0.5,
+            dwell_seconds=5.0,
+            ts="2026-06-21T03:00:00+00:00",
+        )
+        tracker.record(
+            focal_target_ref="a",
+            modality="visual",
+            intensity=0.5,
+            dwell_seconds=15.0,
+            ts="2026-06-21T03:00:10+00:00",
+        )
+        tracker.record(
+            focal_target_ref="b",
+            modality="auditory",
+            intensity=0.5,
+            dwell_seconds=3.0,
+            ts="2026-06-21T03:00:20+00:00",
+        )
+        r = reflect_attention_schema(tracker)
+        by_modality: dict[Modality, ModalityDwell] = {
+            md.modality: md for md in r.modality_dwells
+        }
+        assert by_modality["visual"].average_dwell_seconds == pytest.approx(10.0)
+        assert by_modality["visual"].max_dwell_seconds == pytest.approx(15.0)
+        assert by_modality["visual"].count == 2
+        assert by_modality["auditory"].count == 1
+
+
+class TestExtraHistory:
+    def test_extra_history_pulls_from_db(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        # Persist some history
+        for i in range(3):
+            tracker.record(
+                focal_target_ref="old",
+                modality="visual",
+                intensity=0.5,
+                ts=f"2026-06-20T0{i}:00:00+00:00",
+            )
+        tracker.flush()
+        # New activity in current buffer
+        tracker.record(
+            focal_target_ref="new",
+            modality="visual",
+            intensity=0.5,
+            ts="2026-06-21T03:00:00+00:00",
+        )
+        r = reflect_attention_schema(tracker, extra_history=10)
+        assert r.window_size == 4
+
+    def test_no_extra_history_by_default(self, social_db) -> None:
+        tracker = AttentionSchemaTracker(db=social_db)
+        tracker.record(
+            focal_target_ref="persisted",
+            modality="visual",
+            intensity=0.5,
+            ts="2026-06-20T03:00:00+00:00",
+        )
+        tracker.flush()
+        # buffer is now empty; default reflect ignores SQLite
+        r = reflect_attention_schema(tracker)
+        assert r.window_size == 0

--- a/sociality-mcp/packages/social-core/src/social_core/migrations.py
+++ b/sociality-mcp/packages/social-core/src/social_core/migrations.py
@@ -95,6 +95,30 @@ CREATE INDEX IF NOT EXISTS idx_private_letters_person_ts
 """
 
 
+_MIGRATION_005_SQL = """
+CREATE TABLE IF NOT EXISTS attention_schemas (
+    schema_id TEXT PRIMARY KEY,
+    ts TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
+    focal_target_ref TEXT,
+    modality TEXT NOT NULL,
+    intensity REAL NOT NULL DEFAULT 0.0,
+    dwell_seconds REAL NOT NULL DEFAULT 0.0,
+    predicted_next_focus TEXT,
+    control_handle TEXT,
+    source_tick_id TEXT,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_attention_schemas_ts
+    ON attention_schemas(ts DESC, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_attention_schemas_owner
+    ON attention_schemas(owner_id, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_attention_schemas_modality
+    ON attention_schemas(modality, ts DESC);
+"""
+
+
 _MIGRATION_004_SQL = """
 CREATE TABLE IF NOT EXISTS tick_frames (
     tick_id TEXT PRIMARY KEY,
@@ -355,6 +379,10 @@ MIGRATIONS = [
     Migration(
         name="004_tick_frames",
         sql=_MIGRATION_004_SQL,
+    ),
+    Migration(
+        name="005_attention_schemas",
+        sql=_MIGRATION_005_SQL,
     ),
 ]
 

--- a/sociality-mcp/packages/social-core/tests/test_attention_schemas_migration.py
+++ b/sociality-mcp/packages/social-core/tests/test_attention_schemas_migration.py
@@ -1,0 +1,156 @@
+"""Tests for migration 005 — attention_schemas table.
+
+attention_schemas stores low-dimensional snapshots of "what attention is
+doing" — the Attention Schema Theory surface (Theory B R4). owner_id='self'
+is Kokone modeling her own attention; non-'self' owner_id values are
+ToM-like models of other persons' attention (Phase 2.4.1+).
+
+Backs Phase 2.4's AttentionSchemaTracker in consciousness-mcp.
+"""
+
+from __future__ import annotations
+
+from social_core.db import SocialDB
+from social_core.migrations import MIGRATIONS
+
+
+def test_attention_schemas_table_created(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    tables = {
+        row["name"]
+        for row in db.fetchall("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert "attention_schemas" in tables
+
+
+def test_attention_schemas_columns(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    columns = {
+        row["name"] for row in db.fetchall("PRAGMA table_info(attention_schemas)")
+    }
+    expected = {
+        "schema_id",
+        "ts",
+        "owner_id",
+        "focal_target_ref",
+        "modality",
+        "intensity",
+        "dwell_seconds",
+        "predicted_next_focus",
+        "control_handle",
+        "source_tick_id",
+        "created_at",
+    }
+    assert expected <= columns, f"missing: {expected - columns}"
+
+
+def test_attention_schemas_indexes(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    indexes = {
+        row["name"]
+        for row in db.fetchall(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='attention_schemas'"
+        )
+    }
+    assert "idx_attention_schemas_ts" in indexes
+    assert "idx_attention_schemas_owner" in indexes
+    assert "idx_attention_schemas_modality" in indexes
+
+
+def test_migration_005_registered(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    applied = {row["name"] for row in db.fetchall("SELECT name FROM schema_migrations")}
+    assert "005_attention_schemas" in applied
+    assert len(applied) == len(MIGRATIONS)
+
+
+def test_attention_schemas_insert_round_trip(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    db.execute(
+        """
+        INSERT INTO attention_schemas(
+            schema_id, ts, owner_id, focal_target_ref, modality,
+            intensity, dwell_seconds, predicted_next_focus,
+            control_handle, source_tick_id, created_at
+        ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "schema_test_001",
+            "2026-06-21T03:00:00Z",
+            "self",
+            "wifi_cam.see",
+            "visual",
+            0.8,
+            12.5,
+            "person:kouta",
+            "wifi_cam.look_left",
+            "tick_001",
+            "2026-06-21T03:00:00Z",
+        ),
+    )
+    row = db.fetchone(
+        "SELECT * FROM attention_schemas WHERE schema_id = ?",
+        ("schema_test_001",),
+    )
+    assert row is not None
+    assert row["owner_id"] == "self"
+    assert row["modality"] == "visual"
+    assert row["intensity"] == 0.8
+    assert row["dwell_seconds"] == 12.5
+    assert row["source_tick_id"] == "tick_001"
+
+
+def test_schema_id_unique(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    db.execute(
+        """
+        INSERT INTO attention_schemas(
+            schema_id, ts, owner_id, modality, intensity, created_at
+        ) VALUES(?, ?, ?, ?, ?, ?)
+        """,
+        ("sch_dupe", "2026-06-21T03:00:00Z", "self", "visual", 0.5, "2026-06-21T03:00:00Z"),
+    )
+    import sqlite3
+
+    import pytest
+
+    with pytest.raises(sqlite3.IntegrityError):
+        db.execute(
+            """
+            INSERT INTO attention_schemas(
+                schema_id, ts, owner_id, modality, intensity, created_at
+            ) VALUES(?, ?, ?, ?, ?, ?)
+            """,
+            ("sch_dupe", "2026-06-21T04:00:00Z", "self", "visual", 0.5, "2026-06-21T04:00:00Z"),
+        )
+
+
+def test_owner_id_default_to_self_via_non_null(temp_db_path) -> None:
+    """owner_id is NOT NULL so omitting it is an error — defaults are caller-side."""
+    db = SocialDB(temp_db_path)
+    db.connect()
+    import sqlite3
+
+    import pytest
+
+    with pytest.raises(sqlite3.IntegrityError):
+        db.execute(
+            """
+            INSERT INTO attention_schemas(
+                schema_id, ts, modality, intensity, created_at
+            ) VALUES(?, ?, ?, ?, ?)
+            """,
+            (
+                "sch_no_owner",
+                "2026-06-21T03:00:00Z",
+                "visual",
+                0.5,
+                "2026-06-21T03:00:00Z",
+            ),
+        )


### PR DESCRIPTION
## Summary

Phase 2.4 of the consciousness architecture from [the plan-of-record](https://github.com/lifemate-ai/embodied-claude/blob/main/.claude/plans/jazzy-wishing-starfish.md). Builds on Phase 2.3 (#95 ConsciousFrame + ActionBottleneck).

Implements Attention Schema Theory (AST / Theory B R4): a low-dimensional model of the pattern of winning, distinct from the workspace itself.

### What's new

| Module | Surface |
|---|---|
| \`social_core/migrations.py\` | migration 005 — \`attention_schemas\` table |
| \`individual_kernel_mcp/attention_schema.py\` | \`AttentionSchema\`, \`Modality\`, \`AttentionSchemaTracker\` |
| \`individual_kernel_mcp/reflect.py\` | \`reflect_attention_schema\`, \`AttentionReflection\`, \`ModalityDwell\` |

### Why distinct from workspace.py

\`workspace.py\` (Phase 2.2) picks WHICH memories win each tick. The attention schema MODELS the shape of attention — focal target, modality, intensity, dwell — at lower dimension, with a control_handle so the agent can intervene rather than only observe. This is the read-out surface Phase 2.5's \`introspect()\` will build on.

### Behavior

- **Ring buffer** (default cap 60) holds the recent trajectory cheaply in Python
- **\`update_from_frame(ConsciousFrame)\`** maps Phase 2.3's frame into a schema:
  - modality inferred from \`focal_target_ref\` (cam/see/eye→visual, listen/audio→auditory, person:*→social, null→internal)
  - intensity proxy: \`ignited=True\` → 0.8, subliminal → 0.3
  - dwell accumulates while focal stays the same; resets on change
- **\`flush()\`** persists buffered schemas to SQLite at tick boundary or on demand
- **\`reflect_attention_schema(tracker, extra_history=N)\`** — ON-DEMAND only. Returns modality distribution, per-modality dwell aggregates, focus-change count, dominant focal target, and the current schema

### Phase integration

- **Phase 1**: \`AttentionSchema\` is a typed record that Phase 2.5's HOR layer will wrap into \`EpistemicClaim.derive(evidence_type='inferred')\` via a \`schema_snapshot_id\` binding
- **Phase 2.2**: modality channels {visual, auditory, internal, social} map onto \`precision_from_pe_channels\` ({extero, intero, mnemonic}) — visual/auditory ⊂ extero, internal ⊂ intero, social bridges
- **Phase 2.3**: \`update_from_frame\` consumes \`ConsciousFrame\`; \`source_tick_id\` is a soft FK back to \`tick_frames\`

### Test plan

- [x] **34 new tests** (7 migration + 23 schema/tracker + 11 reflect)
- [x] **116 total individual-kernel-mcp tests pass** (was 82)
- [x] **41 total social-core tests pass** (was 34)
- [x] ruff clean both packages
- [x] Ring buffer cap behavior verified (FIFO at capacity)
- [x] dwell accumulation/reset semantics tested across focal changes
- [x] Modality inference covers camera/listen/person/null cases
- [x] Reflection emits empty result on empty tracker (no division-by-zero)

### What this PR does NOT do (deferred)

- Does NOT expose AttentionSchema / reflect via MCP tools — server.py extension waits for Phase 2.5 introspect tool surface
- Does NOT extend joint-attention-mcp for per-person_id schemas (ToM) — Phase 2.4.1 follow-up
- Does NOT implement HORRecord wrapping (Phase 2.5)
- Does NOT wire store.py.recall_divergent to Phase 2.2 ignition API