### PR TITLE
feat(individual-kernel-mcp): expose Phase 2.3–2.5 stores as MCP tools + runtime integration

### DIFF
--- a/.claude/commands/recover-from-compact.md
+++ b/.claude/commands/recover-from-compact.md
@@ -53,6 +53,24 @@ The behaviors most likely to regress are the ones that were specifically correct
 - Read `~/.claude/memories/counterfactuals.jsonl` — "wanted X, chose Y, because Z" entries
 - Skipping this step is the main cause of post-compaction regression
 
+### 3.5. Self-state read — current introspection report
+
+```
+mcp__individual-kernel__compose_introspection_report(window_hours=24)
+```
+
+Reads (a) the most-recent higher-order self-report, (b) the current
+attention-schema reflection, (c) the count of recently-set-aside
+alternatives. The `canonical_statement` field is a first-person
+read-out — use it as a self-grounding line before resuming. If the
+kernel returns no current HOR, the statement falls back to the
+attention focal, which is fine. A larger window (24h instead of the
+default 1h) is intentional here: post-compaction often follows a long
+quiet period.
+
+If `individual-kernel` is not connected, skip this step — it ships in
+a follow-up alongside the kernel's tick producer.
+
 ### 4. Current tasks
 
 ```

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -53,6 +53,15 @@
       "command": "uv",
       "args": ["run", "--directory", "sociality-mcp", "sociality-mcp"]
     },
+    "individual-kernel": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "consciousness-mcp/packages/individual-kernel-mcp",
+        "individual-kernel-mcp"
+      ]
+    },
     "garmin-health": {
       "command": "node",
       "args": ["/path/to/garmin-health-mcp/index.js"],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,27 @@ orchestration 層。従来の social-state / relationship / self-narrative / bou
 | `compose_private_letter` | payload | 朝の手紙的な letter を保存（本文は Claude が書く）。後で共有するかは visibility で制御 |
 | `get_agent_state` | person_id? | compose より軽量。欲求、最近の experience、active arcs のみ返す。introspection 用 |
 
+### individual-kernel-mcp（脳の自己観察層）
+
+`consciousness-mcp/packages/individual-kernel-mcp/`。Phase 2.1–2.5 の typed records（counterfactual / tick frame / attention schema / HOR）と composer（sleep / introspection）を MCP として露出する kernel-internal な surface。**外向き行為を起こさない**ので boundary-mcp による gate を通さへんが、ここの出力を TTS や投稿に流すときは呼び出し側で boundary を通すこと。
+
+| ツール | パラメータ | 説明 |
+|--------|-----------|------|
+| `record_counterfactual` | payload | 拒否した代替行為を typed record で残す（source ∈ boundary_deny / attention_lost_bid / deliberate_choice / policy / ignition_failed）。evidence_type は Phase 1 EvidenceType を再利用 |
+| `query_counterfactuals` | since?, source?, tick_id?, person_id?, limit? | 直近の counterfactual を返す |
+| `sleep_consolidate` | force?, dry_run? | quiet hours で morning_briefing.json を書き出す scheduler glue |
+| `record_tick_frame` | payload | per-tick の ConsciousFrame を保存。winning_memory_ids / dominant_desire / prediction_error / chosen_action_ref など FK だけ持つ |
+| `get_tick_frame` | tick_id | tick_id から ConsciousFrame を取り出す |
+| `query_tick_frames` | since?, reportability?, person_id?, ignited_only?, limit? | 直近の ConsciousFrame を返す |
+| `record_attention_schema` | focal_target_ref, modality, intensity, dwell_seconds?, ... | AST スナップショットを in-memory ring buffer に積む（cap 60）|
+| `update_attention_from_frame` | tick_id | ConsciousFrame から AttentionSchema を投影（modality / intensity / dwell を自動推論）|
+| `flush_attention_schemas` | — | 在庫を SQLite に永続化。返り値 {count}。プロセス再起動で buffer は消えるので明示 flush 必要 |
+| `summarize_attention_schema` | extra_history? | reflect_attention_schema を呼んで modality 分布 / 焦点変化数 / dominant focal を返す |
+| `record_hor` | payload | Higher-Order Representation を保存。asserted_mode ∈ seeing/wanting/intending/remembering/feeling/attending。EpistemicClaim に projection 可能 |
+| `get_hor` | hor_id | HORRecord を取り出す |
+| `query_hors` | since?, owner_id?, asserted_mode?, target_kind?, source_tick_id?, limit? | HOR を絞り込んで返す |
+| `compose_introspection_report` | window_hours?, owner_id? | 最近の HOR + attention reflection + counterfactual 件数を合わせた IntrospectionReport を作る。canonical_statement は Kokone-voice の一人称文字列 |
+
 ## Heartbeat Protocol
 
 自律行動や会話中に sociality を使うときは、最低限この順序を守ること。

--- a/consciousness-mcp/packages/individual-kernel-mcp/README.md
+++ b/consciousness-mcp/packages/individual-kernel-mcp/README.md
@@ -9,7 +9,32 @@ Phase 2.1 of `consciousness-mcp`. See `../../README.md` for the honesty note tha
 | `counterfactual.py` | `CounterfactualStore` over `social-core` SQLite, typed `CounterfactualInput` / `CounterfactualRecord` |
 | `sleep.py` | `SleepConsolidator` — quiet-hours-gated cron entry, writes `~/.claude/morning_briefing.json` |
 | `auto_emit.py` | Pure function `extract_counterfactuals_from_plan(plan, ctx)` — produces `CounterfactualInput`s without writing |
-| `server.py` | MCP server exposing `query_counterfactuals` and `sleep_consolidate` |
+| `server.py` (Phase 2.1 surface) | MCP server exposing `record_counterfactual`, `query_counterfactuals`, `sleep_consolidate` |
+
+## What ships in Phase 2.3–2.5 (this package, integrated via MCP)
+
+| Module | Role |
+|---|---|
+| `frame.py` | `ConsciousFrame` + `TickFrameStore` + `PredictionErrorChannels` — per-tick canonical record (FK-only, payload-poor) |
+| `bottleneck.py` | `ActionBottleneck.commit_action` — one external action per tick, second attempts deferred + counterfactual'd (not yet MCP-exposed; waits for tick producer) |
+| `attention_schema.py` | `AttentionSchema` + `AttentionSchemaTracker` (ring buffer cap 60, flush to SQLite) — Attention Schema Theory surface |
+| `reflect.py` | `reflect_attention_schema` — on-demand modality / dwell / focus-change summary |
+| `hor.py` | `HORRecord` + `HORStore` — Higher-Order Representations as EpistemicClaim specializations (Phase 1 integration) |
+| `introspect.py` | `validate_hor_content` (uses agent-grammar PEG, Phase 1 first real consumer) + `introspect` composer |
+
+MCP tools exposed by `server.py` (post-integration):
+
+| MCP tool | Wraps |
+|---|---|
+| `record_tick_frame` / `get_tick_frame` / `query_tick_frames` | `TickFrameStore` (Phase 2.3) |
+| `record_attention_schema` / `update_attention_from_frame` / `flush_attention_schemas` / `summarize_attention_schema` | `AttentionSchemaTracker` + `reflect_attention_schema` (Phase 2.4) |
+| `record_hor` / `get_hor` / `query_hors` | `HORStore` (Phase 2.5) |
+| `compose_introspection_report` | `introspect` composer (Phase 2.5) |
+
+Internal helpers (NOT MCP-exposed by design):
+- `validate_hor_content` — embedded inside `compose_introspection_report` output
+- `ActionBottleneck.commit_action` — exposed in a later PR alongside the tick producer
+- `extract_counterfactuals_from_plan` — Python-only; orchestrator calls it
 
 ## What does NOT ship in Phase 2.1
 

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/server.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/server.py
@@ -1,11 +1,30 @@
 """FastMCP server for individual-kernel-mcp.
 
-Phase 2.1 surface:
-  - query_counterfactuals: read-only access to the counterfactual journal
-  - sleep_consolidate: trigger the quiet-hours-gated scheduler glue
+Phase 2.1 surface (shipped earlier):
+  - record_counterfactual
+  - query_counterfactuals
+  - sleep_consolidate
 
-See consciousness-mcp/AGENTS.md for vocabulary discipline. The MCP tool
-descriptions here are functional-only.
+Phase 2.3 surface (this integration PR):
+  - record_tick_frame, get_tick_frame, query_tick_frames
+
+Phase 2.4 surface:
+  - record_attention_schema, update_attention_from_frame,
+    flush_attention_schemas, summarize_attention_schema
+
+Phase 2.5 surface:
+  - record_hor, get_hor, query_hors, compose_introspection_report
+
+This package is kernel-internal. These tools have no external side effects;
+boundary-mcp evaluate_action is NOT applied here. Downstream consumers
+that surface introspection output to TTS / posts / DMs MUST gate at their
+own boundary. ActionBottleneck.commit_action remains intentionally
+unexposed until a tick producer is wired (separate PR).
+
+See consciousness-mcp/AGENTS.md for vocabulary discipline. MCP tool
+names use functional vocabulary even when the underlying Python function
+name reads more naturally (e.g. summarize_attention_schema wraps
+reflect_attention_schema; compose_introspection_report wraps introspect).
 """
 
 from __future__ import annotations
@@ -17,11 +36,27 @@ from typing import Any
 from mcp.server.fastmcp import FastMCP
 from social_core import SocialDB
 
+from individual_kernel_mcp.attention_schema import (
+    AttentionSchemaTracker,
+    Modality,
+)
 from individual_kernel_mcp.counterfactual import (
     CounterfactualInput,
     CounterfactualSource,
     CounterfactualStore,
 )
+from individual_kernel_mcp.frame import (
+    ConsciousFrameInput,
+    TickFrameStore,
+)
+from individual_kernel_mcp.hor import (
+    AssertedMode,
+    HORInput,
+    HORStore,
+    TargetKind,
+)
+from individual_kernel_mcp.introspect import introspect
+from individual_kernel_mcp.reflect import reflect_attention_schema
 from individual_kernel_mcp.sleep import SleepConsolidator
 
 mcp = FastMCP("individual-kernel-mcp")
@@ -32,6 +67,9 @@ class IndividualKernelStores:
     db: SocialDB
     counterfactual: CounterfactualStore
     sleep: SleepConsolidator
+    tick_frames: TickFrameStore
+    attention_tracker: AttentionSchemaTracker
+    hor_store: HORStore
 
 
 @lru_cache(maxsize=1)
@@ -46,6 +84,9 @@ def _stores() -> IndividualKernelStores:
         db=db,
         counterfactual=counterfactual_store,
         sleep=sleep_consolidator,
+        tick_frames=TickFrameStore(db),
+        attention_tracker=AttentionSchemaTracker(db=db, owner_id="self"),
+        hor_store=HORStore(db),
     )
 
 
@@ -56,16 +97,14 @@ def reset_store_cache() -> None:
         _stores.cache_clear()
 
 
+# -----------------------------------------------------------------------------
+# Phase 2.1 surface
+# -----------------------------------------------------------------------------
+
+
 @mcp.tool()
 def record_counterfactual(payload: dict[str, Any]) -> dict[str, Any]:
-    """Record a rejected alternative as a typed counterfactual.
-
-    Use this when the agent commits to one action and explicitly forgoes
-    another. `source` ∈ {boundary_deny, attention_lost_bid,
-    deliberate_choice, policy, ignition_failed}. `evidence_type` reuses
-    Phase 1's EvidenceType enum (observed/inferred/remembered/heard/
-    assumed) so the row round-trips through EpistemicClaim downstream.
-    """
+    """Record a rejected alternative as a typed counterfactual."""
     record = _stores().counterfactual.record(CounterfactualInput(**payload))
     return record.model_dump(mode="json")
 
@@ -78,11 +117,7 @@ def query_counterfactuals(
     person_id: str | None = None,
     limit: int = 50,
 ) -> list[dict[str, Any]]:
-    """Read recent counterfactuals (most recent first).
-
-    Filter by ISO timestamp (`since`), originating gate (`source`),
-    tick id, or person id. Returns CounterfactualRecord dicts.
-    """
+    """Read recent counterfactuals (most recent first)."""
     records = _stores().counterfactual.query(
         since=since,
         source=source,
@@ -98,15 +133,198 @@ def sleep_consolidate(
     force: bool = False,
     dry_run: bool = False,
 ) -> dict[str, Any]:
-    """Run the quiet-hours-gated sleep-consolidation glue.
-
-    Without `force`, the call is skipped unless the wrapped quiet-hours
-    predicate accepts the current timestamp. With `force=True`, the
-    briefing is assembled regardless of the gate. `dry_run=True` returns
-    the briefing without writing morning_briefing.json to disk.
-    """
+    """Run the quiet-hours-gated sleep-consolidation glue."""
     result = _stores().sleep.run(force=force, dry_run=dry_run)
     return result.model_dump(mode="json")
+
+
+# -----------------------------------------------------------------------------
+# Phase 2.3 surface — tick frames
+# -----------------------------------------------------------------------------
+
+
+@mcp.tool()
+def record_tick_frame(payload: dict[str, Any]) -> dict[str, Any]:
+    """Record a ConsciousFrame — the per-tick canonical record.
+
+    Payload follows ConsciousFrameInput: ts?, person_id?, ignited (bool),
+    conflicted (bool), attention_target_ref?, dominant_desire?,
+    winning_memory_ids (list of FKs), prediction_error {extero, intero,
+    mnemonic}, affect_summary?, chosen_action_ref?, reportability ∈
+    {mentionable, background_only, do_not_surface}. Returns the persisted
+    frame with an assigned tick_id.
+    """
+    frame = _stores().tick_frames.record(ConsciousFrameInput(**payload))
+    return frame.model_dump(mode="json")
+
+
+@mcp.tool()
+def get_tick_frame(tick_id: str) -> dict[str, Any] | None:
+    """Fetch a ConsciousFrame by tick_id; null when missing."""
+    frame = _stores().tick_frames.get_by_tick_id(tick_id)
+    if frame is None:
+        return None
+    return frame.model_dump(mode="json")
+
+
+@mcp.tool()
+def query_tick_frames(
+    since: str | None = None,
+    reportability: str | None = None,
+    person_id: str | None = None,
+    ignited_only: bool = False,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Read recent ConsciousFrames (most recent first)."""
+    frames = _stores().tick_frames.query(
+        since=since,
+        reportability=reportability,  # type: ignore[arg-type]
+        person_id=person_id,
+        ignited_only=ignited_only,
+        limit=limit,
+    )
+    return [f.model_dump(mode="json") for f in frames]
+
+
+# -----------------------------------------------------------------------------
+# Phase 2.4 surface — attention schemas
+# -----------------------------------------------------------------------------
+
+
+@mcp.tool()
+def record_attention_schema(
+    focal_target_ref: str | None,
+    modality: Modality,
+    intensity: float,
+    dwell_seconds: float = 0.0,
+    predicted_next_focus: str | None = None,
+    control_handle: str | None = None,
+    source_tick_id: str | None = None,
+    ts: str | None = None,
+) -> dict[str, Any]:
+    """Append an AttentionSchema snapshot to the in-memory ring buffer.
+
+    The buffer is process-scoped (capacity 60); call flush_attention_schemas
+    to persist to SQLite. modality ∈ {visual, auditory, internal, social}.
+    """
+    schema = _stores().attention_tracker.record(
+        focal_target_ref=focal_target_ref,
+        modality=modality,
+        intensity=intensity,
+        dwell_seconds=dwell_seconds,
+        predicted_next_focus=predicted_next_focus,
+        control_handle=control_handle,
+        source_tick_id=source_tick_id,
+        ts=ts,
+    )
+    return schema.model_dump(mode="json")
+
+
+@mcp.tool()
+def update_attention_from_frame(tick_id: str) -> dict[str, Any]:
+    """Build an AttentionSchema from a previously-recorded ConsciousFrame.
+
+    Modality is inferred from frame.attention_target_ref; intensity from
+    frame.ignited (ignited→0.8, subliminal→0.3); dwell accumulates if
+    focal target matches the last buffered schema.
+    """
+    stores = _stores()
+    frame = stores.tick_frames.get_by_tick_id(tick_id)
+    if frame is None:
+        raise ValueError(f"no tick_frame {tick_id!r}; record_tick_frame first")
+    schema = stores.attention_tracker.update_from_frame(frame)
+    return schema.model_dump(mode="json")
+
+
+@mcp.tool()
+def flush_attention_schemas() -> dict[str, int]:
+    """Persist buffered AttentionSchemas to SQLite; clears the buffer."""
+    count = _stores().attention_tracker.flush()
+    return {"count": count}
+
+
+@mcp.tool()
+def summarize_attention_schema(extra_history: int = 0) -> dict[str, Any]:
+    """Build an AttentionReflection over the buffer (and optional history)."""
+    stores = _stores()
+    reflection = reflect_attention_schema(
+        stores.attention_tracker, extra_history=extra_history
+    )
+    return reflection.model_dump(mode="json")
+
+
+# -----------------------------------------------------------------------------
+# Phase 2.5 surface — HOR + introspection
+# -----------------------------------------------------------------------------
+
+
+@mcp.tool()
+def record_hor(payload: dict[str, Any]) -> dict[str, Any]:
+    """Record a higher-order representation (HOR).
+
+    Payload follows HORInput: ts?, owner_id (default 'self'), target_kind
+    ∈ {memory, desire, action, frame, none}, target_ref?, asserted_mode ∈
+    {seeing, wanting, intending, remembering, feeling, attending},
+    asserted_content (non-empty string), schema_snapshot_id?,
+    source_tick_id?, confidence ∈ [0,1] (default 0.6), source ∈
+    {schema_readout, reflection, post_hoc, audit_subagent}.
+    """
+    record = _stores().hor_store.record(HORInput(**payload))
+    return record.model_dump(mode="json")
+
+
+@mcp.tool()
+def get_hor(hor_id: str) -> dict[str, Any] | None:
+    """Fetch a HORRecord by hor_id; null when missing."""
+    record = _stores().hor_store.get_by_hor_id(hor_id)
+    if record is None:
+        return None
+    return record.model_dump(mode="json")
+
+
+@mcp.tool()
+def query_hors(
+    since: str | None = None,
+    owner_id: str | None = None,
+    asserted_mode: AssertedMode | None = None,
+    target_kind: TargetKind | None = None,
+    source_tick_id: str | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Read recent HORRecords (most recent first)."""
+    records = _stores().hor_store.query(
+        since=since,
+        owner_id=owner_id,
+        asserted_mode=asserted_mode,
+        target_kind=target_kind,
+        source_tick_id=source_tick_id,
+        limit=limit,
+    )
+    return [r.model_dump(mode="json") for r in records]
+
+
+@mcp.tool()
+def compose_introspection_report(
+    window_hours: int = 1,
+    owner_id: str = "self",
+) -> dict[str, Any]:
+    """Compose an introspection report (Phase 2.5 read surface).
+
+    Reads the most-recent HOR for owner_id, the current attention
+    reflection from the tracker, and counterfactuals within window_hours.
+    Returns IntrospectionReport with a canonical first-person statement
+    + structured detail (current_hor, current_attention,
+    recent_counterfactual_count, hor_validation, notes).
+    """
+    stores = _stores()
+    report = introspect(
+        hor_store=stores.hor_store,
+        attention_tracker=stores.attention_tracker,
+        counterfactual_store=stores.counterfactual,
+        window_hours=window_hours,
+        owner_id=owner_id,
+    )
+    return report.model_dump(mode="json")
 
 
 def main() -> None:

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_server.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_server.py
@@ -1,31 +1,234 @@
-"""Smoke tests for the MCP server surface.
+"""Smoke + integration tests for the MCP server surface.
 
-Phase 2.1 keeps the server thin — three tools wrapping CounterfactualStore +
-SleepConsolidator. The functional behavior is tested elsewhere; this file
-ensures the tools are registered and importable.
+Phase 2.1 exposed 3 tools. This file extends to the Phase 2.3-2.5 surface
+that comes with the integration PR: 11 new tools wrapping TickFrameStore,
+AttentionSchemaTracker, HORStore + composer.
 """
 
 from __future__ import annotations
 
+import pytest
+
 from individual_kernel_mcp import server
+from individual_kernel_mcp.attention_schema import AttentionSchemaTracker
+from individual_kernel_mcp.counterfactual import CounterfactualStore
+from individual_kernel_mcp.frame import TickFrameStore
+from individual_kernel_mcp.hor import HORStore
 
 
-def test_tools_are_registered() -> None:
-    """All three Phase 2.1 tools must be exposed on the FastMCP instance."""
-    # FastMCP keeps registered tools in an internal manager; the public
-    # accessor is .list_tools() (async) or accessing the underlying manager.
-    # For a smoke test we just check that the functions exist as attributes.
-    assert callable(server.record_counterfactual)
-    assert callable(server.query_counterfactuals)
-    assert callable(server.sleep_consolidate)
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    """Isolate every test from the real ~/.claude/social.db.
+
+    Sets SOCIAL_DB_PATH to a tmp_path-derived sqlite file AND clears the
+    module-level _stores() cache before AND after each test so the
+    SocialDB connection points at the temp file.
+    """
+    db_path = tmp_path / "social.db"
+    monkeypatch.setenv("SOCIAL_DB_PATH", str(db_path))
+    server.reset_store_cache()
+    yield
+    server.reset_store_cache()
+
+
+class TestPhase21Tools:
+    def test_phase21_tools_still_registered(self) -> None:
+        assert callable(server.record_counterfactual)
+        assert callable(server.query_counterfactuals)
+        assert callable(server.sleep_consolidate)
+
+
+class TestPhase23to25ToolsRegistered:
+    def test_all_phase_2_3_to_2_5_tool_names_are_registered_on_server_module(
+        self,
+    ) -> None:
+        """Every new wrapper from the integration PR is importable from server."""
+        names = [
+            "record_tick_frame",
+            "get_tick_frame",
+            "query_tick_frames",
+            "record_attention_schema",
+            "update_attention_from_frame",
+            "flush_attention_schemas",
+            "summarize_attention_schema",
+            "record_hor",
+            "get_hor",
+            "query_hors",
+            "compose_introspection_report",
+        ]
+        for name in names:
+            assert hasattr(server, name), f"missing tool: {name}"
+            assert callable(getattr(server, name)), f"not callable: {name}"
+
+
+class TestStoresDataclass:
+    def test_stores_dataclass_exposes_phase_2_3_to_2_5_stores(self) -> None:
+        """IndividualKernelStores carries tick/attention/hor stores."""
+        stores = server._stores()
+        assert isinstance(stores.tick_frames, TickFrameStore)
+        assert isinstance(stores.attention_tracker, AttentionSchemaTracker)
+        assert isinstance(stores.hor_store, HORStore)
+        assert isinstance(stores.counterfactual, CounterfactualStore)
+        assert stores.attention_tracker.owner_id == "self"
+
+    def test_stores_share_a_single_socialdb(self) -> None:
+        stores = server._stores()
+        assert stores.tick_frames._db is stores.db  # noqa: SLF001
+        assert stores.attention_tracker.db is stores.db
+        assert stores.hor_store._db is stores.db  # noqa: SLF001
+
+
+class TestTickFrameRoundTrip:
+    def test_record_get_query_round_trip(self) -> None:
+        result = server.record_tick_frame(
+            {
+                "person_id": "kouta",
+                "ignited": True,
+                "attention_target_ref": "wifi_cam.see",
+                "dominant_desire": "browse_curiosity",
+                "winning_memory_ids": ["mem_a", "mem_b"],
+                "prediction_error": {"extero": 0.7, "intero": 0.2, "mnemonic": 0.4},
+            }
+        )
+        tick_id = result["tick_id"]
+        assert tick_id.startswith("tick_")
+
+        fetched = server.get_tick_frame(tick_id)
+        assert fetched is not None
+        assert fetched["attention_target_ref"] == "wifi_cam.see"
+        assert fetched["winning_memory_ids"] == ["mem_a", "mem_b"]
+
+        ignited = server.query_tick_frames(ignited_only=True)
+        assert len(ignited) == 1
+        assert ignited[0]["tick_id"] == tick_id
+
+    def test_get_missing_tick_returns_none(self) -> None:
+        assert server.get_tick_frame("tick_nonexistent_xyz") is None
+
+
+class TestAttentionSchemaRoundTrip:
+    def test_record_flush_summarize_round_trip(self) -> None:
+        server.record_attention_schema(
+            focal_target_ref="wifi_cam.see",
+            modality="visual",
+            intensity=0.7,
+        )
+        server.record_attention_schema(
+            focal_target_ref="wifi_cam.listen",
+            modality="auditory",
+            intensity=0.5,
+        )
+        flush_result = server.flush_attention_schemas()
+        assert flush_result["count"] == 2
+        summary = server.summarize_attention_schema()
+        # Buffer is empty after flush; reflection without extra_history is empty.
+        assert summary["window_size"] == 0
+
+        summary_with_history = server.summarize_attention_schema(extra_history=10)
+        assert summary_with_history["window_size"] == 2
+        modalities = set(summary_with_history["modality_distribution"].keys())
+        assert {"visual", "auditory"} <= modalities
+
+    def test_update_attention_from_frame_uses_recorded_frame(self) -> None:
+        frame = server.record_tick_frame(
+            {
+                "attention_target_ref": "wifi_cam.see",
+                "ignited": True,
+            }
+        )
+        schema = server.update_attention_from_frame(tick_id=frame["tick_id"])
+        assert schema["modality"] == "visual"
+        assert schema["source_tick_id"] == frame["tick_id"]
+        # Buffer holds it now.
+        flush_result = server.flush_attention_schemas()
+        assert flush_result["count"] == 1
+
+    def test_update_attention_from_missing_frame_raises(self) -> None:
+        with pytest.raises(ValueError, match="no tick_frame"):
+            server.update_attention_from_frame(tick_id="tick_nonexistent")
+
+
+class TestHORRoundTrip:
+    def test_record_get_query_round_trip(self) -> None:
+        result = server.record_hor(
+            {
+                "target_kind": "none",
+                "asserted_mode": "attending",
+                "asserted_content": "I am attending the workspace",
+                "source": "reflection",
+            }
+        )
+        hor_id = result["hor_id"]
+        assert hor_id.startswith("hor_")
+        fetched = server.get_hor(hor_id)
+        assert fetched is not None
+        assert fetched["asserted_mode"] == "attending"
+
+        results = server.query_hors(asserted_mode="attending")
+        assert len(results) == 1
+        assert results[0]["hor_id"] == hor_id
+
+    def test_get_missing_hor_returns_none(self) -> None:
+        assert server.get_hor("hor_nonexistent_xyz") is None
+
+
+class TestComposeIntrospectionReport:
+    def test_integrates_hor_attention_counterfactual(self) -> None:
+        # Seed a HOR
+        server.record_hor(
+            {
+                "target_kind": "none",
+                "asserted_mode": "attending",
+                "asserted_content": "I am attending the silence",
+                "source": "reflection",
+            }
+        )
+        # Seed an attention schema entry
+        server.record_attention_schema(
+            focal_target_ref="wifi_cam.see",
+            modality="visual",
+            intensity=0.7,
+        )
+        # Seed a counterfactual (recent)
+        server.record_counterfactual(
+            {
+                "rejected_action": "speak_loudly",
+                "source": "boundary_deny",
+            }
+        )
+
+        report = server.compose_introspection_report(window_hours=24)
+        assert report["canonical_statement"]  # non-empty
+        assert report["current_hor"] is not None
+        assert report["current_hor"]["asserted_mode"] == "attending"
+        assert report["recent_counterfactual_count"] == 1
+        assert report["hor_validation"]["well_formed"] is True
+
+    def test_empty_state_returns_report(self) -> None:
+        report = server.compose_introspection_report()
+        assert report["current_hor"] is None
+        assert report["recent_counterfactual_count"] == 0
+        assert report["canonical_statement"]
+
+
+class TestBoundaryPolicyDocstring:
+    def test_server_module_docstring_declares_no_boundary_gating(self) -> None:
+        doc = server.__doc__ or ""
+        assert "boundary-mcp" in doc
+        assert "kernel-internal" in doc
+
+
+class TestServerToolsHonorIsolatedDB:
+    def test_server_tools_do_not_write_to_real_home_db(self, tmp_path) -> None:
+        """The isolated_db fixture redirects writes; sanity check it works."""
+
+        # The isolated_db fixture set SOCIAL_DB_PATH to tmp_path/social.db.
+        # Recording should hit that file, not the real one.
+        server.record_tick_frame({"attention_target_ref": "x", "ignited": False})
+        assert (tmp_path / "social.db").exists() or any(
+            tmp_path.rglob("social.db")
+        )
 
 
 def test_main_is_importable() -> None:
-    """The console entry point declared in pyproject.toml must exist."""
     assert callable(server.main)
-
-
-def test_reset_store_cache_is_idempotent() -> None:
-    """Calling reset before any cache build must not raise."""
-    server.reset_store_cache()
-    server.reset_store_cache()


### PR DESCRIPTION
## Summary

Designed by 7-agent workflow (Map+Inventory × 2 / Design × 1 / Critique × 3 / Synthesis × 1) — full transcript reasoning is in the synthesis. Closes the integration gap that was sitting after PRs #93–#97: Phase 2.1–2.5 typed records existed only as Python imports until now.

### Three changes

| Change | File(s) | Why |
|---|---|---|
| **11 new MCP tools** | \`server.py\` + \`test_server.py\` | wraps TickFrameStore / AttentionSchemaTracker / HORStore / introspect into MCP surface |
| **\`.mcp.json.example\` registration** | \`.mcp.json.example\` | without this, the FastMCP server exists but no agent can call its tools (this is also why the Phase 2.1 tools weren't reachable before — confirmed by grep) |
| **/recover-from-compact wiring** | \`.claude/commands/recover-from-compact.md\` | Step 3.5 calls \`compose_introspection_report(window_hours=24)\` — the one concrete scenario where the read surface alone is sufficient for observable behavior change |

### MCP tool surface added (11)

| Tool | Wraps |
|---|---|
| \`record_tick_frame\` / \`get_tick_frame\` / \`query_tick_frames\` | TickFrameStore (Phase 2.3) |
| \`record_attention_schema\` / \`update_attention_from_frame\` / \`flush_attention_schemas\` / \`summarize_attention_schema\` | AttentionSchemaTracker + reflect_attention_schema (Phase 2.4) |
| \`record_hor\` / \`get_hor\` / \`query_hors\` | HORStore (Phase 2.5) |
| \`compose_introspection_report\` | introspect composer (Phase 2.5) |

### Naming discipline (per consciousness-mcp/AGENTS.md)

Two MCP tool names diverge from their Python function names by design:
- \`reflect_attention_schema\` (Python) → \`summarize_attention_schema\` (MCP)
- \`introspect\` (Python) → \`compose_introspection_report\` (MCP)

The Python names are protected by the AGENTS.md exception clause (internal technical code); MCP-visible tool names are the highest-visibility line in any tool inventory the agent sees, so they need to stay functional-only.

### Intentional non-exposures

- \`validate_hor_content\` stays internal (embedded inside \`compose_introspection_report\` output)
- \`ActionBottleneck.commit_action\` stays internal (waits for tick producer wiring in follow-up PR)
- \`extract_counterfactuals_from_plan\` stays Python-only (orchestrator-side)

### Phase 1 integration (load-bearing)

\`compose_introspection_report.canonical_statement\` is rendered from \`HORRecord.asserted_content\` (EpistemicClaim-projectable via \`HORRecord.to_epistemic_claim\`). Each \`query_hors\` result projects via the same path. \`validate_hor_content\` (internal) uses the agent-grammar PEG combinators (\`lit/seq/alt\`) as its parser — the package's first real consumer, now reachable through the MCP composer.

### Test plan

- [x] **13 new test cases** in \`test_server.py\` (Phase 2.1 surface still present, 11 new tools importable, stores dataclass shape, tick frame round-trip, attention schema record/flush/summarize, frame→attention projection with missing-frame error, HOR round-trip, introspection-report integration of HOR+attention+counterfactual, empty-state report, boundary-policy docstring, DB isolation)
- [x] **168 individual-kernel-mcp tests pass** (was 155)
- [x] **ruff clean**
- [x] DB isolation fixture (\`SOCIAL_DB_PATH\` env override + autouse \`reset_store_cache\`) verified to write to tmp_path, not \`~/.claude/social.db\`
- [ ] Manual: restart Claude Code with updated \`.mcp.json\`, run \`/recover-from-compact\`, confirm Step 3.5 MCP call lands

### Open follow-ups (NOT in this PR)

- Tick producer + \`commit_action\` MCP exposure → separate PR (depends on the tick-cadence decision)
- \`sleep_consolidation\` calling memory-mcp \`consolidate_memories\` / \`recall_divergent\` → separate PR
- \`memory-mcp.store.py.recall_divergent\` switching to Phase 2.2 ignition API → separate PR
- joint-attention-mcp extension for per-person_id AttentionSchema/HOR (ToM) → Phase 2.4.1 / 2.5.1