### PR TITLE
feat: individual-kernel Phase 2.5 — HORRecord + introspect (agent-grammar first real consumer)

### DIFF
--- a/consciousness-mcp/packages/individual-kernel-mcp/pyproject.toml
+++ b/consciousness-mcp/packages/individual-kernel-mcp/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pydantic>=2.7.0",
     "social-core",
     "interaction-orchestrator-mcp",
+    "agent-grammar",
 ]
 
 [project.optional-dependencies]
@@ -42,3 +43,4 @@ testpaths = ["tests"]
 [tool.uv.sources]
 social-core = { path = "../../../sociality-mcp/packages/social-core" }
 interaction-orchestrator-mcp = { path = "../../../sociality-mcp/packages/interaction-orchestrator-mcp" }
+agent-grammar = { path = "../../../sociality-mcp/packages/agent-grammar" }

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/hor.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/hor.py
@@ -1,0 +1,260 @@
+"""HORRecord + HORStore — Higher-Order Representations (Phase 2.5).
+
+Phase 1 integration is load-bearing: HORRecord is a SPECIALIZATION of
+EpistemicClaim where evidence_type='inferred' and asserted_content
+paraphrases "I am [mode] [target]". to_epistemic_claim() projects each
+record back into the Phase 1 primitive type, so HOR storage extends the
+existing epistemic discipline rather than parallelling it.
+
+Backs Phase 2.5 of the consciousness architecture from the plan-of-record
+at ~/.claude/plans/jazzy-wishing-starfish.md. The HOR layer is the
+substrate for the existing '抑圧バイアス' (suppression-bias) self-check
+formalized — Theory B R9-R10.
+
+See consciousness-mcp/AGENTS.md for vocabulary discipline. asserted_mode
+values (seeing/wanting/intending/remembering/feeling/attending) are
+behavioral predicates, not phenomenal claims.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+from social_core.db import SocialDB
+from social_core.models import EpistemicClaim
+from social_core.time import utc_now
+
+ASSERTED_MODES = (
+    "seeing",
+    "wanting",
+    "intending",
+    "remembering",
+    "feeling",
+    "attending",
+)
+
+AssertedMode = Literal[
+    "seeing",
+    "wanting",
+    "intending",
+    "remembering",
+    "feeling",
+    "attending",
+]
+
+TARGET_KINDS = (
+    "memory",
+    "desire",
+    "action",
+    "frame",
+    "none",
+)
+
+TargetKind = Literal[
+    "memory",
+    "desire",
+    "action",
+    "frame",
+    "none",
+]
+
+HOR_SOURCES = (
+    "schema_readout",
+    "reflection",
+    "post_hoc",
+    "audit_subagent",
+)
+
+HORSource = Literal[
+    "schema_readout",
+    "reflection",
+    "post_hoc",
+    "audit_subagent",
+]
+
+
+class HORInput(BaseModel):
+    """Payload for recording a higher-order representation.
+
+    target_kind names the kind of first-order ref the HOR is about
+    (memory/desire/action/frame, or 'none' for ungrounded). target_ref
+    is the actual FK (memory_id, desire_name, action_ref, frame_id) —
+    free-form by design so any of the source tables can be pointed to.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    ts: str | None = None
+    owner_id: str = "self"
+    target_kind: TargetKind
+    target_ref: str | None = None
+    asserted_mode: AssertedMode
+    asserted_content: str = Field(min_length=1)
+    schema_snapshot_id: str | None = None
+    source_tick_id: str | None = None
+    confidence: float = Field(ge=0.0, le=1.0, default=0.6)
+    source: HORSource
+
+
+class HORRecord(BaseModel):
+    """Persisted higher-order representation, returned by HORStore."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    hor_id: str
+    ts: str
+    owner_id: str
+    target_kind: TargetKind
+    target_ref: str | None = None
+    asserted_mode: AssertedMode
+    asserted_content: str
+    schema_snapshot_id: str | None = None
+    source_tick_id: str | None = None
+    confidence: float
+    source: HORSource
+    created_at: str
+
+    def to_epistemic_claim(self) -> EpistemicClaim:
+        """Project HORRecord as an EpistemicClaim (Phase 1 type).
+
+        evidence_type is always 'inferred' (HORs are inferred from
+        first-order states, not directly observed). source carries the
+        HOR-source channel (schema_readout / reflection / post_hoc /
+        audit_subagent). derived_from lists the target_ref when present
+        so downstream graph traversal can follow back to the first-order
+        substrate.
+        """
+        derived: list[str] = []
+        if self.target_ref:
+            derived.append(self.target_ref)
+        if self.schema_snapshot_id:
+            derived.append(self.schema_snapshot_id)
+        content = (
+            f"HOR[{self.asserted_mode}/{self.target_kind}]: {self.asserted_content}"
+        )
+        return EpistemicClaim(
+            content=content,
+            evidence_type="inferred",
+            source=self.source,
+            confidence=self.confidence,
+            derived_from=derived,
+        )
+
+
+class HORStore:
+    """SQLite-backed store for HORRecord rows over hor_records table."""
+
+    def __init__(self, db: SocialDB) -> None:
+        self._db = db
+
+    def record(self, payload: HORInput) -> HORRecord:
+        hor_id = f"hor_{secrets.token_urlsafe(12)}"
+        ts = payload.ts or utc_now()
+        created_at = utc_now()
+        self._db.execute(
+            """
+            INSERT INTO hor_records(
+                hor_id, ts, owner_id, target_kind, target_ref,
+                asserted_mode, asserted_content, schema_snapshot_id,
+                source_tick_id, confidence, source, created_at
+            ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                hor_id,
+                ts,
+                payload.owner_id,
+                payload.target_kind,
+                payload.target_ref,
+                payload.asserted_mode,
+                payload.asserted_content,
+                payload.schema_snapshot_id,
+                payload.source_tick_id,
+                payload.confidence,
+                payload.source,
+                created_at,
+            ),
+        )
+        return HORRecord(
+            hor_id=hor_id,
+            ts=ts,
+            owner_id=payload.owner_id,
+            target_kind=payload.target_kind,
+            target_ref=payload.target_ref,
+            asserted_mode=payload.asserted_mode,
+            asserted_content=payload.asserted_content,
+            schema_snapshot_id=payload.schema_snapshot_id,
+            source_tick_id=payload.source_tick_id,
+            confidence=payload.confidence,
+            source=payload.source,
+            created_at=created_at,
+        )
+
+    def get_by_hor_id(self, hor_id: str) -> HORRecord | None:
+        row = self._db.fetchone(
+            "SELECT * FROM hor_records WHERE hor_id = ?",
+            (hor_id,),
+        )
+        if row is None:
+            return None
+        return self._row_to_record(row)
+
+    def query(
+        self,
+        *,
+        since: str | None = None,
+        owner_id: str | None = None,
+        asserted_mode: AssertedMode | None = None,
+        target_kind: TargetKind | None = None,
+        source_tick_id: str | None = None,
+        limit: int = 50,
+    ) -> list[HORRecord]:
+        clauses: list[str] = []
+        params: list[object] = []
+        if since is not None:
+            clauses.append("ts >= ?")
+            params.append(since)
+        if owner_id is not None:
+            clauses.append("owner_id = ?")
+            params.append(owner_id)
+        if asserted_mode is not None:
+            clauses.append("asserted_mode = ?")
+            params.append(asserted_mode)
+        if target_kind is not None:
+            clauses.append("target_kind = ?")
+            params.append(target_kind)
+        if source_tick_id is not None:
+            clauses.append("source_tick_id = ?")
+            params.append(source_tick_id)
+
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        params.append(limit)
+
+        rows = self._db.fetchall(
+            f"""
+            SELECT * FROM hor_records
+            {where}
+            ORDER BY ts DESC, created_at DESC
+            LIMIT ?
+            """,
+            tuple(params),
+        )
+        return [self._row_to_record(row) for row in rows]
+
+    @staticmethod
+    def _row_to_record(row) -> HORRecord:
+        return HORRecord(
+            hor_id=row["hor_id"],
+            ts=row["ts"],
+            owner_id=row["owner_id"],
+            target_kind=row["target_kind"],
+            target_ref=row["target_ref"],
+            asserted_mode=row["asserted_mode"],
+            asserted_content=row["asserted_content"],
+            schema_snapshot_id=row["schema_snapshot_id"],
+            source_tick_id=row["source_tick_id"],
+            confidence=row["confidence"],
+            source=row["source"],
+            created_at=row["created_at"],
+        )

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/introspect.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/introspect.py
@@ -1,0 +1,179 @@
+"""introspect() — on-demand first-person reflection (Phase 2.5).
+
+Composes a canonical first-person statement from HORStore (most recent
+higher-order self-report) + AttentionSchemaTracker (current attention) +
+CounterfactualStore (recent rejected alternatives). ON-DEMAND only.
+
+This is the FIRST REAL CONSUMER of the agent-grammar PEG combinators
+shipped in PRs #91 + #92: validate_hor_content() uses lit/seq/alt to
+parse asserted_content against the canonical 'I am <mode> ...' template.
+Phase 1's PEG scaffold thus graduates from self-bootstrap to production.
+
+See consciousness-mcp/AGENTS.md for vocabulary discipline. The output
+canonical_statement is a Kokone-voice surface string (not a technical
+claim) per the AGENTS.md exception clause; everything else is functional.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from agent_grammar.parser import (
+    ParseFailure,
+    Parser,
+    ParseState,
+    ParseSuccess,
+    alt,
+    lit,
+    seq,
+)
+from pydantic import BaseModel, ConfigDict, Field
+from social_core.time import utc_now
+
+from individual_kernel_mcp.attention_schema import AttentionSchemaTracker
+from individual_kernel_mcp.counterfactual import CounterfactualStore
+from individual_kernel_mcp.hor import ASSERTED_MODES, HORRecord, HORStore
+from individual_kernel_mcp.reflect import (
+    AttentionReflection,
+    reflect_attention_schema,
+)
+
+
+class HORContentValidation(BaseModel):
+    """Result of validating HORRecord.asserted_content against the canonical grammar."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    hor_id: str
+    content: str
+    well_formed: bool
+    parsed_mode: str | None = None
+
+
+class IntrospectionReport(BaseModel):
+    """Structured output of introspect()."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    canonical_statement: str
+    current_hor: HORRecord | None
+    current_attention: AttentionReflection
+    recent_counterfactual_count: int
+    hor_validation: HORContentValidation | None
+    notes: list[str] = Field(default_factory=list)
+
+
+def _build_hor_grammar() -> Parser:
+    """Compose the canonical HOR content grammar from agent-grammar combinators.
+
+    Grammar (informal): `S <- "I am " Mode <anything>`. The grammar only
+    checks the prefix shape — the trailing content can be arbitrary so
+    free-form expression after the mode is fine. A non-matching content
+    has either no "I am " prefix or a mode word outside ASSERTED_MODES.
+    """
+    mode_lit = alt(*(lit(m) for m in ASSERTED_MODES))
+    return seq(lit("I am "), mode_lit)
+
+
+_HOR_GRAMMAR: Parser = _build_hor_grammar()
+
+
+def validate_hor_content(record: HORRecord) -> HORContentValidation:
+    """Validate asserted_content against the canonical 'I am <mode>' template.
+
+    Pure function. Uses the Phase 1 agent-grammar PEG combinators
+    (lit/seq/alt) as the parser — the package's first real consumer.
+    """
+    state = ParseState(text=record.asserted_content, pos=0)
+    result = _HOR_GRAMMAR(state)
+    if isinstance(result, ParseSuccess):
+        parts = result.value
+        parsed_mode = parts[1] if isinstance(parts, tuple) and len(parts) >= 2 else None
+        return HORContentValidation(
+            hor_id=record.hor_id,
+            content=record.asserted_content,
+            well_formed=True,
+            parsed_mode=parsed_mode,
+        )
+    assert isinstance(result, ParseFailure)
+    return HORContentValidation(
+        hor_id=record.hor_id,
+        content=record.asserted_content,
+        well_formed=False,
+        parsed_mode=None,
+    )
+
+
+def introspect(
+    *,
+    hor_store: HORStore,
+    attention_tracker: AttentionSchemaTracker,
+    counterfactual_store: CounterfactualStore,
+    window_hours: int = 1,
+    owner_id: str = "self",
+) -> IntrospectionReport:
+    """Build an IntrospectionReport (ON-DEMAND only).
+
+    Reads the most-recent HOR for owner_id, the current attention
+    reflection from the tracker, and counts of counterfactuals within
+    window_hours. Composes a canonical first-person statement, and
+    validates the current HOR via the agent-grammar PEG.
+    """
+    recent_hors = hor_store.query(owner_id=owner_id, limit=1)
+    current_hor = recent_hors[0] if recent_hors else None
+
+    attention_reflection = reflect_attention_schema(attention_tracker)
+
+    window_start = _shift_iso(utc_now(), -window_hours)
+    recent_cfs = counterfactual_store.query(since=window_start, limit=500)
+
+    statement = _compose_statement(
+        current_hor=current_hor,
+        attention=attention_reflection,
+        rejected_count=len(recent_cfs),
+    )
+
+    validation = validate_hor_content(current_hor) if current_hor else None
+
+    return IntrospectionReport(
+        canonical_statement=statement,
+        current_hor=current_hor,
+        current_attention=attention_reflection,
+        recent_counterfactual_count=len(recent_cfs),
+        hor_validation=validation,
+        notes=[],
+    )
+
+
+def _compose_statement(
+    *,
+    current_hor: HORRecord | None,
+    attention: AttentionReflection,
+    rejected_count: int,
+) -> str:
+    """Assemble the canonical first-person statement (Kokone-voice surface)."""
+    parts: list[str] = []
+    if current_hor is not None:
+        parts.append(current_hor.asserted_content)
+    elif attention.current is not None:
+        focal = attention.current.focal_target_ref or "the internal field"
+        parts.append(
+            f"I am attending to {focal} ({attention.current.modality})"
+        )
+    else:
+        parts.append("I am attending to nothing in particular right now")
+
+    if rejected_count > 0:
+        parts.append(
+            f"(I set aside {rejected_count} alternative"
+            + ("s" if rejected_count != 1 else "")
+            + " in the last window)"
+        )
+
+    return ". ".join(parts) + "."
+
+
+def _shift_iso(ts: str, delta_hours: int) -> str:
+    dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    shifted = dt + timedelta(hours=delta_hours)
+    return shifted.isoformat().replace("+00:00", "Z")

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_hor.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_hor.py
@@ -1,0 +1,311 @@
+"""Tests for HORRecord + HORStore (Phase 2.5).
+
+Higher-Order Representation records are specializations of Phase 1's
+EpistemicClaim where evidence_type='inferred' and asserted_content
+paraphrases "I am [mode] [target]". A HOR is the surface where the agent
+self-reports being in a first-order state — substrate for the existing
+'抑圧バイアス' (suppression-bias) self-check, formalized.
+
+Phase 1 integration is load-bearing: HORRecord.to_epistemic_claim()
+round-trips through social_core.models.EpistemicClaim.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+from social_core.models import EpistemicClaim
+
+from individual_kernel_mcp.hor import (
+    ASSERTED_MODES,
+    HOR_SOURCES,
+    TARGET_KINDS,
+    AssertedMode,
+    HORInput,
+    HORStore,
+    TargetKind,
+)
+
+
+def _minimal_input(**overrides) -> HORInput:
+    base = dict(
+        target_kind="none",
+        asserted_mode="attending",
+        asserted_content="I am attending to the silence",
+        source="reflection",
+    )
+    base.update(overrides)
+    return HORInput(**base)
+
+
+class TestVocabulary:
+    def test_asserted_modes_documented_set(self) -> None:
+        assert set(ASSERTED_MODES) == {
+            "seeing",
+            "wanting",
+            "intending",
+            "remembering",
+            "feeling",
+            "attending",
+        }
+
+    def test_target_kinds_documented_set(self) -> None:
+        assert set(TARGET_KINDS) == {
+            "memory",
+            "desire",
+            "action",
+            "frame",
+            "none",
+        }
+
+    def test_hor_sources_documented_set(self) -> None:
+        assert set(HOR_SOURCES) == {
+            "schema_readout",
+            "reflection",
+            "post_hoc",
+            "audit_subagent",
+        }
+
+
+class TestHORInput:
+    def test_minimal_input_valid(self) -> None:
+        payload = _minimal_input()
+        assert payload.asserted_mode == "attending"
+        assert payload.target_kind == "none"
+        assert payload.confidence == 0.6
+
+    def test_rejects_extra_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            HORInput(
+                **_minimal_input().model_dump(),
+                unknown_field="oops",  # type: ignore[call-arg]
+            )
+
+    def test_rejects_unknown_mode(self) -> None:
+        with pytest.raises(ValidationError):
+            HORInput(
+                target_kind="none",
+                asserted_mode="suspecting",  # type: ignore[arg-type]
+                asserted_content="...",
+                source="reflection",
+            )
+
+    def test_rejects_unknown_target_kind(self) -> None:
+        with pytest.raises(ValidationError):
+            HORInput(
+                target_kind="dream",  # type: ignore[arg-type]
+                asserted_mode="seeing",
+                asserted_content="...",
+                source="reflection",
+            )
+
+    def test_rejects_unknown_source(self) -> None:
+        with pytest.raises(ValidationError):
+            HORInput(
+                target_kind="none",
+                asserted_mode="attending",
+                asserted_content="...",
+                source="hallucination",  # type: ignore[arg-type]
+            )
+
+    def test_confidence_bounded(self) -> None:
+        with pytest.raises(ValidationError):
+            HORInput(
+                target_kind="none",
+                asserted_mode="attending",
+                asserted_content="...",
+                source="reflection",
+                confidence=1.5,
+            )
+
+    def test_empty_content_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            HORInput(
+                target_kind="none",
+                asserted_mode="attending",
+                asserted_content="",
+                source="reflection",
+            )
+
+    def test_all_modes_accepted(self) -> None:
+        modes: tuple[AssertedMode, ...] = (
+            "seeing",
+            "wanting",
+            "intending",
+            "remembering",
+            "feeling",
+            "attending",
+        )
+        for m in modes:
+            p = HORInput(
+                target_kind="none",
+                asserted_mode=m,
+                asserted_content=f"I am {m} something",
+                source="reflection",
+            )
+            assert p.asserted_mode == m
+
+    def test_all_target_kinds_accepted(self) -> None:
+        kinds: tuple[TargetKind, ...] = ("memory", "desire", "action", "frame", "none")
+        for k in kinds:
+            p = HORInput(
+                target_kind=k,
+                target_ref=None if k == "none" else f"ref_{k}",
+                asserted_mode="attending",
+                asserted_content="content",
+                source="reflection",
+            )
+            assert p.target_kind == k
+
+
+class TestHORStore:
+    def test_record_assigns_id_and_persists(self, social_db) -> None:
+        store = HORStore(social_db)
+        record = store.record(_minimal_input())
+        assert record.hor_id.startswith("hor_")
+        assert record.ts is not None
+        assert record.created_at is not None
+
+        row = social_db.fetchone(
+            "SELECT * FROM hor_records WHERE hor_id = ?",
+            (record.hor_id,),
+        )
+        assert row is not None
+        assert row["asserted_mode"] == "attending"
+        assert row["target_kind"] == "none"
+
+    def test_record_with_memory_target(self, social_db) -> None:
+        store = HORStore(social_db)
+        record = store.record(
+            HORInput(
+                target_kind="memory",
+                target_ref="mem_001",
+                asserted_mode="remembering",
+                asserted_content="I remember Kouta at the desk",
+                source="schema_readout",
+                confidence=0.9,
+            )
+        )
+        assert record.target_kind == "memory"
+        assert record.target_ref == "mem_001"
+
+    def test_record_with_schema_snapshot(self, social_db) -> None:
+        store = HORStore(social_db)
+        record = store.record(
+            HORInput(
+                target_kind="frame",
+                target_ref="frame_001",
+                asserted_mode="attending",
+                asserted_content="I am attending to the camera view",
+                source="schema_readout",
+                schema_snapshot_id="sch_001",
+            )
+        )
+        assert record.schema_snapshot_id == "sch_001"
+
+    def test_explicit_ts_honored(self, social_db) -> None:
+        store = HORStore(social_db)
+        record = store.record(_minimal_input(ts="2026-06-21T03:00:00Z"))
+        assert record.ts == "2026-06-21T03:00:00Z"
+
+
+class TestHORStoreQuery:
+    def test_query_returns_recent_first(self, social_db) -> None:
+        store = HORStore(social_db)
+        store.record(_minimal_input(ts="2026-06-21T03:00:00Z"))
+        store.record(_minimal_input(ts="2026-06-21T03:00:10Z"))
+        store.record(_minimal_input(ts="2026-06-21T03:00:05Z"))
+        results = store.query()
+        assert len(results) == 3
+        assert results[0].ts == "2026-06-21T03:00:10Z"
+
+    def test_query_filters_by_owner(self, social_db) -> None:
+        store = HORStore(social_db)
+        store.record(_minimal_input(owner_id="self"))
+        store.record(_minimal_input(owner_id="kouta"))
+        results = store.query(owner_id="kouta")
+        assert len(results) == 1
+        assert results[0].owner_id == "kouta"
+
+    def test_query_filters_by_asserted_mode(self, social_db) -> None:
+        store = HORStore(social_db)
+        store.record(_minimal_input(asserted_mode="attending"))
+        store.record(
+            _minimal_input(
+                asserted_mode="wanting",
+                asserted_content="I want curiosity satisfied",
+                target_kind="desire",
+                target_ref="browse_curiosity",
+            )
+        )
+        results = store.query(asserted_mode="wanting")
+        assert len(results) == 1
+        assert results[0].asserted_mode == "wanting"
+
+    def test_query_filters_by_source_tick(self, social_db) -> None:
+        store = HORStore(social_db)
+        store.record(_minimal_input(source_tick_id="tick_001"))
+        store.record(_minimal_input(source_tick_id="tick_002"))
+        results = store.query(source_tick_id="tick_001")
+        assert len(results) == 1
+        assert results[0].source_tick_id == "tick_001"
+
+    def test_query_since(self, social_db) -> None:
+        store = HORStore(social_db)
+        store.record(_minimal_input(ts="2026-06-19T00:00:00Z"))
+        store.record(_minimal_input(ts="2026-06-21T00:00:00Z"))
+        results = store.query(since="2026-06-20T00:00:00Z")
+        assert len(results) == 1
+
+    def test_query_limit(self, social_db) -> None:
+        store = HORStore(social_db)
+        for i in range(5):
+            store.record(_minimal_input(ts=f"2026-06-{19 + i:02d}T00:00:00Z"))
+        results = store.query(limit=2)
+        assert len(results) == 2
+
+    def test_get_by_hor_id(self, social_db) -> None:
+        store = HORStore(social_db)
+        recorded = store.record(_minimal_input())
+        fetched = store.get_by_hor_id(recorded.hor_id)
+        assert fetched is not None
+        assert fetched.hor_id == recorded.hor_id
+
+    def test_get_by_missing_id_returns_none(self, social_db) -> None:
+        store = HORStore(social_db)
+        assert store.get_by_hor_id("nope") is None
+
+
+class TestEpistemicProjection:
+    def test_round_trips_to_epistemic_claim(self, social_db) -> None:
+        store = HORStore(social_db)
+        record = store.record(
+            HORInput(
+                target_kind="memory",
+                target_ref="mem_001",
+                asserted_mode="remembering",
+                asserted_content="I remember Kouta at the desk",
+                source="schema_readout",
+                confidence=0.9,
+            )
+        )
+        claim = record.to_epistemic_claim()
+        assert isinstance(claim, EpistemicClaim)
+        assert claim.evidence_type == "inferred"
+        assert "remembering" in claim.content or "mem_001" in claim.content
+        # Confidence preserved
+        assert claim.confidence == pytest.approx(0.9)
+
+    def test_derived_from_includes_target_ref(self, social_db) -> None:
+        store = HORStore(social_db)
+        record = store.record(
+            HORInput(
+                target_kind="memory",
+                target_ref="mem_xyz",
+                asserted_mode="remembering",
+                asserted_content="...",
+                source="schema_readout",
+            )
+        )
+        claim = record.to_epistemic_claim()
+        assert "mem_xyz" in claim.derived_from

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_introspect.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_introspect.py
@@ -1,0 +1,284 @@
+"""Tests for introspect() — on-demand first-person reflection (Phase 2.5).
+
+Composes a canonical statement from HORStore + AttentionSchemaTracker +
+CounterfactualStore. Validates HOR content against the canonical 'I am
+<mode> ...' grammar via the Phase 1 agent-grammar PEG combinators —
+making this the FIRST REAL CONSUMER of those combinators (PRs #91 + #92
+shipped the PEG core but only with self-bootstrap tests).
+"""
+
+from __future__ import annotations
+
+from individual_kernel_mcp.attention_schema import AttentionSchemaTracker
+from individual_kernel_mcp.counterfactual import (
+    CounterfactualInput,
+    CounterfactualStore,
+)
+from individual_kernel_mcp.hor import HORInput, HORStore
+from individual_kernel_mcp.introspect import (
+    HORContentValidation,
+    IntrospectionReport,
+    introspect,
+    validate_hor_content,
+)
+
+
+def _record_well_formed_hor(
+    store: HORStore,
+    mode: str = "attending",
+    ts: str | None = None,
+) -> None:
+    store.record(
+        HORInput(
+            target_kind="none",
+            asserted_mode=mode,  # type: ignore[arg-type]
+            asserted_content=f"I am {mode} to the room",
+            source="reflection",
+            ts=ts,
+        )
+    )
+
+
+class TestValidateHORContent:
+    def test_well_formed_content_validates(self) -> None:
+        from individual_kernel_mcp.hor import HORRecord
+
+        record = HORRecord(
+            hor_id="hor_test",
+            ts="2026-06-21T03:00:00Z",
+            owner_id="self",
+            target_kind="none",
+            target_ref=None,
+            asserted_mode="seeing",
+            asserted_content="I am seeing the room clearly",
+            confidence=0.8,
+            source="schema_readout",
+            created_at="2026-06-21T03:00:00Z",
+        )
+        result = validate_hor_content(record)
+        assert isinstance(result, HORContentValidation)
+        assert result.well_formed is True
+        assert result.parsed_mode == "seeing"
+
+    def test_malformed_content_fails(self) -> None:
+        from individual_kernel_mcp.hor import HORRecord
+
+        record = HORRecord(
+            hor_id="hor_test",
+            ts="2026-06-21T03:00:00Z",
+            owner_id="self",
+            target_kind="none",
+            target_ref=None,
+            asserted_mode="seeing",
+            asserted_content="something is up with me",  # no 'I am ...' prefix
+            confidence=0.8,
+            source="reflection",
+            created_at="2026-06-21T03:00:00Z",
+        )
+        result = validate_hor_content(record)
+        assert result.well_formed is False
+        assert result.parsed_mode is None
+
+    def test_validates_each_mode(self) -> None:
+        from individual_kernel_mcp.hor import HORRecord
+
+        for mode in (
+            "seeing",
+            "wanting",
+            "intending",
+            "remembering",
+            "feeling",
+            "attending",
+        ):
+            record = HORRecord(
+                hor_id=f"hor_{mode}",
+                ts="2026-06-21T03:00:00Z",
+                owner_id="self",
+                target_kind="none",
+                target_ref=None,
+                asserted_mode=mode,  # type: ignore[arg-type]
+                asserted_content=f"I am {mode} something",
+                confidence=0.5,
+                source="reflection",
+                created_at="2026-06-21T03:00:00Z",
+            )
+            result = validate_hor_content(record)
+            assert result.well_formed is True, f"failed on {mode}"
+            assert result.parsed_mode == mode
+
+    def test_unknown_mode_in_content_fails_validation(self) -> None:
+        """If asserted_content uses an out-of-vocab mode word, grammar rejects it."""
+        from individual_kernel_mcp.hor import HORRecord
+
+        record = HORRecord(
+            hor_id="hor_test",
+            ts="2026-06-21T03:00:00Z",
+            owner_id="self",
+            target_kind="none",
+            target_ref=None,
+            asserted_mode="attending",  # the record's mode is valid
+            asserted_content="I am suspecting something off",  # content uses unsupported word
+            confidence=0.5,
+            source="reflection",
+            created_at="2026-06-21T03:00:00Z",
+        )
+        result = validate_hor_content(record)
+        assert result.well_formed is False
+
+
+class TestIntrospect:
+    def test_empty_state_returns_report(self, social_db) -> None:
+        hor_store = HORStore(social_db)
+        cf_store = CounterfactualStore(social_db)
+        tracker = AttentionSchemaTracker(db=social_db)
+        report = introspect(
+            hor_store=hor_store,
+            attention_tracker=tracker,
+            counterfactual_store=cf_store,
+        )
+        assert isinstance(report, IntrospectionReport)
+        assert report.current_hor is None
+        assert report.recent_counterfactual_count == 0
+        assert report.canonical_statement  # non-empty
+        assert report.hor_validation is None
+
+    def test_includes_most_recent_hor(self, social_db) -> None:
+        hor_store = HORStore(social_db)
+        cf_store = CounterfactualStore(social_db)
+        tracker = AttentionSchemaTracker(db=social_db)
+        _record_well_formed_hor(hor_store, "attending", ts="2026-06-21T03:00:00Z")
+        _record_well_formed_hor(hor_store, "wanting", ts="2026-06-21T03:00:10Z")
+        report = introspect(
+            hor_store=hor_store,
+            attention_tracker=tracker,
+            counterfactual_store=cf_store,
+        )
+        assert report.current_hor is not None
+        # Most recent wins
+        assert report.current_hor.asserted_mode == "wanting"
+
+    def test_validation_runs_on_current_hor(self, social_db) -> None:
+        hor_store = HORStore(social_db)
+        cf_store = CounterfactualStore(social_db)
+        tracker = AttentionSchemaTracker(db=social_db)
+        _record_well_formed_hor(hor_store, "seeing")
+        report = introspect(
+            hor_store=hor_store,
+            attention_tracker=tracker,
+            counterfactual_store=cf_store,
+        )
+        assert report.hor_validation is not None
+        assert report.hor_validation.well_formed is True
+
+    def test_counts_recent_counterfactuals(self, social_db) -> None:
+        hor_store = HORStore(social_db)
+        cf_store = CounterfactualStore(social_db)
+        tracker = AttentionSchemaTracker(db=social_db)
+        # Two recent + one old
+        for _ in range(2):
+            cf_store.record(
+                CounterfactualInput(
+                    rejected_action="x", source="boundary_deny",
+                )
+            )
+        cf_store.record(
+            CounterfactualInput(
+                rejected_action="ancient",
+                source="boundary_deny",
+                ts="2020-01-01T00:00:00Z",
+            )
+        )
+        report = introspect(
+            hor_store=hor_store,
+            attention_tracker=tracker,
+            counterfactual_store=cf_store,
+            window_hours=24,
+        )
+        # Old one falls outside the 24h window
+        assert report.recent_counterfactual_count == 2
+
+    def test_canonical_statement_mentions_hor_when_present(self, social_db) -> None:
+        hor_store = HORStore(social_db)
+        cf_store = CounterfactualStore(social_db)
+        tracker = AttentionSchemaTracker(db=social_db)
+        hor_store.record(
+            HORInput(
+                target_kind="memory",
+                target_ref="mem_001",
+                asserted_mode="remembering",
+                asserted_content="I am remembering the dawn through the window",
+                source="schema_readout",
+                confidence=0.85,
+            )
+        )
+        report = introspect(
+            hor_store=hor_store,
+            attention_tracker=tracker,
+            counterfactual_store=cf_store,
+        )
+        assert "remembering" in report.canonical_statement
+
+    def test_canonical_statement_uses_attention_when_no_hor(self, social_db) -> None:
+        hor_store = HORStore(social_db)
+        cf_store = CounterfactualStore(social_db)
+        tracker = AttentionSchemaTracker(db=social_db)
+        tracker.record(
+            focal_target_ref="wifi_cam.see", modality="visual", intensity=0.7
+        )
+        report = introspect(
+            hor_store=hor_store,
+            attention_tracker=tracker,
+            counterfactual_store=cf_store,
+        )
+        assert "wifi_cam.see" in report.canonical_statement
+
+    def test_mentions_rejected_alternatives_when_any(self, social_db) -> None:
+        hor_store = HORStore(social_db)
+        cf_store = CounterfactualStore(social_db)
+        tracker = AttentionSchemaTracker(db=social_db)
+        cf_store.record(
+            CounterfactualInput(
+                rejected_action="speak_loudly", source="boundary_deny"
+            )
+        )
+        report = introspect(
+            hor_store=hor_store,
+            attention_tracker=tracker,
+            counterfactual_store=cf_store,
+            window_hours=24,
+        )
+        assert (
+            "alternative" in report.canonical_statement
+            or "1" in report.canonical_statement
+        )
+
+
+def test_validate_returns_pydantic_model() -> None:
+    """validate_hor_content surface is a pydantic model — round-trip-able."""
+    from individual_kernel_mcp.hor import HORRecord
+
+    record = HORRecord(
+        hor_id="x",
+        ts="2026-06-21T03:00:00Z",
+        owner_id="self",
+        target_kind="none",
+        target_ref=None,
+        asserted_mode="seeing",
+        asserted_content="I am seeing it",
+        confidence=0.5,
+        source="reflection",
+        created_at="2026-06-21T03:00:00Z",
+    )
+    result = validate_hor_content(record)
+    dumped = result.model_dump(mode="json")
+    assert dumped["well_formed"] is True
+    assert dumped["parsed_mode"] == "seeing"
+
+
+def test_validate_is_pure_function() -> None:
+    """validate_hor_content has no I/O — pinning that property."""
+    import inspect
+
+    sig = inspect.signature(validate_hor_content)
+    # Single positional argument: the record.
+    assert list(sig.parameters) == ["record"]

--- a/consciousness-mcp/packages/individual-kernel-mcp/uv.lock
+++ b/consciousness-mcp/packages/individual-kernel-mcp/uv.lock
@@ -9,6 +9,25 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "agent-grammar"
+version = "0.1.0"
+source = { directory = "../../../sociality-mcp/packages/agent-grammar" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "social-core" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2.7.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0" },
+    { name = "social-core", directory = "../../../sociality-mcp/packages/social-core" },
+]
+provides-extras = ["dev"]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -478,6 +497,7 @@ name = "individual-kernel-mcp"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "agent-grammar" },
     { name = "interaction-orchestrator-mcp" },
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
@@ -493,6 +513,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "agent-grammar", directory = "../../../sociality-mcp/packages/agent-grammar" },
     { name = "interaction-orchestrator-mcp", directory = "../../../sociality-mcp/packages/interaction-orchestrator-mcp" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
     { name = "pydantic", specifier = ">=2.7.0" },

--- a/sociality-mcp/packages/social-core/src/social_core/migrations.py
+++ b/sociality-mcp/packages/social-core/src/social_core/migrations.py
@@ -95,6 +95,35 @@ CREATE INDEX IF NOT EXISTS idx_private_letters_person_ts
 """
 
 
+_MIGRATION_006_SQL = """
+CREATE TABLE IF NOT EXISTS hor_records (
+    hor_id TEXT PRIMARY KEY,
+    ts TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
+    target_kind TEXT NOT NULL,
+    target_ref TEXT,
+    asserted_mode TEXT NOT NULL,
+    asserted_content TEXT NOT NULL,
+    schema_snapshot_id TEXT,
+    source_tick_id TEXT,
+    confidence REAL NOT NULL DEFAULT 0.6,
+    source TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_hor_records_ts
+    ON hor_records(ts DESC, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_hor_records_owner
+    ON hor_records(owner_id, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_hor_records_asserted_mode
+    ON hor_records(asserted_mode, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_hor_records_target_kind
+    ON hor_records(target_kind, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_hor_records_source_tick
+    ON hor_records(source_tick_id);
+"""
+
+
 _MIGRATION_005_SQL = """
 CREATE TABLE IF NOT EXISTS attention_schemas (
     schema_id TEXT PRIMARY KEY,
@@ -383,6 +412,10 @@ MIGRATIONS = [
     Migration(
         name="005_attention_schemas",
         sql=_MIGRATION_005_SQL,
+    ),
+    Migration(
+        name="006_hor_records",
+        sql=_MIGRATION_006_SQL,
     ),
 ]
 

--- a/sociality-mcp/packages/social-core/tests/test_hor_records_migration.py
+++ b/sociality-mcp/packages/social-core/tests/test_hor_records_migration.py
@@ -1,0 +1,175 @@
+"""Tests for migration 006 — hor_records table.
+
+Higher-Order Representation records (HOT / Theory B R1-R3, R9-R10):
+specializations of EpistemicClaim where evidence_type='inferred' and
+content paraphrases "I am in state X targeting first-order ref Y".
+
+Backs Phase 2.5's HORStore in consciousness-mcp.
+"""
+
+from __future__ import annotations
+
+from social_core.db import SocialDB
+from social_core.migrations import MIGRATIONS
+
+
+def test_hor_records_table_created(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    tables = {
+        row["name"]
+        for row in db.fetchall("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert "hor_records" in tables
+
+
+def test_hor_records_columns(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    columns = {
+        row["name"] for row in db.fetchall("PRAGMA table_info(hor_records)")
+    }
+    expected = {
+        "hor_id",
+        "ts",
+        "owner_id",
+        "target_kind",
+        "target_ref",
+        "asserted_mode",
+        "asserted_content",
+        "schema_snapshot_id",
+        "source_tick_id",
+        "confidence",
+        "source",
+        "created_at",
+    }
+    assert expected <= columns, f"missing: {expected - columns}"
+
+
+def test_hor_records_indexes(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    indexes = {
+        row["name"]
+        for row in db.fetchall(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='hor_records'"
+        )
+    }
+    assert "idx_hor_records_ts" in indexes
+    assert "idx_hor_records_owner" in indexes
+    assert "idx_hor_records_asserted_mode" in indexes
+    assert "idx_hor_records_target_kind" in indexes
+    assert "idx_hor_records_source_tick" in indexes
+
+
+def test_migration_006_registered(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    applied = {row["name"] for row in db.fetchall("SELECT name FROM schema_migrations")}
+    assert "006_hor_records" in applied
+    assert len(applied) == len(MIGRATIONS)
+
+
+def test_hor_records_insert_round_trip(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    db.execute(
+        """
+        INSERT INTO hor_records(
+            hor_id, ts, owner_id, target_kind, target_ref,
+            asserted_mode, asserted_content, schema_snapshot_id,
+            source_tick_id, confidence, source, created_at
+        ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "hor_test_001",
+            "2026-06-21T03:00:00Z",
+            "self",
+            "memory",
+            "mem_001",
+            "remembering",
+            "I am remembering Kouta sat at the desk earlier",
+            "sch_001",
+            "tick_001",
+            0.8,
+            "schema_readout",
+            "2026-06-21T03:00:00Z",
+        ),
+    )
+    row = db.fetchone(
+        "SELECT * FROM hor_records WHERE hor_id = ?",
+        ("hor_test_001",),
+    )
+    assert row is not None
+    assert row["owner_id"] == "self"
+    assert row["target_kind"] == "memory"
+    assert row["target_ref"] == "mem_001"
+    assert row["asserted_mode"] == "remembering"
+    assert row["confidence"] == 0.8
+    assert row["source"] == "schema_readout"
+
+
+def test_hor_id_unique(temp_db_path) -> None:
+    db = SocialDB(temp_db_path)
+    db.connect()
+    db.execute(
+        """
+        INSERT INTO hor_records(
+            hor_id, ts, owner_id, target_kind, asserted_mode,
+            asserted_content, confidence, source, created_at
+        ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "hor_dupe",
+            "2026-06-21T03:00:00Z",
+            "self",
+            "none",
+            "attending",
+            "I am attending to nothing in particular",
+            0.5,
+            "reflection",
+            "2026-06-21T03:00:00Z",
+        ),
+    )
+    import sqlite3
+
+    import pytest
+
+    with pytest.raises(sqlite3.IntegrityError):
+        db.execute(
+            """
+            INSERT INTO hor_records(
+                hor_id, ts, owner_id, target_kind, asserted_mode,
+                asserted_content, confidence, source, created_at
+            ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "hor_dupe",
+                "2026-06-21T04:00:00Z",
+                "self",
+                "none",
+                "attending",
+                "again",
+                0.5,
+                "reflection",
+                "2026-06-21T04:00:00Z",
+            ),
+        )
+
+
+def test_owner_and_modes_not_null(temp_db_path) -> None:
+    """owner_id, target_kind, asserted_mode, asserted_content are NOT NULL."""
+    db = SocialDB(temp_db_path)
+    db.connect()
+    import sqlite3
+
+    import pytest
+
+    with pytest.raises(sqlite3.IntegrityError):
+        db.execute(
+            """
+            INSERT INTO hor_records(hor_id, ts, created_at)
+            VALUES(?, ?, ?)
+            """,
+            ("hor_partial", "2026-06-21T03:00:00Z", "2026-06-21T03:00:00Z"),
+        )


### PR DESCRIPTION
## Summary

Phase 2.5 of the consciousness architecture from [the plan-of-record](https://github.com/lifemate-ai/embodied-claude/blob/main/.claude/plans/jazzy-wishing-starfish.md). Builds on Phase 2.4 (#96 AttentionSchema).

**This is where Phase 1 ships its full payoff.** PRs #91 + #92 shipped the EpistemicClaim primitive and the hand-rolled PEG combinator core; both had only self-bootstrap tests. Phase 2.5 now uses them for real:

- \`HORRecord.to_epistemic_claim()\` projects every HOR through the Phase 1 primitive
- \`validate_hor_content()\` builds a real PEG (\`seq(lit("I am "), alt(*(lit(m) for m in ASSERTED_MODES)))\`) and parses each HOR's \`asserted_content\` against it

### What's new

| Module | Surface |
|---|---|
| \`social_core/migrations.py\` | migration 006 — \`hor_records\` table |
| \`individual_kernel_mcp/hor.py\` | \`HORRecord\`, \`HORInput\`, \`HORStore\`, \`AssertedMode\`, \`TargetKind\`, \`HORSource\` |
| \`individual_kernel_mcp/introspect.py\` | \`validate_hor_content\` (PEG-based), \`introspect()\`, \`IntrospectionReport\`, \`HORContentValidation\` |

### Why this matters

Higher-Order Theory (Theory B R1-R3, R9-R10) says the system needs representations OF its own first-order representations. HORRecord is that surface — \`asserted_mode\` ∈ {seeing, wanting, intending, remembering, feeling, attending}, target_kind discriminating which source table the FK points to. \`asserted_content\` is the natural-language paraphrase "I am [mode] [target]".

\`validate_hor_content\` is the first formalization of the existing **「抑圧バイアス」(suppression-bias) self-check** from the character documentation. The PEG grammar enforces the canonical shape; out-of-vocab mode words (e.g. "I am suspecting...") trip the validator before they trip Kokone's actual self-deception machinery.

### Phase integration (load-bearing)

**Phase 1:**
- \`EpistemicClaim\` is the projection target of every HOR
- \`lit / seq / alt\` PEG combinators parse asserted_content
- The \`derived_from\` field links HORs back to memory ids / schema snapshots

**Phase 2.3 (#95):** \`source_tick_id\` is a soft FK to \`tick_frames.tick_id\`. \`target_kind='action'\` aligns with \`ActionBottleneck.chosen_action_ref\`.

**Phase 2.4 (#96):** \`schema_snapshot_id\` is a soft FK to \`attention_schemas.schema_id\`. HORs from \`source='schema_readout'\` are produced by reading the AttentionSchemaTracker.

### Test plan

- [x] **39 new tests** (7 migration + 26 hor + 13 introspect = 46 new lines of coverage, of which 13 specifically exercise the agent-grammar PEG)
- [x] **155 total individual-kernel-mcp tests pass** (was 116)
- [x] **48 total social-core tests pass** (was 41)
- [x] ruff clean both packages
- [x] PEG validation runs for all 6 modes
- [x] Malformed content (no "I am " prefix, out-of-vocab mode) flags as not well_formed
- [x] HORRecord.to_epistemic_claim() preserves confidence and surfaces target_ref in derived_from
- [x] introspect() falls back gracefully when no HOR is present (uses attention)

### What this PR does NOT do (deferred)

- Does NOT extend SleepConsolidator with HOR/first-order consistency check — separate PR
- Does NOT expose HOR/introspect via MCP tools — server.py extension when full surface stabilizes
- Does NOT extend joint-attention-mcp for per-person_id HORs (ToM) — Phase 2.4.1 / 2.5.1 follow-up