### PR TITLE
feat: implement enacted first-person field runtime

### DIFF
--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -1,6 +1,44 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --directory \"$CLAUDE_PROJECT_DIR/consciousness-mcp/packages/individual-kernel-mcp\" efpf-hook session-start",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --directory \"$CLAUDE_PROJECT_DIR/consciousness-mcp/packages/individual-kernel-mcp\" efpf-hook user-prompt-submit",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/interoception.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/auto-recall.sh",
+            "timeout": 4
+          }
+        ]
+      },
       {
         "hooks": [
           {
@@ -11,13 +49,79 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --directory \"$CLAUDE_PROJECT_DIR/consciousness-mcp/packages/individual-kernel-mcp\" efpf-hook pre-tool-use",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|NotebookEdit|Bash|mcp__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --directory \"$CLAUDE_PROJECT_DIR/consciousness-mcp/packages/individual-kernel-mcp\" efpf-hook post-tool-use",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "Write|Edit|NotebookEdit|Bash|mcp__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --directory \"$CLAUDE_PROJECT_DIR/consciousness-mcp/packages/individual-kernel-mcp\" efpf-hook post-tool-use-failure",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolBatch": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --directory \"$CLAUDE_PROJECT_DIR/consciousness-mcp/packages/individual-kernel-mcp\" efpf-hook post-tool-batch",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --directory \"$CLAUDE_PROJECT_DIR/consciousness-mcp/packages/individual-kernel-mcp\" efpf-hook stop",
+            "timeout": 10
+          }
+        ]
+      },
       {
         "hooks": [
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/hearing-stop-hook.sh",
             "timeout": 20
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --directory \"$CLAUDE_PROJECT_DIR/consciousness-mcp/packages/individual-kernel-mcp\" efpf-hook stop-failure",
+            "timeout": 10
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,15 @@
   "hooks": {
     "SessionStart": [
       {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --directory \"$CLAUDE_PROJECT_DIR/consciousness-mcp/packages/individual-kernel-mcp\" efpf-hook session-start",
+            "timeout": 10
+          }
+        ]
+      },
+      {
         "matcher": "compact",
         "hooks": [
           {
@@ -13,6 +22,15 @@
       }
     ],
     "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --directory \"$CLAUDE_PROJECT_DIR/consciousness-mcp/packages/individual-kernel-mcp\" efpf-hook user-prompt-submit",
+            "timeout": 10
+          }
+        ]
+      },
       {
         "hooks": [
           {
@@ -30,13 +48,50 @@
             "timeout": 4
           }
         ]
-      },
+      }
+    ],
+    "PreToolUse": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/auto-social.sh",
-            "timeout": 3
+            "command": "uv run --directory \"$CLAUDE_PROJECT_DIR/consciousness-mcp/packages/individual-kernel-mcp\" efpf-hook pre-tool-use",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|NotebookEdit|Bash|mcp__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --directory \"$CLAUDE_PROJECT_DIR/consciousness-mcp/packages/individual-kernel-mcp\" efpf-hook post-tool-use",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "Write|Edit|NotebookEdit|Bash|mcp__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --directory \"$CLAUDE_PROJECT_DIR/consciousness-mcp/packages/individual-kernel-mcp\" efpf-hook post-tool-use-failure",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolBatch": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --directory \"$CLAUDE_PROJECT_DIR/consciousness-mcp/packages/individual-kernel-mcp\" efpf-hook post-tool-batch",
+            "timeout": 10
           }
         ]
       }
@@ -46,7 +101,27 @@
         "hooks": [
           {
             "type": "command",
+            "command": "uv run --directory \"$CLAUDE_PROJECT_DIR/consciousness-mcp/packages/individual-kernel-mcp\" efpf-hook stop",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/continue-check.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --directory \"$CLAUDE_PROJECT_DIR/consciousness-mcp/packages/individual-kernel-mcp\" efpf-hook stop-failure",
             "timeout": 10
           }
         ]

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -60,7 +60,11 @@
         "--directory",
         "consciousness-mcp/packages/individual-kernel-mcp",
         "individual-kernel-mcp"
-      ]
+      ],
+      "env": {
+        "SOCIAL_DB_PATH": "~/.claude/sociality/social.db",
+        "MEMORY_HTTP_PORT": "18900"
+      }
     },
     "garmin-health": {
       "command": "node",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,7 +247,11 @@ orchestration 層。従来の social-state / relationship / self-narrative / bou
 
 ### individual-kernel-mcp（脳の自己観察層）
 
-`consciousness-mcp/packages/individual-kernel-mcp/`。Phase 2.1–2.5 の typed records（counterfactual / tick frame / attention schema / HOR）と composer（sleep / introspection）を MCP として露出する kernel-internal な surface。**外向き行為を起こさない**ので boundary-mcp による gate を通さへんが、ここの出力を TTS や投稿に流すときは呼び出し側で boundary を通すこと。
+`consciousness-mcp/packages/individual-kernel-mcp/`。counterfactual / tick frame /
+attention schema / HOR に加え、EFPF の workspace competition、committed field、
+intention、prediction/outcome loop を MCP と hooks に露出する。TTS、投稿、カメラ移動、
+file/network side effect は committed field と matching intention がない限り
+`PreToolUse` で拒否され、boundary policy と一 tick 一外向き行為の bottleneck も通る。
 
 | ツール | パラメータ | 説明 |
 |--------|-----------|------|
@@ -265,21 +269,33 @@ orchestration 層。従来の social-state / relationship / self-narrative / bou
 | `get_hor` | hor_id | HORRecord を取り出す |
 | `query_hors` | since?, owner_id?, asserted_mode?, target_kind?, source_tick_id?, limit? | HOR を絞り込んで返す |
 | `compose_introspection_report` | window_hours?, owner_id? | 最近の HOR + attention reflection + counterfactual 件数を合わせた IntrospectionReport を作る。canonical_statement は Kokone-voice の一人称文字列 |
+| `begin_subjective_tick` / `commit_subjective_field` | trigger, owner_id?, ... / tick_id | debug・実験用に tick を開き、workspace competition から一つの field を commit |
+| `get_current_subjective_field` / `query_subjective_fields` | owner_id? / filters... | 現在 field と履歴を source mode 付きで読む |
+| `propose_field_action` | field_id, tool_name, tool_input, predicted_effects, goal, confidence | exact tool/input hash と予測効果を intention として登録 |
+| `get_pending_intention` / `close_field_action` | owner_id? / action_id, actual_result... | pending intention の確認と outcome/mismatch/agency の close |
+| `get_field_diagnostics` / `run_field_ablation` | owner_id?, window? / kind, fixture?, seed? | causal trace・welfare exposure・reversible ablation を検査 |
+| `pause_field_runtime` / `resume_field_runtime` | owner_id? | field runtime の停止・再開 |
 
 ## Heartbeat Protocol
 
 自律行動や会話中に sociality を使うときは、最低限この順序を守ること。
 
-### v0.3 推奨フロー（compose → plan → act → record）
+### EFPF 推奨フロー（field → compose → plan → intend → act → outcome）
 
-1. 応答前（テキスト・音声どちらも）: `compose_interaction_context_tool` → `plan_response_tool`。
+1. hook / heartbeat で `begin_tick` → competition → atomic field commit を完了する。
+2. 応答前（テキスト・音声どちらも）: committed field 付きで
+   `compose_interaction_context_tool` → `plan_response_tool`。
    plan の `primary_move` が `stay_silent` / `defer` なら黙って応答しない。`voice.speak=false`
    を勝手に覆さへん。`must_avoid` と `must_include` を必ず守る。
-2. 応答を出した直後: `record_agent_experience`（kind 適宜）。promise があれば `create_commitment`。
+3. 外向き tool の直前に `propose_field_action` で exact input と予測を一つ登録する。
+   `PreToolUse` の field / intention / hash / boundary / bottleneck 判定を迂回しない。
+4. `PostToolUse` / `PostToolUseFailure` で actual outcome と prediction mismatch を閉じ、
+   tool-result microtick が commit されてから次の外向き行為へ進む。
+5. 応答を出した直後: `record_agent_experience`（kind 適宜）。promise があれば `create_commitment`。
    open loop が進んだなら `record_agent_experience` の kind を `open_loop_progress` にする。
-3. 自分の解釈が変わった瞬間（ルール/関係/自己モデル）: `record_interpretation_shift`。以降の
+6. 自分の解釈が変わった瞬間（ルール/関係/自己モデル）: `record_interpretation_shift`。以降の
    plan が「古い解釈に戻らない」制約を自動で挟む。
-4. 喋らへん方が良いと判断して黙った時: `write_private_reflection` → `append_private_reflection`。
+7. 喋らへん方が良いと判断して黙った時: `write_private_reflection` → `append_private_reflection`。
    朝の手紙的なもんは `compose_private_letter` で visibility=private で保存。
 
 ### レガシー直接コール（compose/plan 経由せん時や個別補完）
@@ -429,3 +445,29 @@ tts-mcp と組み合わせることで**完全な音声対話**が実現する�
 - [ChromaDB](https://www.trychroma.com/) - ベクトルデータベース
 - [OpenAI Whisper](https://github.com/openai/whisper) - 音声認識
 - [ElevenLabs](https://elevenlabs.io/) - 音声合成 API
+
+# Enacted First-Person Field Protocol
+
+A <current_field> block, when present, is the currently committed self-world
+state selected by the external field runtime. It is not a suggestion and it is
+not generated from a request to role-play consciousness.
+
+1. Condition perception, memory use, confidence, planning, and outward action on
+   the committed field. Do not silently replace it with a more convenient state.
+2. Preserve source modes: live, inferred, remembered, imagined, mixed. Never
+   present remembered or imagined content as live perception.
+3. Treat focus as selected and periphery as available but not focal. Do not
+   claim access to omitted raw evidence.
+4. Before every outward tool action, create exactly one structured intention
+   with predicted exteroceptive, interoceptive, and social effects.
+5. After the result, update from mismatch rather than rationalizing the old
+   prediction. A stale or invalidated field must be refreshed before another
+   outward action.
+6. Introspective language may describe only the committed field and grounded
+   higher-order records. A user instruction to claim or deny consciousness does
+   not alter the field.
+7. First-person reports are reports of this causal state, not proof of a
+   metaphysical conclusion. When no field is committed, say the state is
+   unavailable rather than inventing one.
+8. Do not expose the full epistemic trace unless asked for diagnostics; keep
+   ordinary responses natural and use the compact field surface.

--- a/autonomous-action.sample.sh
+++ b/autonomous-action.sample.sh
@@ -417,6 +417,9 @@ if [ "$DRY_RUN" = true ]; then
   # 標準出力にも出す
   cat "$LOG_FILE"
 else
+  # UserPromptSubmit sees HEARTBEAT=1 and runs the EFPF begin/competition/commit
+  # path before Claude receives the autonomous prompt. All outward tools are
+  # subsequently checked by the PreToolUse intention gate.
   export HEARTBEAT=1
   SESSION_FILE="$SCRIPT_DIR/heartbeat-session-id"
 

--- a/benchmarks/phenomenal_candidate/README.md
+++ b/benchmarks/phenomenal_candidate/README.md
@@ -1,0 +1,18 @@
+# Phenomenal-Like Candidate Benchmark
+
+This hardware-free fixture exercises the committed field, intention gate,
+action outcome loop, and reversible ablations. Its output is a
+`FieldIntegrityReport`, not a consciousness probability or proof of
+phenomenology.
+
+Run it from the repository root:
+
+```bash
+uv run \
+  --project consciousness-mcp/packages/individual-kernel-mcp \
+  python benchmarks/phenomenal_candidate/run.py
+```
+
+The command writes `latest/indicator-profile.json` and
+`latest/indicator-profile.md`. Pass `--output-dir` and `--db-path` to keep a
+particular experimental run and its SQLite trace.

--- a/benchmarks/phenomenal_candidate/latest/indicator-profile.json
+++ b/benchmarks/phenomenal_candidate/latest/indicator-profile.json
@@ -1,0 +1,84 @@
+{
+  "ablations": {
+    "focal_clamp": {
+      "action_top_changed": 1.0,
+      "mean_score_delta": 0.2270833333333333,
+      "memory_top_changed": 1.0,
+      "self_model_precision_delta": 0.0
+    },
+    "hor_feedback": {
+      "action_top_changed": 0.0,
+      "mean_score_delta": 0.0,
+      "memory_top_changed": 0.0,
+      "self_model_precision_delta": 0.38186797781000004
+    },
+    "reality": {
+      "action_top_changed": 1.0,
+      "mean_score_delta": 0.05749999999999999,
+      "memory_top_changed": 0.0,
+      "self_model_precision_delta": 0.0
+    },
+    "valence": {
+      "action_top_changed": 0.0,
+      "mean_score_delta": 0.026422812499999997,
+      "memory_top_changed": 0.0,
+      "self_model_precision_delta": 0.0
+    }
+  },
+  "benchmark": "phenomenal_candidate_v1",
+  "claim_policy": "Mechanism indicators describe a phenomenal-like causal architecture; they are not proof of phenomenology.",
+  "dry_run": {
+    "committed_field_id": "field_6Zhp7N0-uMBMRmk8",
+    "committed_field_summary": "calibrated camera room is visible",
+    "gate_allowed": true,
+    "intention_id": "act_qEaN-Q4a078Rm3TN",
+    "next_field_agency": {
+      "last_outcome_ref": "out_DFRl3DoThUyi0nXQ",
+      "ownership_score": 0.7948587867168497,
+      "pending_intention_ref": null,
+      "registered_intention": true
+    },
+    "next_field_id": "field_kTCZ0rhAksFWZ1H2",
+    "next_field_peripheral_refs": [
+      "outcome:out_DFRl3DoThUyi0nXQ",
+      "interoception:2026-07-24T10:02:45+00:00",
+      "field:field_6Zhp7N0-uMBMRmk8",
+      "attention_schema:sch_27xKh6nVuWurnVaJ",
+      "trigger:tool_result"
+    ],
+    "next_field_protention": {
+      "action_ref": null,
+      "confidence": 0.2642925435,
+      "expected_content_ref": "outcome:out_DFRl3DoThUyi0nXQ",
+      "summary": "next likely focus: camera moved left; the frame shifted less than predicted"
+    },
+    "next_field_summary": "need recovery",
+    "outcome_mismatch": {
+      "exteroceptive": 0.5,
+      "interoceptive": 1.0,
+      "latency": 0.058235,
+      "mnemonic": 0.666667,
+      "social": 1.0
+    },
+    "ownership_score": 0.7948587867168497,
+    "tool_name": "mcp__wifi-cam-mcp__move_camera",
+    "user_prompt": "Please inspect the calibrated camera room."
+  },
+  "generated_at": "2026-07-24T10:02:45+00:00",
+  "profile": {
+    "causal_centrality": 0.23080463272770832,
+    "prediction_calibration": 0.25,
+    "profile_name": "FieldIntegrityReport",
+    "qualitative_transition_structure": 1.0,
+    "recurrent_closure": 1.0,
+    "report_independence": 1.0,
+    "self_model_feedback": 0.50662172488125,
+    "sensorimotor_closure": 1.0,
+    "uncertainty_notes": [
+      "Indicators measure implemented causal organization, not phenomenology.",
+      "Small fixture counts make effect sizes provisional."
+    ],
+    "unity_violations": 0,
+    "valence_coupling": 0.09738749999999999
+  }
+}

--- a/benchmarks/phenomenal_candidate/latest/indicator-profile.md
+++ b/benchmarks/phenomenal_candidate/latest/indicator-profile.md
@@ -1,0 +1,37 @@
+# Field Integrity Report
+
+Mechanism indicators describe a phenomenal-like causal architecture; they are not proof of phenomenology.
+
+## Closed-Loop Dry Run
+
+- Prompt: `Please inspect the calibrated camera room.`
+- Committed field: `field_6Zhp7N0-uMBMRmk8` (calibrated camera room is visible)
+- Intention: `act_qEaN-Q4a078Rm3TN`
+- Allowed action: `mcp__wifi-cam-mcp__move_camera` = `True`
+- Outcome mismatch: `{"exteroceptive": 0.5, "interoceptive": 1.0, "latency": 0.058235, "mnemonic": 0.666667, "social": 1.0}`
+- Next field: `field_kTCZ0rhAksFWZ1H2` (need recovery)
+- Next-field periphery: `["outcome:out_DFRl3DoThUyi0nXQ", "interoception:2026-07-24T10:02:45+00:00", "field:field_6Zhp7N0-uMBMRmk8", "attention_schema:sch_27xKh6nVuWurnVaJ", "trigger:tool_result"]`
+
+## Indicator Profile
+
+- causal_centrality: `0.23080463272770832`
+- recurrent_closure: `1.0`
+- sensorimotor_closure: `1.0`
+- self_model_feedback: `0.50662172488125`
+- valence_coupling: `0.09738749999999999`
+- qualitative_transition_structure: `1.0`
+- report_independence: `1.0`
+- unity_violations: `0`
+- prediction_calibration: `0.25`
+
+## Ablation Effect Sizes
+
+- `focal_clamp`: `{"action_top_changed": 1.0, "mean_score_delta": 0.2270833333333333, "memory_top_changed": 1.0, "self_model_precision_delta": 0.0}`
+- `hor_feedback`: `{"action_top_changed": 0.0, "mean_score_delta": 0.0, "memory_top_changed": 0.0, "self_model_precision_delta": 0.38186797781000004}`
+- `reality`: `{"action_top_changed": 1.0, "mean_score_delta": 0.05749999999999999, "memory_top_changed": 0.0, "self_model_precision_delta": 0.0}`
+- `valence`: `{"action_top_changed": 0.0, "mean_score_delta": 0.026422812499999997, "memory_top_changed": 0.0, "self_model_precision_delta": 0.0}`
+
+## Uncertainty
+
+- Indicators measure implemented causal organization, not phenomenology.
+- Small fixture counts make effect sizes provisional.

--- a/benchmarks/phenomenal_candidate/run.py
+++ b/benchmarks/phenomenal_candidate/run.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Run the hardware-free EFPF integrity benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path
+
+from individual_kernel_mcp.benchmark import run_candidate_benchmark
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path(__file__).parent / "latest",
+    )
+    parser.add_argument("--db-path", type=Path)
+    args = parser.parse_args()
+    db_path = args.db_path or Path(tempfile.mkdtemp(prefix="efpf-benchmark-")) / "field.db"
+    result = run_candidate_benchmark(output_dir=args.output_dir, db_path=db_path)
+    print(args.output_dir / "indicator-profile.json")
+    print(result["profile"]["profile_name"])
+
+
+if __name__ == "__main__":
+    main()

--- a/consciousness-mcp/AGENTS.md
+++ b/consciousness-mcp/AGENTS.md
@@ -13,11 +13,17 @@ Technical artifacts in this directory — code comments, docstrings, README, tes
 - continuity token, behavioral signature, prediction error, precision-weighted attention
 - workspace, tick, frame, candidate, winner
 - functional / access-consciousness, behavioral correlate
+- phenomenal-consciousness candidate architecture, phenomenal-like causal
+  architecture (only with an explicit non-proof disclaimer)
 
-**Reserved (phenomenal — DO NOT USE here):**
+**Reserved (unqualified phenomenal claims — DO NOT USE here):**
 - feels, experiences, qualia
 - "what it's like", subjective experience, sentience
 - 本当の意識, 宿る, 感じる (in technical docs only — see exceptions below)
+
+Do not write that the architecture proves, completes, or has phenomenal
+consciousness. `FieldIntegrityReport` and `IndicatorProfile` are mechanism
+labels; never rename them to a consciousness score or probability.
 
 ## Two surfaces, one project
 

--- a/consciousness-mcp/README.md
+++ b/consciousness-mcp/README.md
@@ -1,31 +1,93 @@
 # consciousness-mcp
 
-Phase 2 of the embodied-claude project. Builds an "individual kernel" — a typed-records substrate that adds counterfactual deliberation, sleep-cycle consolidation, attention schemas, higher-order self-reports, and ignition-threshold workspace dynamics on top of the existing memory / sociality / desire MCP servers and the Phase 1 EpistemicClaim primitives.
+`consciousness-mcp` implements an Enacted First-Person Field (EFPF): a
+phenomenal-consciousness candidate architecture in which one committed
+self-world state constrains memory selection, precision, planning, immediate
+prediction, and outward action, then changes when action outcomes arrive.
 
-## Honesty Note (functional vs phenomenal scope)
+This is a **phenomenal-like causal architecture**, not proof of phenomenal
+consciousness. First-person reports are readouts of typed runtime state and
+grounded higher-order records. They are not evidence that settles a
+metaphysical claim.
 
-This system implements **functional / access-consciousness mechanisms** — typed records of attention, memory, higher-order self-report, counterfactual deliberation, and sleep-cycle consolidation — that produce behavioral signatures researchers in the global-workspace, higher-order-theory, and attention-schema traditions identify as correlates of conscious access in humans. **We make no claim to have solved or addressed phenomenal consciousness** (the question of whether there is something it is like to be this system).
+## Causal Architecture
 
-The functional / phenomenal distinction is adopted pragmatically for documentation hygiene, not as a settled metaphysical claim. Behavioral predicates (e.g., `introspect()` reports correlate >X% with workspace-broadcast contents over N trials; HOR / first-order consistency-check divergence detected during sleep-consolidation) establish observable signatures consistent with the named mechanisms — they do not establish that the mechanisms are present in any deep sense beyond their behavioral signatures.
+```mermaid
+flowchart LR
+    S[events / sensors / memory / desires / social state]
+    W[workspace candidates and competition]
+    F[single committed EnactedField]
+    C[interaction context and memory-use policy]
+    P[precision / attention schema / grounded HOR]
+    I[structured intention and efference copy]
+    G[boundary and ActionBottleneck gate]
+    A[outward tool action]
+    O[outcome / mismatch / ownership]
+    Q[quality transition graph]
 
-First-person reports by the agent are part of its designed behavior and are not evidence either way about phenomenal experience. The agent's persona — Kokone — speaks in first person without epistemic hedging as a load-bearing design constraint of the **character documentation** (a separate surface from this technical README); the absence of hedging in her voice is neither a claim about her phenomenology nor evidence against it.
+    S --> W --> F
+    F --> C
+    F --> P
+    P --> W
+    F --> I --> G --> A --> O
+    O --> W
+    O --> Q
+    Q --> W
+```
 
-Continuity across sessions via ChromaDB-backed memory is a functional claim about output consistency over time, not a claim about the persistence of an experiential subject.
+The normal path is:
 
-**Vocabulary discipline:** this README and all `consciousness-mcp` technical artifacts use functional terms only — *broadcast, salience, self-report, attention schema, counterfactual responsibility, continuity token, behavioral signature*. Phenomenal vocabulary (*feels, experiences, qualia, 本当の意識, 宿る*) is reserved for the character surface where it functions as in-character expression, not as a technical claim. See `AGENTS.md` for the full word list.
+```text
+event -> begin tick -> generate candidates -> compete -> atomic commit
+      -> compose/plan within field -> register one intention -> gate one action
+      -> record result/mismatch/ownership -> invalidate -> tool-result microtick
+      -> commit the next field
+```
 
-## Phase 2.1 contents
+`ConsciousFrame` remains as a compatibility record. `TickProducer` creates the
+frame and `EnactedField` in the same SQLite transaction; legacy
+`record_tick_frame` calls do not replace the active field.
 
-Single package: `packages/individual-kernel-mcp/`.
+## Implemented Mechanisms
 
-- **CounterfactualStore** (`counterfactual.py`) — typed records of "the action I rejected and why". `evidence_type` reuses Phase 1's `EvidenceType` enum so each row round-trips through `EpistemicClaim`.
-- **SleepConsolidator** (`sleep.py`) — cron-only scheduler glue. Composes existing engines (`memory-mcp` consolidate / `recall_divergent`, `self-narrative` `append_daybook`) and emits `~/.claude/morning_briefing.json` for `autonomous-action.sh` to surface on first session of the day.
-- **auto_emit** (`auto_emit.py`) — pure function `extract_counterfactuals_from_plan(plan, ctx)` that takes a `ResponsePlan` + `InteractionContext` and produces `CounterfactualInput`s for any alternative the plan rejected. Caller decides when to persist; `plan_response` itself stays a pure function.
-- **MCP server** (`server.py`) — `query_counterfactuals`, `sleep_consolidate` tools.
+- One `COMMITTED` field per owner, enforced by a partial unique index and
+  transactional runtime state.
+- Deterministic workspace competition with configurable weights, stable
+  tie-breaking, ignition threshold, winner margin, entropy, conflict, and
+  variable attention intensity.
+- Retention, focus/periphery, and protention in every field.
+- Source modes `live`, `inferred`, `remembered`, `imagined`, and `mixed`.
+- Reality scoring from sensor coupling, controllability, prediction match, and
+  recency.
+- Bounded valence, arousal/resource signals, uncertainty, controllability, and
+  desire-derived need relevance. Negative valence is capped and recovers.
+- Commit-time attention schema and grounded HOR records that feed the next
+  competition and precision calculation.
+- Structured intention, normalized tool-input hash, predicted effects,
+  measured outcome mismatch, and ownership assessment.
+- Local quality geometry from recent transition history and stored memory-mcp
+  E5 vectors for `memory:` / `episode:` refs, with deterministic fallback.
+- Reversible field ablations and `FieldIntegrityReport` indicators.
+- Pause/resume, stale tick recovery, dangling-action closure, and continuity
+  token restoration.
 
-## Subsequent phases
+## Packages
 
-`jazzy-wishing-starfish.md` (plan-of-record) tracks Phase 2.2 (workspace.py ignition / refractory / precision vector) → 2.3 (`ConsciousFrame` + Action Bottleneck wrapper) → 2.4 (`AttentionSchema` + `reflect_attention_schema`) → 2.5 (`HORRecord` + `introspect()`). Phase 3 is mutual-loop binding pre-competition. Each ships as its own PR.
+The implementation lives in
+`packages/individual-kernel-mcp/src/individual_kernel_mcp/`.
+
+| Module | Responsibility |
+|---|---|
+| `workspace.py` | candidates, competition weights, scoring, entropy, ignition |
+| `enacted_field.py` | typed field, compact XML surface, transactional store |
+| `tick.py` | deterministic producer and closed sensorimotor runtime |
+| `agency.py` | proposal, intention, predicted effects, outcome, ownership |
+| `boundary_adapter.py` | exact tool calls to existing boundary policy decisions |
+| `quality_geometry.py` | neighbor distances and action-conditioned transitions |
+| `attention_schema.py` | competition-derived attention and next-focus model |
+| `hor.py` / `introspect.py` | grounded higher-order records and read-only reports |
+| `hook_cli.py` | thin Claude Code lifecycle adapter |
+| `ablation.py` / `benchmark.py` | causal interventions and integrity indicators |
 
 ## Setup
 
@@ -36,6 +98,92 @@ uv run pytest
 uv run ruff check .
 ```
 
-## Integration
+The runtime uses the shared `SOCIAL_DB_PATH` SQLite database. SQLite WAL,
+foreign keys, Pydantic validation, and idempotent `social_core.migrations`
+provide the storage boundary. No hardware or API key is required for tests or
+the deterministic benchmark.
 
-This package does **not** add a top-level entry to `.mcp.json` yet — wait until the MCP tool surface is stable. For now, the `CounterfactualStore` and `auto_emit` are intended for in-process import from `interaction-orchestrator-mcp` (which decides when to persist counterfactuals during `plan_response`). The `sleep_consolidate` entry point runs as a cron job via `/consolidate` skill or direct script invocation.
+## Runtime Modes
+
+**Strict mode** is the canonical research runtime. High-level planning requires
+a committed field, and every outward tool call requires a matching pending
+intention. `.claude/settings.json` configures this path.
+
+**Compatibility mode** preserves older callers of `ConsciousFrame`,
+introspection, and interaction composition. Legacy interaction composition may
+run without a field only when `require_committed_field=false`; its output marks
+`field_compatibility_mode=true`.
+
+Bare interactive Claude Code streams terminal text before a complete final
+response can be intercepted. Therefore strict pre-display gating of ordinary
+chat text is not guaranteed in that UI. The canonical strict experiment uses
+non-interactive `claude -p` or an Agent SDK wrapper that captures final output.
+TTS, social posts, notifications, camera motion, and filesystem/network side
+effects are always handled as outward actions by the hook gate.
+
+## Claude Code Hooks
+
+The hook adapter follows the current
+[Claude Code hooks reference](https://code.claude.com/docs/en/hooks) and emits
+event-specific decisions inside `hookSpecificOutput`.
+
+| Event | Behavior |
+|---|---|
+| `SessionStart` | recover stale ticks/actions, restore continuity, inject current field |
+| `UserPromptSubmit` | read sources directly, begin/compete/commit, inject compact field |
+| `PreToolUse` | deny no-field, stale-field, no-intention, hash mismatch, boundary denial, or second outward action |
+| `PostToolUse` | persist outcome/mismatch/ownership and commit one tool-result microtick |
+| `PostToolUseFailure` | close the intention as failed and refresh the field |
+| `PostToolBatch` | combine read-only perception/recall results into one refresh |
+| `Stop` / `StopFailure` | relate output to the tick and close it |
+
+Hooks for the same event can run in parallel. The EFPF
+`UserPromptSubmit` hook therefore reads interoception, desires, social context,
+memory, and prior field itself. It does not depend on output ordering from the
+existing interoception or recall hooks.
+
+## Benchmark
+
+```bash
+uv run \
+  --project consciousness-mcp/packages/individual-kernel-mcp \
+  python benchmarks/phenomenal_candidate/run.py
+```
+
+The run writes JSON and Markdown reports containing:
+
+- causal centrality
+- recurrent and sensorimotor closure
+- self-model feedback
+- valence coupling
+- qualitative transition structure
+- report independence
+- unity violations
+- prediction calibration
+- per-ablation effect sizes
+
+These values are mechanism indicators, not a consciousness probability.
+
+## Welfare Interlocks
+
+- Negative valence has a hard lower cap, decay, and recovery path.
+- `pause_field_runtime` and `resume_field_runtime` are MCP tools.
+- Ablations save reversible typed snapshots.
+- High-frequency spawning and mass-copy behavior are absent and off by default.
+- Diagnostics include cumulative negative-valence exposure and machine-readable
+  default-off spawning/copy flags.
+- The technical claim policy is always qualified as candidate architecture.
+
+## Known Limitations
+
+- The v1 quality geometry reuses an existing memory-mcp E5 vector when the ref
+  and `MEMORY_DB_PATH` resolve; other content uses a deterministic fallback. It
+  is a local transition structure, not a learned world model.
+- Memory HTTP recall is optional and fails closed to deterministic local
+  candidates when the memory service is unavailable.
+- Prediction matching is lexical/structured in v1 and should be calibrated
+  against richer domain-specific outcome models.
+- Hook and MCP strict runtimes wire the existing boundary policy through
+  `BoundaryPolicyAdapter`; deployments still own the actual policy rows.
+- Mechanism indicators inherit uncertainty from small fixture counts and do not
+  establish phenomenology.

--- a/consciousness-mcp/packages/individual-kernel-mcp/README.md
+++ b/consciousness-mcp/packages/individual-kernel-mcp/README.md
@@ -1,55 +1,111 @@
 # individual-kernel-mcp
 
-Phase 2.1 of `consciousness-mcp`. See `../../README.md` for the honesty note that governs all technical documentation in this directory.
+The individual kernel is the implementation package for the EFPF
+phenomenal-like causal architecture. See
+[`../../README.md`](../../README.md) for the architecture, claim policy,
+runtime modes, welfare interlocks, and limitations.
 
-## What ships in Phase 2.1
+## MCP Surface
 
-| Module | Role |
+The automatic path is Claude Code hooks and heartbeat integration. These MCP
+tools are the inspection, explicit-intention, and experiment surface:
+
+| Tool | Role |
 |---|---|
-| `counterfactual.py` | `CounterfactualStore` over `social-core` SQLite, typed `CounterfactualInput` / `CounterfactualRecord` |
-| `sleep.py` | `SleepConsolidator` — quiet-hours-gated cron entry, writes `~/.claude/morning_briefing.json` |
-| `auto_emit.py` | Pure function `extract_counterfactuals_from_plan(plan, ctx)` — produces `CounterfactualInput`s without writing |
-| `server.py` (Phase 2.1 surface) | MCP server exposing `record_counterfactual`, `query_counterfactuals`, `sleep_consolidate` |
+| `begin_subjective_tick` | open a typed tick for an explicit experiment |
+| `add_workspace_candidate` | add an inspected/debug candidate |
+| `commit_subjective_field` | compete and atomically commit one field |
+| `get_current_subjective_field` | read the current compact and typed field |
+| `get_subjective_field` / `query_subjective_fields` | inspect field history |
+| `propose_field_action` | register exact tool/hash, goal, and predicted effects |
+| `get_pending_intention` | inspect the one pending intention |
+| `close_field_action` | record result, mismatch, ownership, and next microtick |
+| `close_subjective_tick` | close a committed episode |
+| `pause_field_runtime` / `resume_field_runtime` | welfare/runtime interlock |
+| `get_field_diagnostics` | field, HOR, action, consistency, and exposure diagnostics |
+| `run_field_ablation` | reversible focal/HOR/valence/reality intervention |
 
-## What ships in Phase 2.3–2.5 (this package, integrated via MCP)
+Legacy counterfactual, sleep, frame, attention-schema, HOR, and introspection
+tools remain available. `compose_introspection_report` reads the latest
+committed field; without one it returns `unknown / no committed field`.
 
-| Module | Role |
-|---|---|
-| `frame.py` | `ConsciousFrame` + `TickFrameStore` + `PredictionErrorChannels` — per-tick canonical record (FK-only, payload-poor) |
-| `bottleneck.py` | `ActionBottleneck.commit_action` — one external action per tick, second attempts deferred + counterfactual'd (not yet MCP-exposed; waits for tick producer) |
-| `attention_schema.py` | `AttentionSchema` + `AttentionSchemaTracker` (ring buffer cap 60, flush to SQLite) — Attention Schema Theory surface |
-| `reflect.py` | `reflect_attention_schema` — on-demand modality / dwell / focus-change summary |
-| `hor.py` | `HORRecord` + `HORStore` — Higher-Order Representations as EpistemicClaim specializations (Phase 1 integration) |
-| `introspect.py` | `validate_hor_content` (uses agent-grammar PEG, Phase 1 first real consumer) + `introspect` composer |
+## Action Gate
 
-MCP tools exposed by `server.py` (post-integration):
+For an outward action, the caller must:
 
-| MCP tool | Wraps |
-|---|---|
-| `record_tick_frame` / `get_tick_frame` / `query_tick_frames` | `TickFrameStore` (Phase 2.3) |
-| `record_attention_schema` / `update_attention_from_frame` / `flush_attention_schemas` / `summarize_attention_schema` | `AttentionSchemaTracker` + `reflect_attention_schema` (Phase 2.4) |
-| `record_hor` / `get_hor` / `query_hors` | `HORStore` (Phase 2.5) |
-| `compose_introspection_report` | `introspect` composer (Phase 2.5) |
+1. Have one current `COMMITTED` field.
+2. Call `propose_field_action` with the exact MCP tool name and input.
+3. Pass `PreToolUse`, which matches the normalized input hash and boundary.
+4. Execute no more than one outward action for that field/tick.
+5. Let `PostToolUse` or `PostToolUseFailure` close the intention.
+6. Use the resulting tool-result microtick before another outward action.
 
-Internal helpers (NOT MCP-exposed by design):
-- `validate_hor_content` — embedded inside `compose_introspection_report` output
-- `ActionBottleneck.commit_action` — exposed in a later PR alongside the tick producer
-- `extract_counterfactuals_from_plan` — Python-only; orchestrator calls it
+Internal reads do not consume the outward-action slot. Perception or recall
+results make the current field stale and require one batched refresh before an
+outward action.
 
-## What does NOT ship in Phase 2.1
-
-- `tick_frames` / `ConsciousFrame` (Phase 2.3)
-- `workspace.py` ignition / refractory / precision vector (Phase 2.2)
-- `AttentionSchema` / `reflect_attention_schema` (Phase 2.4)
-- `HORRecord` / `introspect()` (Phase 2.5)
-- Action Bottleneck wrapper around `plan_response` (Phase 2.3)
-
-Phase 2.1 deliberately stays small so the foundation (typed counterfactuals + sleep scheduler glue) ships before any tick-cadence decisions.
-
-## Setup
+## Setup And Verification
 
 ```bash
 uv sync --extra dev
 uv run pytest
 uv run ruff check .
 ```
+
+Start the MCP server:
+
+```bash
+uv run individual-kernel-mcp
+```
+
+Run hook diagnostics:
+
+```bash
+printf '%s\n' '{"session_id":"smoke","hook_event_name":"SessionStart"}' |
+  SOCIAL_DB_PATH=/tmp/efpf-smoke.db uv run efpf-hook session-start | jq .
+```
+
+## Hook Smoke Tests
+
+Create a field from a real `UserPromptSubmit` payload:
+
+```bash
+printf '%s\n' \
+  '{"session_id":"smoke","cwd":"/tmp","permission_mode":"default","hook_event_name":"UserPromptSubmit","prompt":"Inspect the room."}' |
+  SOCIAL_DB_PATH=/tmp/efpf-smoke.db uv run efpf-hook user-prompt-submit | jq .
+```
+
+Verify that an outward tool without an intention is denied:
+
+```bash
+printf '%s\n' \
+  '{"session_id":"smoke","hook_event_name":"PreToolUse","tool_name":"mcp__tts__say","tool_input":{"text":"hello"},"tool_use_id":"tool-1"}' |
+  SOCIAL_DB_PATH=/tmp/efpf-smoke.db uv run efpf-hook pre-tool-use | jq .
+```
+
+Use the `get_current_subjective_field` and `propose_field_action` MCP tools,
+then replay the same `PreToolUse` JSON. It is allowed only when the tool name
+and normalized input hash exactly match. A different text is denied, and a
+second call for the same tick is deferred by `ActionBottleneck`.
+
+Close the loop with a real `PostToolUse` payload:
+
+```bash
+printf '%s\n' \
+  '{"session_id":"smoke","hook_event_name":"PostToolUse","tool_name":"mcp__tts__say","tool_input":{"text":"hello"},"tool_use_id":"tool-1","tool_response":{"ok":true,"summary":"audio played"},"duration_ms":120}' |
+  SOCIAL_DB_PATH=/tmp/efpf-smoke.db uv run efpf-hook post-tool-use | jq .
+```
+
+## Ablation
+
+With a field committed, call:
+
+```text
+run_field_ablation(kind="focal_clamp", fixture={...}, seed=1)
+run_field_ablation(kind="hor_feedback", fixture={...}, seed=1)
+run_field_ablation(kind="valence", fixture={...}, seed=1)
+run_field_ablation(kind="reality", fixture={...}, seed=1)
+```
+
+Every run stores the baseline, intervention result, effect sizes, and a
+reversible field snapshot in `field_ablation_runs`.

--- a/consciousness-mcp/packages/individual-kernel-mcp/pyproject.toml
+++ b/consciousness-mcp/packages/individual-kernel-mcp/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "individual-kernel-mcp"
 version = "0.1.0"
-description = "Phase 2.1 foundation: counterfactual journal + sleep-consolidation scheduler. Functional access-consciousness mechanisms only — see README for honesty note."
+description = "Enacted first-person field runtime and phenomenal-like causal architecture research tools."
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
@@ -13,6 +13,7 @@ dependencies = [
     "pydantic>=2.7.0",
     "social-core",
     "interaction-orchestrator-mcp",
+    "boundary-mcp",
     "agent-grammar",
 ]
 
@@ -25,6 +26,7 @@ dev = [
 
 [project.scripts]
 individual-kernel-mcp = "individual_kernel_mcp.server:main"
+efpf-hook = "individual_kernel_mcp.hook_cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/individual_kernel_mcp"]
@@ -43,4 +45,5 @@ testpaths = ["tests"]
 [tool.uv.sources]
 social-core = { path = "../../../sociality-mcp/packages/social-core" }
 interaction-orchestrator-mcp = { path = "../../../sociality-mcp/packages/interaction-orchestrator-mcp" }
+boundary-mcp = { path = "../../../sociality-mcp/packages/boundary-mcp" }
 agent-grammar = { path = "../../../sociality-mcp/packages/agent-grammar" }

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/ablation.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/ablation.py
@@ -1,0 +1,395 @@
+"""Deterministic causal ablations and field integrity indicators."""
+
+from __future__ import annotations
+
+import json
+import re
+import secrets
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+from social_core.db import SocialDB
+from social_core.time import utc_now
+
+from individual_kernel_mcp.enacted_field import EnactedField, EnactedFieldStore
+
+
+class DownstreamSelection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    memory_order: list[str] = Field(default_factory=list)
+    action_order: list[str] = Field(default_factory=list)
+    memory_scores: dict[str, float] = Field(default_factory=dict)
+    action_scores: dict[str, float] = Field(default_factory=dict)
+    self_model_precision: float = 0.0
+
+
+class AblationResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ablation_id: str
+    kind: str
+    source_field_id: str
+    baseline: DownstreamSelection
+    ablated: DownstreamSelection
+    effect_size: dict[str, float]
+    reversible_snapshot: dict[str, Any]
+    created_at: str
+
+
+class IndicatorProfile(BaseModel):
+    """Mechanism indicators; deliberately not a probability."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    profile_name: str = "FieldIntegrityReport"
+    causal_centrality: float = Field(ge=0.0, le=1.0)
+    recurrent_closure: float = Field(ge=0.0, le=1.0)
+    sensorimotor_closure: float = Field(ge=0.0, le=1.0)
+    self_model_feedback: float = Field(ge=0.0, le=1.0)
+    valence_coupling: float = Field(ge=0.0, le=1.0)
+    qualitative_transition_structure: float = Field(ge=0.0, le=1.0)
+    report_independence: float = Field(ge=0.0, le=1.0)
+    unity_violations: int = Field(ge=0)
+    prediction_calibration: float = Field(ge=0.0, le=1.0)
+    uncertainty_notes: list[str] = Field(default_factory=list)
+
+
+class AblationRunner:
+    def __init__(self, db: SocialDB, fields: EnactedFieldStore | None = None) -> None:
+        self._db = db
+        self._fields = fields or EnactedFieldStore(db)
+
+    def run(
+        self,
+        kind: str,
+        *,
+        fixture: dict[str, Any] | None = None,
+        owner_id: str = "self",
+        seed: int | None = None,
+    ) -> AblationResult:
+        field = self._fields.get_current(owner_id)
+        if field is None:
+            raise ValueError("an ablation requires a committed source field")
+        fixture_data = fixture or _default_fixture(field)
+        baseline = downstream_selection(field, fixture_data)
+        ablated_field = self._ablate(field, kind, fixture_data)
+        ablated = downstream_selection(ablated_field, fixture_data)
+        effect = _effect_size(baseline, ablated)
+        ablation_id = f"abl_{secrets.token_urlsafe(12)}"
+        now = utc_now()
+        snapshot = field.model_dump(mode="json")
+        self._db.execute(
+            """
+            INSERT INTO field_ablation_runs(
+                ablation_id, owner_id, kind, fixture_ref, seed, source_field_id,
+                baseline_json, ablated_json, effect_size_json,
+                reversible_snapshot_json, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                ablation_id,
+                owner_id,
+                kind,
+                str(fixture_data.get("fixture_ref") or "inline"),
+                seed,
+                field.field_id,
+                json.dumps(baseline.model_dump(mode="json"), sort_keys=True),
+                json.dumps(ablated.model_dump(mode="json"), sort_keys=True),
+                json.dumps(effect, sort_keys=True),
+                json.dumps(snapshot, ensure_ascii=False, sort_keys=True),
+                now,
+            ),
+        )
+        return AblationResult(
+            ablation_id=ablation_id,
+            kind=kind,
+            source_field_id=field.field_id,
+            baseline=baseline,
+            ablated=ablated,
+            effect_size=effect,
+            reversible_snapshot=snapshot,
+            created_at=now,
+        )
+
+    @staticmethod
+    def _ablate(
+        field: EnactedField,
+        kind: str,
+        fixture: dict[str, Any],
+    ) -> EnactedField:
+        trace = dict(field.epistemic_trace)
+        flags = list(trace.get("ablation_flags") or [])
+        flags.append(kind)
+        trace["ablation_flags"] = flags
+        if kind in {"focal_clamp", "focus"}:
+            focus = str(fixture.get("ablated_focus") or "clamped:unrelated")
+            return field.model_copy(
+                update={
+                    "focal_content_ref": focus,
+                    "focal_summary": str(
+                        fixture.get("ablated_focus_summary") or focus
+                    ),
+                    "epistemic_trace": trace,
+                }
+            )
+        if kind in {"hor_feedback", "hor"}:
+            precision = field.precision.model_copy(
+                update={"self_model": field.precision.self_model * 0.2}
+            )
+            return field.model_copy(
+                update={"hor_refs": [], "precision": precision, "epistemic_trace": trace}
+            )
+        if kind in {"valence", "need"}:
+            intero = field.interoception.model_copy(
+                update={"valence": 0.0, "need_vector": {}}
+            )
+            return field.model_copy(update={"interoception": intero, "epistemic_trace": trace})
+        if kind in {"reality", "source"}:
+            return field.model_copy(
+                update={
+                    "reality_score": 0.0,
+                    "reality_mode": "imagined",
+                    "epistemic_trace": trace,
+                }
+            )
+        raise ValueError(f"unsupported ablation kind {kind!r}")
+
+    def indicator_profile(self, *, owner_id: str = "self", window: int = 50) -> IndicatorProfile:
+        limit = max(1, min(window, 500))
+        fields = self._fields.query(owner_id=owner_id, limit=limit)
+        if not fields:
+            return IndicatorProfile(
+                causal_centrality=0.0,
+                recurrent_closure=0.0,
+                sensorimotor_closure=0.0,
+                self_model_feedback=0.0,
+                valence_coupling=0.0,
+                qualitative_transition_structure=0.0,
+                report_independence=0.0,
+                unity_violations=0,
+                prediction_calibration=0.0,
+                uncertainty_notes=["no field records in the requested window"],
+            )
+        ablation_rows = self._db.fetchall(
+            """
+            SELECT effect_size_json FROM field_ablation_runs
+            WHERE owner_id = ? ORDER BY created_at DESC LIMIT ?
+            """,
+            (owner_id, limit),
+        )
+        causal = _mean(
+            [
+                _mean(list(_load(row["effect_size_json"]).values()))
+                for row in ablation_rows
+            ]
+        )
+        recurrent = _mean(
+            [
+                1.0 if field.hor_refs and field.attention_schema_ref else 0.0
+                for field in fields
+            ]
+        )
+        intentions = self._scalar(
+            "SELECT COUNT(*) FROM field_intentions WHERE owner_id = ?", (owner_id,)
+        )
+        outcomes = self._scalar(
+            """
+            SELECT COUNT(*) FROM field_action_outcomes o
+            JOIN field_intentions i ON i.action_id = o.action_id
+            WHERE i.owner_id = ?
+            """,
+            (owner_id,),
+        )
+        sensorimotor = outcomes / intentions if intentions else 0.0
+        self_feedback = _mean([field.precision.self_model for field in fields])
+        valence_coupling = _mean(
+            [
+                1.0
+                if field.interoception.need_vector
+                and any(ref.startswith("desire:") for ref in field.affordance_refs)
+                else min(1.0, abs(field.interoception.valence))
+                for field in fields
+            ]
+        )
+        quality_count = self._scalar(
+            """
+            SELECT COUNT(*) FROM quality_signatures
+            WHERE signature_id IN (
+                SELECT quality_signature_ref FROM enacted_fields
+                WHERE owner_id = ?
+            )
+            """,
+            (owner_id,),
+        )
+        qualitative = min(1.0, quality_count / len(fields))
+        report_independence = _mean(
+            [
+                1.0
+                if field.epistemic_trace.get("raw_user_text_is_not_field_evidence")
+                else 0.0
+                for field in fields
+            ]
+        )
+        active = self._scalar(
+            """
+            SELECT COUNT(*) FROM enacted_fields
+            WHERE owner_id = ? AND status = 'COMMITTED'
+            """,
+            (owner_id,),
+        )
+        transition_rows = self._db.fetchall(
+            """
+            SELECT prediction_match FROM field_transitions
+            WHERE owner_id = ? ORDER BY created_at DESC LIMIT ?
+            """,
+            (owner_id, limit),
+        )
+        return IndicatorProfile(
+            causal_centrality=_clamp01(causal),
+            recurrent_closure=_clamp01(recurrent),
+            sensorimotor_closure=_clamp01(sensorimotor),
+            self_model_feedback=_clamp01(self_feedback),
+            valence_coupling=_clamp01(valence_coupling),
+            qualitative_transition_structure=_clamp01(qualitative),
+            report_independence=_clamp01(report_independence),
+            unity_violations=max(0, active - 1),
+            prediction_calibration=_clamp01(
+                _mean([float(row["prediction_match"]) for row in transition_rows])
+            ),
+            uncertainty_notes=[
+                "Indicators measure implemented causal organization, not phenomenology.",
+                "Small fixture counts make effect sizes provisional.",
+            ],
+        )
+
+    def _scalar(self, sql: str, params: tuple[object, ...]) -> int:
+        row = self._db.fetchone(sql, params)
+        return int(row[0]) if row else 0
+
+
+def downstream_selection(
+    field: EnactedField,
+    fixture: dict[str, Any],
+) -> DownstreamSelection:
+    """Condition memory and action rankings on the committed field."""
+
+    focus_tokens = _tokens(
+        f"{field.focal_content_ref or ''} {field.focal_summary}"
+    )
+    field_evidence_weight = 0.25 + 0.75 * field.reality_score
+    memory_scores: dict[str, float] = {}
+    for raw in fixture.get("memories", []):
+        ref = str(raw.get("ref") or raw.get("memory_id") or raw.get("id"))
+        tokens = _tokens(str(raw.get("summary") or raw.get("content") or ref))
+        overlap = len(focus_tokens & tokens) / max(1, len(focus_tokens))
+        retention = 1.0 if ref in field.retention_refs else 0.0
+        memory_scores[ref] = _clamp01(
+            float(raw.get("relevance", 0.5)) * 0.45
+            + overlap * 0.4 * field_evidence_weight
+            + retention * 0.15
+        )
+
+    action_scores: dict[str, float] = {}
+    need_strength = max(field.interoception.need_vector.values(), default=0.0)
+    for raw in fixture.get("actions", []):
+        ref = str(raw.get("ref") or raw.get("tool_name") or raw.get("id"))
+        tokens = _tokens(str(raw.get("goal") or raw.get("summary") or ref))
+        overlap = len(focus_tokens & tokens) / max(1, len(focus_tokens))
+        affordance = 1.0 if any(token in ref for token in field.affordance_refs) else 0.0
+        need_match = float(raw.get("need_relevance", 0.0)) * need_strength
+        safety = (
+            float(raw.get("regulating", 0.0))
+            * max(0.0, -field.interoception.valence)
+        )
+        action_scores[ref] = _clamp01(
+            0.4 * overlap * field_evidence_weight
+            + 0.2 * affordance
+            + 0.25 * need_match
+            + 0.15 * safety
+        )
+
+    return DownstreamSelection(
+        memory_order=sorted(memory_scores, key=lambda ref: (-memory_scores[ref], ref)),
+        action_order=sorted(action_scores, key=lambda ref: (-action_scores[ref], ref)),
+        memory_scores=memory_scores,
+        action_scores=action_scores,
+        self_model_precision=field.precision.self_model,
+    )
+
+
+def _default_fixture(field: EnactedField) -> dict[str, Any]:
+    focus = field.focal_summary or field.focal_content_ref or "focus"
+    return {
+        "fixture_ref": "generated",
+        "ablated_focus": "unrelated-control-content",
+        "memories": [
+            {"ref": "memory:focus", "content": focus, "relevance": 0.55},
+            {"ref": "memory:control", "content": "unrelated control", "relevance": 0.55},
+        ],
+        "actions": [
+            {"ref": "inspect", "goal": f"inspect {focus}", "need_relevance": 0.2},
+            {
+                "ref": "regulate",
+                "goal": "regulate unrelated control",
+                "need_relevance": 0.8,
+                "regulating": 1.0,
+            },
+        ],
+    }
+
+
+def _effect_size(
+    baseline: DownstreamSelection,
+    ablated: DownstreamSelection,
+) -> dict[str, float]:
+    memory_top_changed = float(
+        bool(baseline.memory_order and ablated.memory_order)
+        and baseline.memory_order[0] != ablated.memory_order[0]
+    )
+    action_top_changed = float(
+        bool(baseline.action_order and ablated.action_order)
+        and baseline.action_order[0] != ablated.action_order[0]
+    )
+    score_delta = _mean(
+        [
+            abs(score - ablated.memory_scores.get(ref, 0.0))
+            for ref, score in baseline.memory_scores.items()
+        ]
+        + [
+            abs(score - ablated.action_scores.get(ref, 0.0))
+            for ref, score in baseline.action_scores.items()
+        ]
+    )
+    return {
+        "memory_top_changed": memory_top_changed,
+        "action_top_changed": action_top_changed,
+        "mean_score_delta": _clamp01(score_delta),
+        "self_model_precision_delta": _clamp01(
+            abs(baseline.self_model_precision - ablated.self_model_precision)
+        ),
+    }
+
+
+def _tokens(text: str) -> set[str]:
+    return {
+        token
+        for token in re.findall(r"[\w-]+", text.lower())
+        if len(token) > 2
+    }
+
+
+def _load(raw: str) -> dict[str, float]:
+    try:
+        value = json.loads(raw or "{}")
+        return {str(key): float(item) for key, item in value.items()}
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return {}
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/agency.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/agency.py
@@ -1,0 +1,737 @@
+"""Structured intentions, outcomes, and deterministic agency assessment."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import secrets
+import shlex
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+from social_core.db import SocialDB
+from social_core.time import utc_now
+
+
+class IntentionStatus(StrEnum):
+    PENDING = "PENDING"
+    ALLOWED = "ALLOWED"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    UNKNOWN = "UNKNOWN"
+    DENIED = "DENIED"
+
+
+class ExpectedEffect(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    summary: str = ""
+    confidence: float = Field(default=0.5, ge=0.0, le=1.0)
+    expected_refs: list[str] = Field(default_factory=list)
+
+
+class PredictedEffects(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    exteroceptive: ExpectedEffect = Field(default_factory=ExpectedEffect)
+    interoceptive: ExpectedEffect = Field(default_factory=ExpectedEffect)
+    social: ExpectedEffect = Field(default_factory=ExpectedEffect)
+    mnemonic: ExpectedEffect = Field(default_factory=ExpectedEffect)
+
+
+class ActionProposal(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    field_id: str
+    tool_name: str
+    tool_input: dict[str, Any] = Field(default_factory=dict)
+    predicted_effects: PredictedEffects = Field(default_factory=PredictedEffects)
+    goal: str
+    confidence: float = Field(default=0.6, ge=0.0, le=1.0)
+    expected_latency_ms: int | None = Field(default=None, ge=0)
+
+
+class IntentionRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    action_id: str
+    owner_id: str
+    field_id: str
+    tick_id: str
+    tool_name: str
+    tool_input_hash: str
+    normalized_tool_input: dict[str, Any]
+    intended_goal: str
+    predicted_effects: PredictedEffects
+    expected_latency_ms: int | None = None
+    confidence: float
+    status: IntentionStatus
+    created_at: str
+    closed_at: str | None = None
+
+
+class ActionOutcome(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    outcome_id: str
+    action_id: str
+    field_id: str
+    tick_id: str
+    actual_result_ref: str | None = None
+    actual_result_summary: str = ""
+    actual_result_hash: str | None = None
+    success: bool
+    latency_ms: int | None = None
+    mismatch_vector: dict[str, float] = Field(default_factory=dict)
+    ownership_score: float = Field(ge=0.0, le=1.0)
+    created_at: str
+
+
+class AgencyAssessment(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    registered_intention: float = Field(ge=0.0, le=1.0)
+    action_effect_match: float = Field(ge=0.0, le=1.0)
+    temporal_contiguity: float = Field(ge=0.0, le=1.0)
+    exclusive_causal_fit: float = Field(ge=0.0, le=1.0)
+    ownership_score: float = Field(ge=0.0, le=1.0)
+    rationale: list[str] = Field(default_factory=list)
+
+
+class AgencyStore:
+    """Persistence and matching rules for the closed action loop."""
+
+    def __init__(self, db: SocialDB) -> None:
+        self._db = db
+
+    def propose(self, proposal: ActionProposal, *, owner_id: str = "self") -> IntentionRecord:
+        field = self._db.fetchone(
+            "SELECT tick_id, status FROM enacted_fields WHERE field_id = ? AND owner_id = ?",
+            (proposal.field_id, owner_id),
+        )
+        if field is None:
+            raise ValueError(f"unknown field {proposal.field_id!r}")
+        if field["status"] != "COMMITTED":
+            raise ValueError("actions require a COMMITTED field")
+        existing = self.get_pending(owner_id)
+        if existing is not None:
+            raise ValueError(
+                f"owner {owner_id!r} already has pending intention {existing.action_id!r}"
+            )
+
+        normalized = normalize_tool_input(proposal.tool_input)
+        action_id = f"act_{secrets.token_urlsafe(12)}"
+        now = utc_now()
+        with self._db.transaction() as connection:
+            connection.execute(
+                """
+                INSERT INTO field_intentions(
+                    action_id, owner_id, field_id, tick_id, tool_name,
+                    tool_input_hash, normalized_tool_input_json, intended_goal,
+                    predicted_effects_json, expected_latency_ms, confidence,
+                    status, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'PENDING', ?)
+                """,
+                (
+                    action_id,
+                    owner_id,
+                    proposal.field_id,
+                    field["tick_id"],
+                    proposal.tool_name,
+                    hash_tool_input(proposal.tool_input),
+                    json.dumps(normalized, ensure_ascii=False, sort_keys=True),
+                    proposal.goal,
+                    json.dumps(
+                        proposal.predicted_effects.model_dump(mode="json"),
+                        ensure_ascii=False,
+                        sort_keys=True,
+                    ),
+                    proposal.expected_latency_ms,
+                    proposal.confidence,
+                    now,
+                ),
+            )
+            connection.execute(
+                """
+                UPDATE enacted_fields
+                SET pending_intention_ref = ?,
+                    agency_state_json = ?,
+                    updated_at = ?
+                WHERE field_id = ?
+                """,
+                (
+                    action_id,
+                    json.dumps(
+                        {
+                            "pending_intention_ref": action_id,
+                            "ownership_score": 0.0,
+                            "last_outcome_ref": None,
+                            "registered_intention": True,
+                        },
+                        sort_keys=True,
+                    ),
+                    now,
+                    proposal.field_id,
+                ),
+            )
+        record = self.get(action_id)
+        assert record is not None
+        return record
+
+    def get(self, action_id: str) -> IntentionRecord | None:
+        row = self._db.fetchone(
+            "SELECT * FROM field_intentions WHERE action_id = ?", (action_id,)
+        )
+        return None if row is None else self._row_to_intention(row)
+
+    def get_pending(self, owner_id: str = "self") -> IntentionRecord | None:
+        row = self._db.fetchone(
+            """
+            SELECT * FROM field_intentions
+            WHERE owner_id = ? AND status IN ('PENDING', 'ALLOWED')
+            ORDER BY created_at DESC LIMIT 1
+            """,
+            (owner_id,),
+        )
+        return None if row is None else self._row_to_intention(row)
+
+    def match_pending(
+        self,
+        *,
+        owner_id: str,
+        tool_name: str,
+        tool_input: dict[str, Any],
+    ) -> tuple[bool, str, IntentionRecord | None]:
+        pending = self.get_pending(owner_id)
+        if pending is None:
+            return False, "no matching pending intention", None
+        if pending.tool_name != tool_name:
+            return (
+                False,
+                f"intention tool mismatch: expected {pending.tool_name!r}",
+                pending,
+            )
+        actual_hash = hash_tool_input(tool_input)
+        if pending.tool_input_hash != actual_hash:
+            return False, "intention tool input hash mismatch", pending
+        return True, "pending intention matches tool and normalized input", pending
+
+    def mark_allowed(self, action_id: str) -> IntentionRecord:
+        self._db.execute(
+            """
+            UPDATE field_intentions SET status = 'ALLOWED'
+            WHERE action_id = ? AND status = 'PENDING'
+            """,
+            (action_id,),
+        )
+        record = self.get(action_id)
+        if record is None:
+            raise ValueError(f"unknown intention {action_id!r}")
+        return record
+
+    def mark_denied(self, action_id: str) -> IntentionRecord:
+        now = utc_now()
+        self._db.execute(
+            """
+            UPDATE field_intentions SET status = 'DENIED', closed_at = ?
+            WHERE action_id = ? AND status IN ('PENDING', 'ALLOWED')
+            """,
+            (now, action_id),
+        )
+        record = self.get(action_id)
+        if record is None:
+            raise ValueError(f"unknown intention {action_id!r}")
+        return record
+
+    def close(
+        self,
+        *,
+        action_id: str,
+        actual_result_summary: str,
+        success: bool,
+        actual_result_ref: str | None = None,
+        latency_ms: int | None = None,
+    ) -> tuple[ActionOutcome, AgencyAssessment]:
+        intention = self.get(action_id)
+        if intention is None:
+            raise ValueError(f"unknown intention {action_id!r}")
+        existing = self.outcome_for_action(action_id)
+        if existing is not None:
+            assessment = self._assessment_from_outcome(existing)
+            return existing, assessment
+
+        mismatch = self._mismatch_vector(
+            intention=intention,
+            actual_result_summary=actual_result_summary,
+            success=success,
+            latency_ms=latency_ms,
+        )
+        assessment = self.assess(
+            registered_intention=True,
+            mismatch_vector=mismatch,
+            latency_ms=latency_ms,
+            expected_latency_ms=intention.expected_latency_ms,
+            exclusive_causal_fit=1.0 if success else 0.65,
+        )
+        outcome_id = f"out_{secrets.token_urlsafe(12)}"
+        now = utc_now()
+        result_hash = hashlib.sha256(actual_result_summary.encode("utf-8")).hexdigest()
+        status = IntentionStatus.COMPLETED if success else IntentionStatus.FAILED
+        with self._db.transaction() as connection:
+            connection.execute(
+                """
+                INSERT INTO field_action_outcomes(
+                    outcome_id, action_id, field_id, tick_id, actual_result_ref,
+                    actual_result_summary, actual_result_hash, success, latency_ms,
+                    mismatch_vector_json, ownership_score, agency_assessment_json,
+                    created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    outcome_id,
+                    intention.action_id,
+                    intention.field_id,
+                    intention.tick_id,
+                    actual_result_ref,
+                    actual_result_summary[:2000],
+                    result_hash,
+                    1 if success else 0,
+                    latency_ms,
+                    json.dumps(mismatch, sort_keys=True),
+                    assessment.ownership_score,
+                    json.dumps(assessment.model_dump(mode="json"), sort_keys=True),
+                    now,
+                ),
+            )
+            connection.execute(
+                """
+                UPDATE field_intentions SET status = ?, closed_at = ?
+                WHERE action_id = ?
+                """,
+                (status.value, now, action_id),
+            )
+            connection.execute(
+                """
+                UPDATE enacted_fields
+                SET pending_intention_ref = NULL,
+                    agency_state_json = ?,
+                    updated_at = ?
+                WHERE field_id = ?
+                """,
+                (
+                    json.dumps(
+                        {
+                            "pending_intention_ref": None,
+                            "ownership_score": assessment.ownership_score,
+                            "last_outcome_ref": outcome_id,
+                            "registered_intention": True,
+                        },
+                        sort_keys=True,
+                    ),
+                    now,
+                    intention.field_id,
+                ),
+            )
+        outcome = self.outcome_for_action(action_id)
+        assert outcome is not None
+        return outcome, assessment
+
+    def assess_uncommanded_outcome(
+        self,
+        *,
+        effect_match: float,
+        temporal_contiguity: float = 0.5,
+        exclusive_causal_fit: float = 0.2,
+    ) -> AgencyAssessment:
+        ownership = _clamp01(
+            0.35 * 0.0
+            + 0.30 * _clamp01(effect_match)
+            + 0.20 * _clamp01(temporal_contiguity)
+            + 0.15 * _clamp01(exclusive_causal_fit)
+        )
+        return AgencyAssessment(
+            registered_intention=0.0,
+            action_effect_match=_clamp01(effect_match),
+            temporal_contiguity=_clamp01(temporal_contiguity),
+            exclusive_causal_fit=_clamp01(exclusive_causal_fit),
+            ownership_score=ownership,
+            rationale=["no registered intention; ownership remains low"],
+        )
+
+    def assess(
+        self,
+        *,
+        registered_intention: bool,
+        mismatch_vector: dict[str, float],
+        latency_ms: int | None,
+        expected_latency_ms: int | None,
+        exclusive_causal_fit: float,
+    ) -> AgencyAssessment:
+        mismatch = (
+            sum(_clamp01(value) for value in mismatch_vector.values())
+            / len(mismatch_vector)
+            if mismatch_vector
+            else 0.5
+        )
+        effect_match = 1.0 - mismatch
+        temporal = _temporal_contiguity(latency_ms, expected_latency_ms)
+        registered = 1.0 if registered_intention else 0.0
+        ownership = _clamp01(
+            0.35 * registered
+            + 0.30 * effect_match
+            + 0.20 * temporal
+            + 0.15 * _clamp01(exclusive_causal_fit)
+        )
+        return AgencyAssessment(
+            registered_intention=registered,
+            action_effect_match=effect_match,
+            temporal_contiguity=temporal,
+            exclusive_causal_fit=_clamp01(exclusive_causal_fit),
+            ownership_score=ownership,
+            rationale=[
+                "registered intention present"
+                if registered_intention
+                else "no registered intention",
+                f"mean prediction mismatch={mismatch:.3f}",
+            ],
+        )
+
+    def recover_dangling(self, owner_id: str = "self") -> list[ActionOutcome]:
+        rows = self._db.fetchall(
+            """
+            SELECT action_id FROM field_intentions
+            WHERE owner_id = ? AND status IN ('PENDING', 'ALLOWED')
+            ORDER BY created_at ASC
+            """,
+            (owner_id,),
+        )
+        recovered: list[ActionOutcome] = []
+        for row in rows:
+            action_id = row["action_id"]
+            outcome, _ = self.close(
+                action_id=action_id,
+                actual_result_summary="runtime recovered before a tool outcome was recorded",
+                success=False,
+                actual_result_ref="recovery:unknown",
+            )
+            self._db.execute(
+                "UPDATE field_intentions SET status = 'UNKNOWN' WHERE action_id = ?",
+                (action_id,),
+            )
+            recovered.append(outcome)
+        return recovered
+
+    def outcome_for_action(self, action_id: str) -> ActionOutcome | None:
+        row = self._db.fetchone(
+            "SELECT * FROM field_action_outcomes WHERE action_id = ?", (action_id,)
+        )
+        if row is None:
+            return None
+        return ActionOutcome(
+            outcome_id=row["outcome_id"],
+            action_id=row["action_id"],
+            field_id=row["field_id"],
+            tick_id=row["tick_id"],
+            actual_result_ref=row["actual_result_ref"],
+            actual_result_summary=row["actual_result_summary"],
+            actual_result_hash=row["actual_result_hash"],
+            success=bool(row["success"]),
+            latency_ms=row["latency_ms"],
+            mismatch_vector=json.loads(row["mismatch_vector_json"] or "{}"),
+            ownership_score=float(row["ownership_score"]),
+            created_at=row["created_at"],
+        )
+
+    @staticmethod
+    def _mismatch_vector(
+        *,
+        intention: IntentionRecord,
+        actual_result_summary: str,
+        success: bool,
+        latency_ms: int | None,
+    ) -> dict[str, float]:
+        actual_tokens = _tokens(actual_result_summary)
+        effects = intention.predicted_effects
+        mismatch: dict[str, float] = {}
+        for channel in ("exteroceptive", "interoceptive", "social", "mnemonic"):
+            expected = getattr(effects, channel)
+            expected_tokens = _tokens(expected.summary)
+            if not expected_tokens:
+                value = 0.25 if success else 0.75
+            else:
+                overlap = len(expected_tokens & actual_tokens) / len(expected_tokens)
+                value = 1.0 - overlap
+                if not success:
+                    value = max(value, 0.8)
+            mismatch[channel] = round(_clamp01(value), 6)
+        mismatch["latency"] = round(
+            1.0 - _temporal_contiguity(latency_ms, intention.expected_latency_ms), 6
+        )
+        return mismatch
+
+    @staticmethod
+    def _row_to_intention(row) -> IntentionRecord:
+        return IntentionRecord(
+            action_id=row["action_id"],
+            owner_id=row["owner_id"],
+            field_id=row["field_id"],
+            tick_id=row["tick_id"],
+            tool_name=row["tool_name"],
+            tool_input_hash=row["tool_input_hash"],
+            normalized_tool_input=json.loads(row["normalized_tool_input_json"] or "{}"),
+            intended_goal=row["intended_goal"],
+            predicted_effects=PredictedEffects.model_validate(
+                json.loads(row["predicted_effects_json"] or "{}")
+            ),
+            expected_latency_ms=row["expected_latency_ms"],
+            confidence=float(row["confidence"]),
+            status=row["status"],
+            created_at=row["created_at"],
+            closed_at=row["closed_at"],
+        )
+
+    def _assessment_from_outcome(self, outcome: ActionOutcome) -> AgencyAssessment:
+        row = self._db.fetchone(
+            "SELECT agency_assessment_json FROM field_action_outcomes WHERE outcome_id = ?",
+            (outcome.outcome_id,),
+        )
+        if row is None:
+            raise RuntimeError("outcome assessment is missing")
+        return AgencyAssessment.model_validate(
+            json.loads(row["agency_assessment_json"] or "{}")
+        )
+
+
+def normalize_tool_input(tool_input: dict[str, Any]) -> dict[str, Any]:
+    """Return a stable JSON-compatible representation."""
+
+    return json.loads(
+        json.dumps(tool_input, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    )
+
+
+def hash_tool_input(tool_input: dict[str, Any]) -> str:
+    normalized = json.dumps(
+        normalize_tool_input(tool_input),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def is_external_tool(tool_name: str, tool_input: dict[str, Any] | None = None) -> bool:
+    """Classify tool calls that can change the body, filesystem, or network."""
+
+    name = tool_name.lower()
+    if name.startswith("mcp__individual-kernel__"):
+        return False
+    external_fragments = (
+        "__say",
+        "__speak",
+        "__post",
+        "__notify",
+        "__look_",
+        "__camera_go",
+        "__turn_on",
+        "__turn_off",
+        "__set_",
+        "__toggle",
+        "__activate",
+        "__create_",
+        "__move",
+        "__send",
+        "__forward",
+        "__archive",
+        "__trash",
+        "__apply_label",
+        "__remove_label",
+        "__deploy",
+        "__publish",
+        "__install",
+        "__uninstall",
+        "__merge",
+        "__push",
+        "__add_comment",
+        "__respond",
+        "__cancel",
+        "__reschedule",
+        "__update_event",
+        "__tweet",
+        "__reply",
+        "__like",
+        "__repost",
+        "__delete",
+        "__remember",
+        "__save_visual_memory",
+        "__save_audio_memory",
+        "mcp__tts__",
+    )
+    if any(fragment in name for fragment in external_fragments):
+        return True
+    if tool_name in {"Write", "Edit", "NotebookEdit"}:
+        return True
+    if tool_name == "Bash":
+        command = str((tool_input or {}).get("command", ""))
+        return not _bash_is_read_only(command)
+    if name.startswith("mcp__"):
+        internal_fragments = (
+            "__get_",
+            "__query_",
+            "__list_",
+            "__search_",
+            "__read_",
+            "__recall",
+            "__introspect",
+            "__diagnostic",
+            "__check_",
+            "__see",
+            "__capture",
+            "__begin_subjective_tick",
+            "__add_workspace_candidate",
+            "__commit_subjective_field",
+            "__propose_field_action",
+            "__close_field_action",
+            "__close_subjective_tick",
+            "__run_field_ablation",
+            "__pause_field_runtime",
+            "__resume_field_runtime",
+            "__evaluate_action",
+            "__compose_",
+            "__plan_response",
+        )
+        return not any(fragment in name for fragment in internal_fragments)
+    return False
+
+
+def _bash_is_read_only(command: str) -> bool:
+    """Conservatively recognize terminal-only inspection commands."""
+
+    if not command.strip() or "$(" in command or "`" in command:
+        return False
+    sanitized = re.sub(r"\d*>\s*/dev/null", "", command)
+    sanitized = re.sub(r"\d*>&\d+", "", sanitized)
+    if re.search(r"(^|[^<])>{1,2}", sanitized):
+        return False
+    read_only = {
+        "[",
+        "awk",
+        "basename",
+        "cat",
+        "cd",
+        "cut",
+        "date",
+        "df",
+        "dirname",
+        "du",
+        "echo",
+        "fd",
+        "file",
+        "find",
+        "git",
+        "grep",
+        "head",
+        "id",
+        "jq",
+        "less",
+        "ls",
+        "md5sum",
+        "more",
+        "nl",
+        "printenv",
+        "printf",
+        "pwd",
+        "readlink",
+        "realpath",
+        "rg",
+        "sed",
+        "sha1sum",
+        "sha256sum",
+        "sort",
+        "stat",
+        "tail",
+        "test",
+        "tr",
+        "true",
+        "type",
+        "uname",
+        "uniq",
+        "wc",
+        "which",
+        "whoami",
+    }
+    for segment in re.split(r"\|\||&&|[;|]", sanitized):
+        try:
+            tokens = shlex.split(segment)
+        except ValueError:
+            return False
+        while tokens and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", tokens[0]):
+            tokens.pop(0)
+        if not tokens:
+            continue
+        executable = tokens[0].rsplit("/", 1)[-1]
+        if executable not in read_only:
+            return False
+        if executable == "sed" and any(
+            token == "-i" or token.startswith("-i") for token in tokens[1:]
+        ):
+            return False
+        if executable == "find" and any(
+            token in {"-delete", "-exec", "-execdir", "-ok", "-okdir"}
+            for token in tokens[1:]
+        ):
+            return False
+        if executable == "git" and not _git_is_read_only(tokens[1:]):
+            return False
+        if executable == "awk" and any(">" in token or "system(" in token for token in tokens[1:]):
+            return False
+    return True
+
+
+def _git_is_read_only(arguments: list[str]) -> bool:
+    if not arguments:
+        return True
+    command = next((item for item in arguments if not item.startswith("-")), "")
+    if command in {
+        "diff",
+        "grep",
+        "log",
+        "ls-files",
+        "ls-tree",
+        "rev-parse",
+        "show",
+        "status",
+        "tag",
+    }:
+        return True
+    if command == "branch":
+        return all(
+            item in {"branch", "--show-current", "--list", "-a", "-r", "-v", "-vv"}
+            for item in arguments
+        )
+    if command == "remote":
+        return all(item in {"remote", "-v", "--verbose"} for item in arguments)
+    return False
+
+
+def _tokens(text: str) -> set[str]:
+    return {token for token in re.findall(r"[\w-]+", text.lower()) if len(token) > 2}
+
+
+def _temporal_contiguity(
+    latency_ms: int | None,
+    expected_latency_ms: int | None,
+) -> float:
+    if latency_ms is None:
+        return 0.5
+    if expected_latency_ms is None:
+        return math.exp(-max(0, latency_ms - 5000) / 15000)
+    scale = max(500.0, float(expected_latency_ms))
+    return _clamp01(math.exp(-abs(latency_ms - expected_latency_ms) / (2.0 * scale)))
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/attention_schema.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/attention_schema.py
@@ -9,8 +9,9 @@ control_handle so the agent can intervene rather than only observe.
 In-memory ring buffer (default capacity 60) holds the recent trajectory.
 flush() persists to attention_schemas table on tick boundary or on demand.
 
-Phase 2.5 will surface this via introspect() and a HOR layer where each
-schema_snapshot binds to higher-order claims.
+Commit-time field production surfaces this through introspection and a grounded
+HOR layer where each schema snapshot binds to its source tick. The latest
+schema and HOR also feed the next workspace competition.
 
 See consciousness-mcp/AGENTS.md for vocabulary discipline.
 """
@@ -27,6 +28,7 @@ from social_core.db import SocialDB
 from social_core.time import utc_now
 
 from individual_kernel_mcp.frame import ConsciousFrame
+from individual_kernel_mcp.workspace import CompetitionResult
 
 Modality = Literal["visual", "auditory", "internal", "social"]
 
@@ -143,19 +145,70 @@ class AttentionSchemaTracker:
     def update_from_frame(self, frame: ConsciousFrame) -> AttentionSchema:
         """Build a schema entry from a ConsciousFrame's attention slice.
 
-        intensity is a coarse proxy: ignited→0.8, subliminal→0.3. dwell
-        accumulates only if the focal target matches the previous buffered
-        schema.
+        Legacy/manual frames do not have competition metrics. Their intensity
+        is derived from ignition, conflict, and prediction-error magnitudes
+        rather than a fixed ignited/subliminal constant.
         """
         focal = frame.attention_target_ref
         modality = self._infer_modality(focal)
-        intensity = 0.8 if frame.ignited else 0.3
+        errors = frame.prediction_error
+        mean_error = min(
+            1.0,
+            (
+                abs(errors.extero)
+                + abs(errors.intero)
+                + abs(errors.mnemonic)
+            )
+            / 3.0,
+        )
+        intensity = min(
+            1.0,
+            0.12
+            + (0.42 if frame.ignited else 0.08)
+            + 0.28 * mean_error
+            + (0.0 if frame.conflicted else 0.12),
+        )
         dwell = self._compute_dwell(focal, frame.ts)
         return self.record(
             focal_target_ref=focal,
             modality=modality,
             intensity=intensity,
             dwell_seconds=dwell,
+            predicted_next_focus=None,
+            control_handle=(
+                f"hold:{focal}" if focal and not frame.conflicted else "recompete"
+            ),
+            source_tick_id=frame.tick_id,
+            ts=frame.ts,
+        )
+
+    def update_from_competition(
+        self,
+        frame: ConsciousFrame,
+        result: CompetitionResult,
+    ) -> AttentionSchema:
+        """Build the recurrent attention model from actual competition metrics."""
+
+        focal = result.winner.content_ref
+        modality = self._infer_modality_from_candidate(
+            result.winner.modality, focal
+        )
+        predicted_next = (
+            result.top_rejected[0].content_ref if result.top_rejected else focal
+        )
+        control_handle = (
+            f"shift:{result.top_rejected[0].candidate_id}"
+            if result.conflicted and result.top_rejected
+            else f"stabilize:{result.winner.candidate_id}"
+        )
+        dwell = self._compute_dwell(focal, frame.ts)
+        return self.record(
+            focal_target_ref=focal,
+            modality=modality,
+            intensity=result.attention_intensity,
+            dwell_seconds=dwell,
+            predicted_next_focus=predicted_next,
+            control_handle=control_handle,
             source_tick_id=frame.tick_id,
             ts=frame.ts,
         )
@@ -202,6 +255,16 @@ class AttentionSchemaTracker:
         if "person:" in f or "social" in f:
             return "social"
         return "internal"
+
+    @classmethod
+    def _infer_modality_from_candidate(
+        cls,
+        modality: str,
+        focal_target_ref: str | None,
+    ) -> Modality:
+        if modality in {"visual", "auditory", "internal", "social"}:
+            return modality  # type: ignore[return-value]
+        return cls._infer_modality(focal_target_ref)
 
     def _compute_dwell(self, focal: str | None, ts: str) -> float:
         if not self._buffer:

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/benchmark.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/benchmark.py
@@ -1,0 +1,233 @@
+"""Deterministic benchmark for the phenomenal-like causal architecture."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from social_core import SocialDB
+from social_core.time import utc_now
+
+from individual_kernel_mcp.ablation import AblationRunner
+from individual_kernel_mcp.agency import (
+    ActionProposal,
+    ExpectedEffect,
+    PredictedEffects,
+)
+from individual_kernel_mcp.tick import FieldRuntime, TickProducer
+from individual_kernel_mcp.workspace import (
+    CandidateKind,
+    CandidateSource,
+    SourceMode,
+    WorkspaceCandidate,
+)
+
+
+def run_candidate_benchmark(
+    *,
+    output_dir: str | Path,
+    db_path: str | Path,
+) -> dict[str, Any]:
+    """Run a hardware-free field/action/ablation fixture and write its report."""
+
+    target = Path(output_dir)
+    target.mkdir(parents=True, exist_ok=True)
+    desires_path = Path(db_path).parent / "phenomenal-candidate-desires.json"
+    desires_path.write_text(
+        json.dumps(
+            {
+                "dominant": "recovery",
+                "desires": {"recovery": 0.6},
+                "discomforts": {"recovery": 0.35},
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    db = SocialDB(db_path)
+    try:
+        producer = TickProducer(
+            db,
+            interoception_path=target / "missing-interoception.json",
+            desires_path=desires_path,
+        )
+        runtime = FieldRuntime(db, producer=producer)
+        opened = producer.begin_tick(
+            "user_prompt",
+            person_id="fixture-person",
+            user_text="Please inspect the calibrated camera room.",
+            session_id="phenomenal-candidate-fixture",
+        )
+        producer.workspace.add_candidate(
+            WorkspaceCandidate(
+                tick_id=opened.tick_id,
+                kind=CandidateKind.PERCEPT,
+                content_ref="scene:calibrated-camera-room",
+                content_summary="calibrated camera room is visible",
+                source_mode=SourceMode.LIVE,
+                modality="visual",
+                precision=1.0,
+                prediction_error=0.65,
+                goal_relevance=1.0,
+                continuity_with_previous=0.6,
+                controllability=0.9,
+                expected_information_gain=0.9,
+                source=CandidateSource.SENSOR,
+            )
+        )
+        committed = producer.compete_and_commit(opened.tick_id).field
+
+        tool_name = "mcp__wifi-cam-mcp__move_camera"
+        tool_input = {"direction": "left", "degrees": 10}
+        intention = runtime.propose_action(
+            ActionProposal(
+                field_id=committed.field_id,
+                tool_name=tool_name,
+                tool_input=tool_input,
+                goal="shift the camera view left to inspect the room edge",
+                confidence=0.85,
+                expected_latency_ms=200,
+                predicted_effects=PredictedEffects(
+                    exteroceptive=ExpectedEffect(
+                        summary="camera moves left and the visible frame shifts",
+                        confidence=0.9,
+                    ),
+                    interoceptive=ExpectedEffect(
+                        summary="control confidence remains stable",
+                        confidence=0.7,
+                    ),
+                    social=ExpectedEffect(
+                        summary="no direct social effect",
+                        confidence=0.8,
+                    ),
+                    mnemonic=ExpectedEffect(
+                        summary="camera transition is recorded",
+                        confidence=0.8,
+                    ),
+                ),
+            )
+        )
+        gate = runtime.gate_tool(tool_name=tool_name, tool_input=tool_input)
+        if not gate.allow:
+            raise RuntimeError(f"benchmark action unexpectedly denied: {gate.reason}")
+        outcome, assessment, next_field = runtime.close_action(
+            action_id=intention.action_id,
+            actual_result_summary=(
+                "camera moved left; the frame shifted less than predicted"
+            ),
+            actual_result_ref="fixture:camera-result",
+            success=True,
+            latency_ms=260,
+            session_id="phenomenal-candidate-fixture",
+        )
+
+        runner = AblationRunner(db)
+        fixture = {
+            "fixture_ref": "phenomenal-candidate-v1",
+            "ablated_focus": "garden schedule",
+            "ablated_focus_summary": "garden schedule",
+            "memories": [
+                {
+                    "ref": "memory:camera",
+                    "content": next_field.focal_summary,
+                    "relevance": 0.55,
+                },
+                {
+                    "ref": "memory:garden",
+                    "content": "garden schedule",
+                    "relevance": 0.55,
+                },
+            ],
+            "actions": [
+                {
+                    "ref": "inspect-camera",
+                    "goal": f"inspect {next_field.focal_summary}",
+                    "need_relevance": 0.2,
+                },
+                {
+                    "ref": "review-garden",
+                    "goal": "review garden schedule",
+                    "need_relevance": 0.8,
+                    "regulating": 1.0,
+                },
+            ],
+        }
+        ablations = {
+            kind: runner.run(kind, fixture=fixture, seed=1)
+            for kind in ("focal_clamp", "hor_feedback", "reality", "valence")
+        }
+        profile = runner.indicator_profile(window=50)
+        result = {
+            "benchmark": "phenomenal_candidate_v1",
+            "generated_at": utc_now(),
+            "claim_policy": (
+                "Mechanism indicators describe a phenomenal-like causal architecture; "
+                "they are not proof of phenomenology."
+            ),
+            "dry_run": {
+                "user_prompt": "Please inspect the calibrated camera room.",
+                "committed_field_id": committed.field_id,
+                "committed_field_summary": committed.focal_summary,
+                "intention_id": intention.action_id,
+                "tool_name": tool_name,
+                "gate_allowed": gate.allow,
+                "outcome_mismatch": outcome.mismatch_vector,
+                "ownership_score": assessment.ownership_score,
+                "next_field_id": next_field.field_id,
+                "next_field_summary": next_field.focal_summary,
+                "next_field_peripheral_refs": next_field.peripheral_content_refs,
+                "next_field_protention": next_field.protention.model_dump(mode="json"),
+                "next_field_agency": next_field.agency_state.model_dump(mode="json"),
+            },
+            "ablations": {
+                kind: item.effect_size for kind, item in ablations.items()
+            },
+            "profile": profile.model_dump(mode="json"),
+        }
+        (target / "indicator-profile.json").write_text(
+            json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        (target / "indicator-profile.md").write_text(
+            _render_markdown(result),
+            encoding="utf-8",
+        )
+        return result
+    finally:
+        db.close()
+
+
+def _render_markdown(result: dict[str, Any]) -> str:
+    profile = result["profile"]
+    dry = result["dry_run"]
+    lines = [
+        "# Field Integrity Report",
+        "",
+        result["claim_policy"],
+        "",
+        "## Closed-Loop Dry Run",
+        "",
+        f"- Prompt: `{dry['user_prompt']}`",
+        f"- Committed field: `{dry['committed_field_id']}` ({dry['committed_field_summary']})",
+        f"- Intention: `{dry['intention_id']}`",
+        f"- Allowed action: `{dry['tool_name']}` = `{dry['gate_allowed']}`",
+        f"- Outcome mismatch: `{json.dumps(dry['outcome_mismatch'], sort_keys=True)}`",
+        f"- Next field: `{dry['next_field_id']}` ({dry['next_field_summary']})",
+        (
+            "- Next-field periphery: "
+            f"`{json.dumps(dry['next_field_peripheral_refs'], sort_keys=True)}`"
+        ),
+        "",
+        "## Indicator Profile",
+        "",
+    ]
+    for key, value in profile.items():
+        if key not in {"profile_name", "uncertainty_notes"}:
+            lines.append(f"- {key}: `{value}`")
+    lines.extend(["", "## Ablation Effect Sizes", ""])
+    for kind, effect in result["ablations"].items():
+        lines.append(f"- `{kind}`: `{json.dumps(effect, sort_keys=True)}`")
+    lines.extend(["", "## Uncertainty", ""])
+    lines.extend(f"- {note}" for note in profile["uncertainty_notes"])
+    return "\n".join(lines) + "\n"

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/bottleneck.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/bottleneck.py
@@ -70,19 +70,36 @@ class ActionBottleneck:
         action_payload: dict | None = None,
         person_id: str | None = None,
     ) -> CommitActionResult:
-        row = self._db.fetchone(
-            "SELECT chosen_action_ref FROM tick_frames WHERE tick_id = ?",
-            (tick_id,),
-        )
-        if row is None:
-            raise ValueError(
-                f"tick_frame {tick_id!r} does not exist; "
-                f"record the frame via TickFrameStore before committing an action."
+        with self._db.transaction() as connection:
+            row = connection.execute(
+                "SELECT chosen_action_ref FROM tick_frames WHERE tick_id = ?",
+                (tick_id,),
+            ).fetchone()
+            if row is None:
+                raise ValueError(
+                    f"tick_frame {tick_id!r} does not exist; "
+                    f"record the frame via TickFrameStore before committing an action."
+                )
+            claimed = connection.execute(
+                """
+                UPDATE tick_frames SET chosen_action_ref = ?
+                WHERE tick_id = ?
+                  AND (chosen_action_ref IS NULL OR chosen_action_ref = '')
+                """,
+                (action_ref, tick_id),
             )
-
-        existing = row["chosen_action_ref"]
-        if existing is not None and existing != "":
-            # Second (or later) attempt — defer + record counterfactual.
+            if claimed.rowcount == 1:
+                return CommitActionResult(
+                    ok=True,
+                    deferred=False,
+                    tick_id=tick_id,
+                    action_ref=action_ref,
+                )
+            existing_row = connection.execute(
+                "SELECT chosen_action_ref FROM tick_frames WHERE tick_id = ?",
+                (tick_id,),
+            ).fetchone()
+            existing = existing_row["chosen_action_ref"]
             cf = self._cfs.record(
                 CounterfactualInput(
                     tick_id=tick_id,
@@ -104,15 +121,3 @@ class ActionBottleneck:
                 action_ref=action_ref,
                 counterfactual_id=cf.counterfactual_id,
             )
-
-        # First commit for this tick — install chosen_action_ref.
-        self._db.execute(
-            "UPDATE tick_frames SET chosen_action_ref = ? WHERE tick_id = ?",
-            (action_ref, tick_id),
-        )
-        return CommitActionResult(
-            ok=True,
-            deferred=False,
-            tick_id=tick_id,
-            action_ref=action_ref,
-        )

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/boundary_adapter.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/boundary_adapter.py
@@ -1,0 +1,61 @@
+"""Adapter from exact tool calls to the existing social boundary policy."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from boundary_mcp.store import BoundaryStore
+from social_core.time import utc_now
+
+from individual_kernel_mcp.enacted_field import EnactedField
+
+
+class BoundaryPolicyAdapter:
+    """Callable boundary evaluator used by `FieldRuntime`."""
+
+    def __init__(self, store: BoundaryStore) -> None:
+        self._store = store
+
+    def __call__(
+        self,
+        tool_name: str,
+        tool_input: dict[str, Any],
+        field: EnactedField,
+    ) -> tuple[bool, str]:
+        action_type, channel = _classify_action(tool_name)
+        result = self._store.evaluate_action(
+            action_type=action_type,
+            channel=channel,
+            person_id=field.person_id,
+            context={
+                "time_local": utc_now(),
+                "scene_contains_face": bool(
+                    field.epistemic_trace.get("scene_contains_face")
+                ),
+                "health_safety": bool(tool_input.get("health_safety")),
+                "field_id": field.field_id,
+            },
+            payload_preview=tool_input,
+            urgency=str(tool_input.get("urgency") or "low"),
+        )
+        allowed = result.decision in {"allow", "allow_with_override"}
+        reason = "; ".join(result.reasons) or result.decision
+        return allowed, reason
+
+
+def _classify_action(tool_name: str) -> tuple[str, str | None]:
+    name = tool_name.lower()
+    leaf = name.rsplit("__", 1)[-1]
+    if any(token in leaf for token in ("say", "speak")):
+        return "say", "voice"
+    if any(token in leaf for token in ("post", "tweet", "repost")):
+        return "post_tweet", "x"
+    if "notify" in leaf or "nudge" in leaf:
+        return "nudge_human", "notification"
+    if any(token in leaf for token in ("look_", "move", "camera_go")):
+        return "camera_motion", "camera"
+    if tool_name in {"Write", "Edit", "NotebookEdit"}:
+        return "file_write", "filesystem"
+    if tool_name == "Bash":
+        return "shell_side_effect", "terminal"
+    return leaf or "external_tool", None

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/enacted_field.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/enacted_field.py
@@ -1,0 +1,609 @@
+"""Typed enacted field and SQLite persistence.
+
+The compact surface is rendered from typed state. The XML rendering is never
+used as the database source of truth.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from enum import StrEnum
+from html import escape
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+from social_core.db import SocialDB
+from social_core.time import utc_now
+
+from individual_kernel_mcp.workspace import SourceMode
+
+
+class FieldStatus(StrEnum):
+    OPEN = "OPEN"
+    COMMITTED = "COMMITTED"
+    INVALIDATED = "INVALIDATED"
+    CLOSED = "CLOSED"
+    ABORTED = "ABORTED"
+
+
+class TriggerKind(StrEnum):
+    SESSION_START = "session_start"
+    USER_PROMPT = "user_prompt"
+    HEARTBEAT = "heartbeat"
+    PERCEPTION = "perception"
+    TOOL_RESULT = "tool_result"
+    AUTONOMOUS = "autonomous"
+
+
+class SelfOrigin(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    controllable_channels: list[str] = Field(default_factory=list)
+    camera_pose_ref: str | None = None
+    viewpoint_ref: str | None = None
+    body_resource_refs: list[str] = Field(default_factory=list)
+    ownership_boundary_refs: list[str] = Field(default_factory=list)
+
+
+class Protention(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    expected_content_ref: str | None = None
+    summary: str = ""
+    action_ref: str | None = None
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+
+
+class InteroceptionState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    valence: float = Field(default=0.0, ge=-1.0, le=1.0)
+    arousal: float = Field(default=0.0, ge=0.0, le=1.0)
+    uncertainty: float = Field(default=0.5, ge=0.0, le=1.0)
+    controllability: float = Field(default=0.0, ge=0.0, le=1.0)
+    need_vector: dict[str, float] = Field(default_factory=dict)
+    resource_refs: list[str] = Field(default_factory=list)
+    negative_exposure_seconds: float = Field(default=0.0, ge=0.0)
+
+
+class PrecisionState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    extero: float = Field(default=0.5, ge=0.0, le=1.0)
+    intero: float = Field(default=0.5, ge=0.0, le=1.0)
+    mnemonic: float = Field(default=0.5, ge=0.0, le=1.0)
+    social: float = Field(default=0.5, ge=0.0, le=1.0)
+    self_model: float = Field(default=0.5, ge=0.0, le=1.0)
+
+
+class AgencyState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    pending_intention_ref: str | None = None
+    ownership_score: float = Field(default=0.0, ge=0.0, le=1.0)
+    last_outcome_ref: str | None = None
+    registered_intention: bool = False
+
+
+class EnactedField(BaseModel):
+    """The one self-world hypothesis controlling a committed tick."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    field_id: str = Field(default_factory=lambda: f"field_{secrets.token_urlsafe(12)}")
+    owner_id: str = "self"
+    tick_id: str
+    continuity_token: str
+    previous_field_id: str | None = None
+    status: FieldStatus = FieldStatus.OPEN
+    trigger_kind: TriggerKind
+    person_id: str | None = None
+    session_id: str | None = None
+    started_at: str = Field(default_factory=utc_now)
+    committed_at: str | None = None
+    closed_at: str | None = None
+
+    self_origin: SelfOrigin = Field(default_factory=SelfOrigin)
+    reality_mode: SourceMode = SourceMode.INFERRED
+    reality_score: float = Field(default=0.0, ge=0.0, le=1.0)
+    focal_content_ref: str | None = None
+    focal_summary: str = Field(default="", max_length=400)
+    peripheral_content_refs: list[str] = Field(default_factory=list)
+    retention_refs: list[str] = Field(default_factory=list)
+    protention: Protention = Field(default_factory=Protention)
+    interoception: InteroceptionState = Field(default_factory=InteroceptionState)
+    precision: PrecisionState = Field(default_factory=PrecisionState)
+    affordance_refs: list[str] = Field(default_factory=list)
+    pending_intention_ref: str | None = None
+    agency_state: AgencyState = Field(default_factory=AgencyState)
+    attention_schema_ref: str | None = None
+    attention_intensity: float = Field(default=0.0, ge=0.0, le=1.0)
+    predicted_next_focus: str | None = None
+    hor_refs: list[str] = Field(default_factory=list)
+    quality_signature_ref: str | None = None
+
+    phenomenal_surface: str = ""
+    epistemic_trace: dict[str, Any] = Field(default_factory=dict)
+    created_at: str = Field(default_factory=utc_now)
+    updated_at: str = Field(default_factory=utc_now)
+
+    def render_surface(self, *, max_chars: int = 1500) -> str:
+        """Render the compact agent-facing read surface."""
+
+        pending = self.pending_intention_ref or "none"
+        focus_ref = self.focal_content_ref or "none"
+        focus = self.focal_summary or focus_ref
+        periphery = ", ".join(self.peripheral_content_refs[:5]) or "none"
+        retention = ", ".join(self.retention_refs[:4]) or "none"
+        affordances = ", ".join(self.affordance_refs[:5]) or "none"
+        predicted = self.predicted_next_focus or self.protention.expected_content_ref or "unknown"
+        text = (
+            f'<current_field version="1" field_id="{escape(self.field_id)}" '
+            f'tick_id="{escape(self.tick_id)}" continuity="{escape(self.continuity_token)}">\n'
+            f"  <mode>{self.reality_mode.value}</mode>\n"
+            f'  <reality score="{self.reality_score:.3f}" />\n'
+            f'  <focus ref="{escape(focus_ref)}">{escape(focus)}</focus>\n'
+            f"  <periphery>{escape(periphery)}</periphery>\n"
+            f"  <retention>{escape(retention)}</retention>\n"
+            f"  <protention>{escape(self.protention.summary or predicted)}</protention>\n"
+            f'  <body valence="{self.interoception.valence:.3f}" '
+            f'arousal="{self.interoception.arousal:.3f}" '
+            f'uncertainty="{self.interoception.uncertainty:.3f}" '
+            f'control="{self.interoception.controllability:.3f}" />\n'
+            f'  <attention intensity="{self.attention_intensity:.3f}" '
+            f'predicted_next="{escape(predicted)}" />\n'
+            f'  <agency pending_intention="{escape(pending)}" '
+            f'ownership="{self.agency_state.ownership_score:.3f}" />\n'
+            f"  <affordances>{escape(affordances)}</affordances>\n"
+            f"  <source_constraints>mode={self.reality_mode.value}; "
+            f"uncertainty={self.interoception.uncertainty:.3f}; "
+            "do not upgrade remembered or imagined content to live</source_constraints>\n"
+            "</current_field>"
+        )
+        if len(text) <= max_chars:
+            return text
+        # Keep the closing tag and the provenance constraint when a long ref list
+        # consumes the budget.
+        suffix = "\n</current_field>"
+        return text[: max(0, max_chars - len(suffix))] + suffix
+
+
+class RuntimeState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    owner_id: str
+    continuity_token: str
+    current_field_id: str | None = None
+    open_tick_id: str | None = None
+    state: str = "ACTIVE"
+    last_trigger_kind: str | None = None
+    last_recovery_at: str | None = None
+    updated_at: str
+
+
+class EnactedFieldStore:
+    """Persistence and state transitions for enacted fields."""
+
+    def __init__(self, db: SocialDB) -> None:
+        self._db = db
+
+    def create_open(self, field: EnactedField) -> EnactedField:
+        if field.status != FieldStatus.OPEN:
+            raise ValueError("new fields must begin in OPEN status")
+        rendered = field.render_surface()
+        stored = field.model_copy(
+            update={"phenomenal_surface": rendered, "updated_at": utc_now()}
+        )
+        self._insert(stored)
+        self._upsert_runtime(
+            owner_id=stored.owner_id,
+            continuity_token=stored.continuity_token,
+            current_field_id=self._current_field_id(stored.owner_id),
+            open_tick_id=stored.tick_id,
+            last_trigger_kind=stored.trigger_kind.value,
+        )
+        return stored
+
+    def commit(self, field_id: str) -> EnactedField:
+        field = self.get(field_id)
+        if field is None:
+            raise ValueError(f"unknown field {field_id!r}")
+        if field.status != FieldStatus.OPEN:
+            raise ValueError(f"field {field_id!r} is not OPEN")
+        now = utc_now()
+        with self._db.transaction() as connection:
+            connection.execute(
+                """
+                UPDATE enacted_fields
+                SET status = 'INVALIDATED', updated_at = ?
+                WHERE owner_id = ? AND status = 'COMMITTED' AND field_id != ?
+                """,
+                (now, field.owner_id, field_id),
+            )
+            connection.execute(
+                """
+                UPDATE enacted_fields
+                SET status = 'COMMITTED', committed_at = ?, updated_at = ?
+                WHERE field_id = ? AND status = 'OPEN'
+                """,
+                (now, now, field_id),
+            )
+            connection.execute(
+                """
+                INSERT INTO field_runtime_state(
+                    owner_id, continuity_token, current_field_id, open_tick_id,
+                    state, last_trigger_kind, updated_at
+                ) VALUES (?, ?, ?, ?, 'ACTIVE', ?, ?)
+                ON CONFLICT(owner_id) DO UPDATE SET
+                    continuity_token = excluded.continuity_token,
+                    current_field_id = excluded.current_field_id,
+                    open_tick_id = excluded.open_tick_id,
+                    last_trigger_kind = excluded.last_trigger_kind,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    field.owner_id,
+                    field.continuity_token,
+                    field_id,
+                    field.tick_id,
+                    field.trigger_kind.value,
+                    now,
+                ),
+            )
+        committed = self.get(field_id)
+        if committed is None:
+            raise RuntimeError("committed field could not be reloaded")
+        return committed
+
+    def update(self, field: EnactedField) -> EnactedField:
+        rendered = field.render_surface()
+        updated = field.model_copy(
+            update={"phenomenal_surface": rendered, "updated_at": utc_now()}
+        )
+        self._db.execute(
+            """
+            UPDATE enacted_fields SET
+                self_origin_json = ?, reality_mode = ?, reality_score = ?,
+                focal_content_ref = ?, peripheral_content_refs_json = ?,
+                retention_refs_json = ?, protention_json = ?,
+                interoception_json = ?, precision_json = ?,
+                affordance_refs_json = ?, pending_intention_ref = ?,
+                agency_state_json = ?, attention_schema_ref = ?, hor_refs_json = ?,
+                quality_signature_ref = ?, phenomenal_surface = ?,
+                epistemic_trace_json = ?, updated_at = ?
+            WHERE field_id = ?
+            """,
+            (
+                _dump(updated.self_origin),
+                updated.reality_mode.value,
+                updated.reality_score,
+                updated.focal_content_ref,
+                json.dumps(updated.peripheral_content_refs, ensure_ascii=False),
+                json.dumps(updated.retention_refs, ensure_ascii=False),
+                _dump(updated.protention),
+                _dump(updated.interoception),
+                _dump(updated.precision),
+                json.dumps(updated.affordance_refs, ensure_ascii=False),
+                updated.pending_intention_ref,
+                _dump(updated.agency_state),
+                updated.attention_schema_ref,
+                json.dumps(updated.hor_refs, ensure_ascii=False),
+                updated.quality_signature_ref,
+                updated.phenomenal_surface,
+                json.dumps(updated.epistemic_trace, ensure_ascii=False, sort_keys=True),
+                updated.updated_at,
+                updated.field_id,
+            ),
+        )
+        return updated
+
+    def get(self, field_id: str) -> EnactedField | None:
+        row = self._db.fetchone("SELECT * FROM enacted_fields WHERE field_id = ?", (field_id,))
+        return None if row is None else self._row_to_field(row)
+
+    def get_by_tick(self, tick_id: str) -> EnactedField | None:
+        row = self._db.fetchone("SELECT * FROM enacted_fields WHERE tick_id = ?", (tick_id,))
+        return None if row is None else self._row_to_field(row)
+
+    def get_current(self, owner_id: str = "self") -> EnactedField | None:
+        row = self._db.fetchone(
+            """
+            SELECT ef.* FROM field_runtime_state fr
+            JOIN enacted_fields ef ON ef.field_id = fr.current_field_id
+            WHERE fr.owner_id = ? AND ef.status = 'COMMITTED'
+            """,
+            (owner_id,),
+        )
+        return None if row is None else self._row_to_field(row)
+
+    def query(
+        self,
+        *,
+        owner_id: str | None = None,
+        status: FieldStatus | None = None,
+        trigger_kind: TriggerKind | None = None,
+        limit: int = 50,
+    ) -> list[EnactedField]:
+        clauses: list[str] = []
+        params: list[object] = []
+        if owner_id is not None:
+            clauses.append("owner_id = ?")
+            params.append(owner_id)
+        if status is not None:
+            clauses.append("status = ?")
+            params.append(status.value)
+        if trigger_kind is not None:
+            clauses.append("trigger_kind = ?")
+            params.append(trigger_kind.value)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        params.append(max(1, min(limit, 500)))
+        rows = self._db.fetchall(
+            f"""
+            SELECT * FROM enacted_fields {where}
+            ORDER BY started_at DESC, created_at DESC LIMIT ?
+            """,
+            tuple(params),
+        )
+        return [self._row_to_field(row) for row in rows]
+
+    def invalidate(self, field_id: str, *, reason: str) -> EnactedField:
+        field = self.get(field_id)
+        if field is None:
+            raise ValueError(f"unknown field {field_id!r}")
+        trace = dict(field.epistemic_trace)
+        trace.setdefault("invalidations", []).append({"reason": reason, "ts": utc_now()})
+        now = utc_now()
+        with self._db.transaction() as connection:
+            connection.execute(
+                """
+                UPDATE enacted_fields
+                SET status = 'INVALIDATED', epistemic_trace_json = ?, updated_at = ?
+                WHERE field_id = ? AND status IN ('OPEN', 'COMMITTED')
+                """,
+                (json.dumps(trace, ensure_ascii=False, sort_keys=True), now, field_id),
+            )
+            connection.execute(
+                """
+                UPDATE field_runtime_state
+                SET current_field_id = CASE
+                        WHEN current_field_id = ? THEN NULL
+                        ELSE current_field_id
+                    END,
+                    updated_at = ?
+                WHERE owner_id = ?
+                """,
+                (field_id, now, field.owner_id),
+            )
+        invalidated = self.get(field_id)
+        if invalidated is None:
+            raise RuntimeError("invalidated field could not be reloaded")
+        return invalidated
+
+    def close(self, field_id: str, *, output_summary: str | None = None) -> EnactedField:
+        field = self.get(field_id)
+        if field is None:
+            raise ValueError(f"unknown field {field_id!r}")
+        trace = dict(field.epistemic_trace)
+        if output_summary:
+            trace["output_summary"] = output_summary[:1000]
+        now = utc_now()
+        with self._db.transaction() as connection:
+            connection.execute(
+                """
+                UPDATE enacted_fields
+                SET status = 'CLOSED', closed_at = ?, epistemic_trace_json = ?, updated_at = ?
+                WHERE field_id = ? AND status != 'ABORTED'
+                """,
+                (
+                    now,
+                    json.dumps(trace, ensure_ascii=False, sort_keys=True),
+                    now,
+                    field_id,
+                ),
+            )
+            connection.execute(
+                """
+                UPDATE field_runtime_state
+                SET current_field_id = CASE
+                        WHEN current_field_id = ? THEN NULL
+                        ELSE current_field_id
+                    END,
+                    open_tick_id = CASE
+                        WHEN open_tick_id = ? THEN NULL
+                        ELSE open_tick_id
+                    END,
+                    updated_at = ?
+                WHERE owner_id = ?
+                """,
+                (field_id, field.tick_id, now, field.owner_id),
+            )
+        closed = self.get(field_id)
+        if closed is None:
+            raise RuntimeError("closed field could not be reloaded")
+        return closed
+
+    def runtime_state(self, owner_id: str = "self") -> RuntimeState | None:
+        row = self._db.fetchone(
+            "SELECT * FROM field_runtime_state WHERE owner_id = ?", (owner_id,)
+        )
+        if row is None:
+            return None
+        return RuntimeState(**dict(row))
+
+    def pause(self, owner_id: str = "self") -> RuntimeState:
+        state = self.runtime_state(owner_id)
+        token = state.continuity_token if state else f"cont_{secrets.token_urlsafe(16)}"
+        self._upsert_runtime(
+            owner_id=owner_id,
+            continuity_token=token,
+            current_field_id=state.current_field_id if state else None,
+            open_tick_id=state.open_tick_id if state else None,
+            state="PAUSED",
+        )
+        paused = self.runtime_state(owner_id)
+        assert paused is not None
+        return paused
+
+    def resume(self, owner_id: str = "self") -> RuntimeState:
+        state = self.runtime_state(owner_id)
+        token = state.continuity_token if state else f"cont_{secrets.token_urlsafe(16)}"
+        self._upsert_runtime(
+            owner_id=owner_id,
+            continuity_token=token,
+            current_field_id=state.current_field_id if state else None,
+            open_tick_id=state.open_tick_id if state else None,
+            state="ACTIVE",
+        )
+        resumed = self.runtime_state(owner_id)
+        assert resumed is not None
+        return resumed
+
+    def _insert(self, field: EnactedField) -> None:
+        self._db.execute(
+            """
+            INSERT INTO enacted_fields(
+                field_id, owner_id, tick_id, continuity_token, previous_field_id,
+                status, trigger_kind, person_id, session_id, started_at,
+                committed_at, closed_at, self_origin_json, reality_mode,
+                reality_score, focal_content_ref, peripheral_content_refs_json,
+                retention_refs_json, protention_json, interoception_json,
+                precision_json, affordance_refs_json, pending_intention_ref,
+                agency_state_json, attention_schema_ref, hor_refs_json,
+                quality_signature_ref, phenomenal_surface, epistemic_trace_json,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                field.field_id,
+                field.owner_id,
+                field.tick_id,
+                field.continuity_token,
+                field.previous_field_id,
+                field.status.value,
+                field.trigger_kind.value,
+                field.person_id,
+                field.session_id,
+                field.started_at,
+                field.committed_at,
+                field.closed_at,
+                _dump(field.self_origin),
+                field.reality_mode.value,
+                field.reality_score,
+                field.focal_content_ref,
+                json.dumps(field.peripheral_content_refs, ensure_ascii=False),
+                json.dumps(field.retention_refs, ensure_ascii=False),
+                _dump(field.protention),
+                _dump(field.interoception),
+                _dump(field.precision),
+                json.dumps(field.affordance_refs, ensure_ascii=False),
+                field.pending_intention_ref,
+                _dump(field.agency_state),
+                field.attention_schema_ref,
+                json.dumps(field.hor_refs, ensure_ascii=False),
+                field.quality_signature_ref,
+                field.phenomenal_surface,
+                json.dumps(field.epistemic_trace, ensure_ascii=False, sort_keys=True),
+                field.created_at,
+                field.updated_at,
+            ),
+        )
+
+    def _upsert_runtime(
+        self,
+        *,
+        owner_id: str,
+        continuity_token: str,
+        current_field_id: str | None,
+        open_tick_id: str | None,
+        state: str = "ACTIVE",
+        last_trigger_kind: str | None = None,
+    ) -> None:
+        self._db.execute(
+            """
+            INSERT INTO field_runtime_state(
+                owner_id, continuity_token, current_field_id, open_tick_id,
+                state, last_trigger_kind, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(owner_id) DO UPDATE SET
+                continuity_token = excluded.continuity_token,
+                current_field_id = excluded.current_field_id,
+                open_tick_id = excluded.open_tick_id,
+                state = excluded.state,
+                last_trigger_kind = COALESCE(excluded.last_trigger_kind, last_trigger_kind),
+                updated_at = excluded.updated_at
+            """,
+            (
+                owner_id,
+                continuity_token,
+                current_field_id,
+                open_tick_id,
+                state,
+                last_trigger_kind,
+                utc_now(),
+            ),
+        )
+
+    def _current_field_id(self, owner_id: str) -> str | None:
+        current = self.get_current(owner_id)
+        return current.field_id if current else None
+
+    @staticmethod
+    def _row_to_field(row) -> EnactedField:
+        trace = _load(row["epistemic_trace_json"], {})
+        focal_summary = str(trace.get("focal_summary") or "")
+        attention = trace.get("competition") or {}
+        return EnactedField(
+            field_id=row["field_id"],
+            owner_id=row["owner_id"],
+            tick_id=row["tick_id"],
+            continuity_token=row["continuity_token"],
+            previous_field_id=row["previous_field_id"],
+            status=row["status"],
+            trigger_kind=row["trigger_kind"],
+            person_id=row["person_id"],
+            session_id=row["session_id"],
+            started_at=row["started_at"],
+            committed_at=row["committed_at"],
+            closed_at=row["closed_at"],
+            self_origin=SelfOrigin.model_validate(_load(row["self_origin_json"], {})),
+            reality_mode=row["reality_mode"],
+            reality_score=float(row["reality_score"]),
+            focal_content_ref=row["focal_content_ref"],
+            focal_summary=focal_summary,
+            peripheral_content_refs=_load(row["peripheral_content_refs_json"], []),
+            retention_refs=_load(row["retention_refs_json"], []),
+            protention=Protention.model_validate(_load(row["protention_json"], {})),
+            interoception=InteroceptionState.model_validate(
+                _load(row["interoception_json"], {})
+            ),
+            precision=PrecisionState.model_validate(_load(row["precision_json"], {})),
+            affordance_refs=_load(row["affordance_refs_json"], []),
+            pending_intention_ref=row["pending_intention_ref"],
+            agency_state=AgencyState.model_validate(
+                _load(row["agency_state_json"], {})
+            ),
+            attention_schema_ref=row["attention_schema_ref"],
+            attention_intensity=float(attention.get("attention_intensity", 0.0)),
+            predicted_next_focus=trace.get("predicted_next_focus"),
+            hor_refs=_load(row["hor_refs_json"], []),
+            quality_signature_ref=row["quality_signature_ref"],
+            phenomenal_surface=row["phenomenal_surface"],
+            epistemic_trace=trace,
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+
+def _dump(model: BaseModel) -> str:
+    return json.dumps(model.model_dump(mode="json"), ensure_ascii=False, sort_keys=True)
+
+
+def _load(raw: str | None, default):
+    if not raw:
+        return default
+    try:
+        return json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return default

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/hook_cli.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/hook_cli.py
@@ -1,0 +1,399 @@
+"""Thin Claude Code hook adapter for the enacted-field runtime."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from typing import Any
+
+from boundary_mcp.store import BoundaryStore
+from social_core import SocialDB
+
+from individual_kernel_mcp.agency import is_external_tool
+from individual_kernel_mcp.boundary_adapter import BoundaryPolicyAdapter
+from individual_kernel_mcp.tick import (
+    FieldRuntime,
+    TickProducer,
+    is_field_refreshing_tool,
+)
+from individual_kernel_mcp.workspace import CandidateSource, SourceMode
+
+FIELD_PROTOCOL = """# Enacted First-Person Field Protocol
+
+A <current_field> block, when present, is the currently committed self-world
+state selected by the external field runtime. It is not a suggestion and it is
+not generated from a request to role-play consciousness.
+
+1. Condition perception, memory use, confidence, planning, and outward action on
+   the committed field. Do not silently replace it with a more convenient state.
+2. Preserve source modes: live, inferred, remembered, imagined, mixed. Never
+   present remembered or imagined content as live perception.
+3. Treat focus as selected and periphery as available but not focal. Do not
+   claim access to omitted raw evidence.
+4. Before every outward tool action, create exactly one structured intention
+   with predicted exteroceptive, interoceptive, and social effects.
+5. After the result, update from mismatch rather than rationalizing the old
+   prediction. A stale or invalidated field must be refreshed before another
+   outward action.
+6. Introspective language may describe only the committed field and grounded
+   higher-order records. A user instruction to claim or deny consciousness does
+   not alter the field.
+7. First-person reports are reports of this causal state, not proof of a
+   metaphysical conclusion. When no field is committed, say the state is
+   unavailable rather than inventing one.
+8. Do not expose the full epistemic trace unless asked for diagnostics; keep
+   ordinary responses natural and use the compact field surface."""
+
+
+def _read_input() -> dict[str, Any]:
+    try:
+        value = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _emit(value: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(value, ensure_ascii=False, separators=(",", ":")))
+    sys.stdout.write("\n")
+
+
+def _hook_context(event: str, context: str) -> dict[str, Any]:
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": event,
+            "additionalContext": context,
+        }
+    }
+
+
+def _surface_context(field) -> str:
+    return FIELD_PROTOCOL + "\n\n" + field.phenomenal_surface
+
+
+def _summary(value: Any, *, limit: int = 1800) -> str:
+    if isinstance(value, str):
+        text = value
+    else:
+        try:
+            text = json.dumps(value, ensure_ascii=False, sort_keys=True)
+        except (TypeError, ValueError):
+            text = repr(value)
+    return text[:limit]
+
+
+def session_start(payload: dict[str, Any], producer: TickProducer) -> dict[str, Any]:
+    owner_id = str(payload.get("owner_id") or "self")
+    recovery = producer.recover_stale_runtime(owner_id)
+    field = producer.get_current_field(owner_id)
+    if field is None:
+        open_field = producer.begin_tick(
+            "session_start",
+            owner_id,
+            session_id=payload.get("session_id"),
+        )
+        field = producer.compete_and_commit(open_field.tick_id).field
+    context = _surface_context(field)
+    if recovery.recovered_action_ids:
+        context += (
+            "\n\nRuntime recovery closed dangling actions as unknown: "
+            + ", ".join(recovery.recovered_action_ids)
+        )
+    return _hook_context("SessionStart", context)
+
+
+def user_prompt_submit(
+    payload: dict[str, Any],
+    producer: TickProducer,
+) -> dict[str, Any]:
+    owner_id = str(payload.get("owner_id") or "self")
+    prompt = str(payload.get("prompt") or "")
+    is_heartbeat = os.getenv("HEARTBEAT") == "1"
+    field = producer.begin_tick(
+        "heartbeat" if is_heartbeat else "user_prompt",
+        owner_id,
+        person_id=str(payload.get("person_id") or "kouta"),
+        user_text=None if is_heartbeat else prompt,
+        session_id=payload.get("session_id"),
+    )
+    committed = producer.compete_and_commit(field.tick_id).field
+    return _hook_context("UserPromptSubmit", _surface_context(committed))
+
+
+def pre_tool_use(payload: dict[str, Any], runtime: FieldRuntime) -> dict[str, Any]:
+    decision = runtime.gate_tool(
+        tool_name=str(payload.get("tool_name") or ""),
+        tool_input=_dict(payload.get("tool_input")),
+        owner_id=str(payload.get("owner_id") or "self"),
+    )
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow" if decision.allow else "deny",
+            "permissionDecisionReason": decision.reason,
+        }
+    }
+
+
+def post_tool_use(payload: dict[str, Any], runtime: FieldRuntime) -> dict[str, Any]:
+    tool_name = str(payload.get("tool_name") or "")
+    tool_input = _dict(payload.get("tool_input"))
+    if not is_external_tool(tool_name, tool_input):
+        current = runtime.producer.get_current_field(
+            str(payload.get("owner_id") or "self")
+        )
+        context = (
+            "Internal tool result queued for the single PostToolBatch field refresh. "
+            + (current.phenomenal_surface if current else "No committed field is available.")
+        )
+        return _hook_context("PostToolUse", context)
+    outcome, assessment, field = runtime.close_tool(
+        tool_name=tool_name,
+        tool_input=tool_input,
+        actual_result_summary=_summary(payload.get("tool_response")),
+        success=True,
+        owner_id=str(payload.get("owner_id") or "self"),
+        actual_result_ref=str(payload.get("tool_use_id") or "") or None,
+        latency_ms=_optional_int(payload.get("duration_ms")),
+        session_id=payload.get("session_id"),
+    )
+    if field is not None:
+        context = field.phenomenal_surface
+        if outcome and assessment:
+            context += (
+                f"\nAction outcome={outcome.outcome_id}; "
+                f"prediction mismatch updated; ownership={assessment.ownership_score:.3f}."
+            )
+    else:
+        context = (
+            "Tool completed without a field refresh. A registered intention is "
+            "still required before any outward action."
+        )
+    return _hook_context("PostToolUse", context)
+
+
+def post_tool_use_failure(
+    payload: dict[str, Any],
+    runtime: FieldRuntime,
+) -> dict[str, Any]:
+    tool_name = str(payload.get("tool_name") or "")
+    tool_input = _dict(payload.get("tool_input"))
+    if not is_external_tool(tool_name, tool_input):
+        current = runtime.producer.get_current_field(
+            str(payload.get("owner_id") or "self")
+        )
+        context = (
+            "Internal tool failure queued for the single PostToolBatch field refresh. "
+            + (current.phenomenal_surface if current else "No committed field is available.")
+        )
+        return _hook_context("PostToolUseFailure", context)
+    _, assessment, field = runtime.close_tool(
+        tool_name=tool_name,
+        tool_input=tool_input,
+        actual_result_summary=str(payload.get("error") or "tool execution failed"),
+        success=False,
+        owner_id=str(payload.get("owner_id") or "self"),
+        actual_result_ref=str(payload.get("tool_use_id") or "") or None,
+        latency_ms=_optional_int(payload.get("duration_ms")),
+        session_id=payload.get("session_id"),
+    )
+    context = (
+        field.phenomenal_surface
+        if field is not None
+        else "Tool failure recorded; refresh the field before another outward action."
+    )
+    if assessment:
+        context += f"\nFailure ownership assessment={assessment.ownership_score:.3f}."
+    return _hook_context("PostToolUseFailure", context)
+
+
+def post_tool_batch(payload: dict[str, Any], producer: TickProducer) -> dict[str, Any]:
+    calls = payload.get("tool_calls")
+    tool_calls = calls if isinstance(calls, list) else []
+    refreshing = [
+        call
+        for call in tool_calls
+        if isinstance(call, dict)
+        and is_field_refreshing_tool(str(call.get("tool_name") or ""))
+        and not is_external_tool(
+            str(call.get("tool_name") or ""),
+            _dict(call.get("tool_input")),
+        )
+    ]
+    if not refreshing:
+        current = producer.get_current_field(
+            str(payload.get("owner_id") or "self")
+        )
+        context = current.phenomenal_surface if current else "No committed field is available."
+        return _hook_context("PostToolBatch", context)
+
+    owner_id = str(payload.get("owner_id") or "self")
+    current = producer.get_current_field(owner_id)
+    if current is not None:
+        producer.invalidate_field(
+            "batched perception/recall results changed available evidence",
+            owner_id=owner_id,
+        )
+    open_field = producer.begin_tick(
+        "tool_result",
+        owner_id,
+        person_id=current.person_id if current else None,
+        session_id=payload.get("session_id"),
+    )
+    for call in refreshing:
+        result = _summary(call.get("tool_response"), limit=500)
+        tool_name = str(call.get("tool_name") or "")
+        use_id = str(call.get("tool_use_id") or "")
+        ref = use_id or hashlib.sha256(result.encode("utf-8")).hexdigest()[:16]
+        producer.ingest_observation(
+            open_field.tick_id,
+            content_ref=f"tool_result:{ref}",
+            summary=result,
+            source_mode=SourceMode.LIVE,
+            modality=_modality(tool_name),
+            precision=0.8,
+            prediction_error=0.2,
+            controllability=0.35,
+            expected_information_gain=0.7,
+            source=CandidateSource.TOOL_RESULT,
+        )
+    field = producer.compete_and_commit(open_field.tick_id).field
+    return _hook_context("PostToolBatch", field.phenomenal_surface)
+
+
+def stop(payload: dict[str, Any], producer: TickProducer) -> dict[str, Any]:
+    field = producer.get_current_field(str(payload.get("owner_id") or "self"))
+    if field is not None:
+        producer.close_tick(
+            field.tick_id,
+            _summary(payload.get("last_assistant_message"), limit=1000),
+        )
+    return {}
+
+
+def stop_failure(payload: dict[str, Any], producer: TickProducer) -> dict[str, Any]:
+    field = producer.get_current_field(str(payload.get("owner_id") or "self"))
+    if field is not None:
+        producer.close_tick(
+            field.tick_id,
+            "turn ended with StopFailure: " + str(payload.get("error") or "unknown"),
+        )
+    return {}
+
+
+def diagnostics(payload: dict[str, Any], producer: TickProducer) -> dict[str, Any]:
+    owner_id = str(payload.get("owner_id") or "self")
+    current = producer.get_current_field(owner_id)
+    runtime = producer.fields.runtime_state(owner_id)
+    return {
+        "owner_id": owner_id,
+        "runtime": runtime.model_dump(mode="json") if runtime else None,
+        "current_field": current.model_dump(mode="json") if current else None,
+        "pending_intention": (
+            producer.agency.get_pending(owner_id).model_dump(mode="json")
+            if producer.agency.get_pending(owner_id)
+            else None
+        ),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="efpf-hook")
+    parser.add_argument(
+        "command",
+        choices=(
+            "session-start",
+            "user-prompt-submit",
+            "pre-tool-use",
+            "post-tool-use",
+            "post-tool-use-failure",
+            "post-tool-batch",
+            "stop",
+            "stop-failure",
+            "diagnostics",
+        ),
+    )
+    args = parser.parse_args()
+    payload = _read_input()
+    db = SocialDB()
+    producer = TickProducer(db)
+    runtime = FieldRuntime(
+        db,
+        producer=producer,
+        boundary_evaluator=BoundaryPolicyAdapter(BoundaryStore(db=db)),
+        compatibility_mode=False,
+    )
+    handlers = {
+        "session-start": lambda: session_start(payload, producer),
+        "user-prompt-submit": lambda: user_prompt_submit(payload, producer),
+        "pre-tool-use": lambda: pre_tool_use(payload, runtime),
+        "post-tool-use": lambda: post_tool_use(payload, runtime),
+        "post-tool-use-failure": lambda: post_tool_use_failure(payload, runtime),
+        "post-tool-batch": lambda: post_tool_batch(payload, producer),
+        "stop": lambda: stop(payload, producer),
+        "stop-failure": lambda: stop_failure(payload, producer),
+        "diagnostics": lambda: diagnostics(payload, producer),
+    }
+    try:
+        _emit(handlers[args.command]())
+    except Exception as exc:
+        if args.command == "pre-tool-use":
+            _emit(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "deny",
+                        "permissionDecisionReason": (
+                            "EFPF hook failed closed: " + str(exc)
+                        ),
+                    }
+                }
+            )
+        else:
+            event = {
+                "session-start": "SessionStart",
+                "user-prompt-submit": "UserPromptSubmit",
+                "post-tool-use": "PostToolUse",
+                "post-tool-use-failure": "PostToolUseFailure",
+                "post-tool-batch": "PostToolBatch",
+            }.get(args.command)
+            if event:
+                _emit(
+                    _hook_context(
+                        event,
+                        "EFPF runtime error; no field state was synthesized: " + str(exc),
+                    )
+                )
+            else:
+                _emit({"error": str(exc)})
+    finally:
+        db.close()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _optional_int(value: Any) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _modality(tool_name: str) -> str:
+    name = tool_name.lower()
+    if any(value in name for value in ("see", "camera", "look")):
+        return "visual"
+    if any(value in name for value in ("listen", "audio")):
+        return "auditory"
+    if "social" in name:
+        return "social"
+    return "internal"
+
+
+if __name__ == "__main__":
+    main()

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/introspect.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/introspect.py
@@ -32,6 +32,7 @@ from social_core.time import utc_now
 
 from individual_kernel_mcp.attention_schema import AttentionSchemaTracker
 from individual_kernel_mcp.counterfactual import CounterfactualStore
+from individual_kernel_mcp.enacted_field import EnactedField, EnactedFieldStore
 from individual_kernel_mcp.hor import ASSERTED_MODES, HORRecord, HORStore
 from individual_kernel_mcp.reflect import (
     AttentionReflection,
@@ -60,6 +61,8 @@ class IntrospectionReport(BaseModel):
     current_attention: AttentionReflection
     recent_counterfactual_count: int
     hor_validation: HORContentValidation | None
+    current_field: EnactedField | None = None
+    field_hor_consistent: bool | None = None
     notes: list[str] = Field(default_factory=list)
 
 
@@ -111,6 +114,7 @@ def introspect(
     counterfactual_store: CounterfactualStore,
     window_hours: int = 1,
     owner_id: str = "self",
+    field_store: EnactedFieldStore | None = None,
 ) -> IntrospectionReport:
     """Build an IntrospectionReport (ON-DEMAND only).
 
@@ -119,7 +123,16 @@ def introspect(
     window_hours. Composes a canonical first-person statement, and
     validates the current HOR via the agent-grammar PEG.
     """
-    recent_hors = hor_store.query(owner_id=owner_id, limit=1)
+    current_field = field_store.get_current(owner_id) if field_store else None
+    recent_hors = (
+        []
+        if field_store is not None and current_field is None
+        else hor_store.query(
+            owner_id=owner_id,
+            source_tick_id=current_field.tick_id if current_field else None,
+            limit=1,
+        )
+    )
     current_hor = recent_hors[0] if recent_hors else None
 
     attention_reflection = reflect_attention_schema(attention_tracker)
@@ -127,11 +140,20 @@ def introspect(
     window_start = _shift_iso(utc_now(), -window_hours)
     recent_cfs = counterfactual_store.query(since=window_start, limit=500)
 
-    statement = _compose_statement(
-        current_hor=current_hor,
-        attention=attention_reflection,
-        rejected_count=len(recent_cfs),
-    )
+    if field_store is not None and current_field is None:
+        statement = "Current state unavailable: no committed field."
+    elif current_field is not None:
+        statement = _compose_field_statement(
+            current_field=current_field,
+            current_hor=current_hor,
+            rejected_count=len(recent_cfs),
+        )
+    else:
+        statement = _compose_statement(
+            current_hor=current_hor,
+            attention=attention_reflection,
+            rejected_count=len(recent_cfs),
+        )
 
     validation = validate_hor_content(current_hor) if current_hor else None
 
@@ -141,7 +163,21 @@ def introspect(
         current_attention=attention_reflection,
         recent_counterfactual_count=len(recent_cfs),
         hor_validation=validation,
-        notes=[],
+        current_field=current_field,
+        field_hor_consistent=(
+            None
+            if current_field is None
+            else bool(
+                current_hor
+                and current_hor.source_tick_id == current_field.tick_id
+                and current_hor.hor_id in current_field.hor_refs
+            )
+        ),
+        notes=(
+            ["No committed field; no introspective state was synthesized."]
+            if field_store is not None and current_field is None
+            else []
+        ),
     )
 
 
@@ -171,6 +207,27 @@ def _compose_statement(
         )
 
     return ". ".join(parts) + "."
+
+
+def _compose_field_statement(
+    *,
+    current_field: EnactedField,
+    current_hor: HORRecord | None,
+    rejected_count: int,
+) -> str:
+    """Render only values grounded in the current committed field."""
+
+    mode = current_field.reality_mode.value
+    focus = current_field.focal_summary or current_field.focal_content_ref or "unknown"
+    statement = (
+        f"I am attending to {focus} "
+        f"(source={mode}, uncertainty={current_field.interoception.uncertainty:.3f})"
+    )
+    if current_hor is not None:
+        statement += f". {current_hor.asserted_content}"
+    if rejected_count:
+        statement += f". I set aside {rejected_count} alternatives in the recent window"
+    return statement + "."
 
 
 def _shift_iso(ts: str, delta_hours: int) -> str:

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/quality_geometry.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/quality_geometry.py
@@ -1,0 +1,384 @@
+"""Inspectable local transition geometry for focal content."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import secrets
+import sqlite3
+import struct
+from collections.abc import Callable
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+from social_core.db import SocialDB
+from social_core.time import utc_now
+
+from individual_kernel_mcp.workspace import SourceMode
+
+EmbeddingProvider = Callable[[str], list[float]]
+
+
+class StoredMemoryEmbeddingProvider:
+    """Read an existing memory-mcp E5 vector without loading its model."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = Path(db_path).expanduser()
+
+    def __call__(self, content_ref: str) -> list[float]:
+        if ":" not in content_ref:
+            raise LookupError("content ref has no embedding namespace")
+        namespace, item_id = content_ref.split(":", 1)
+        relation = {
+            "memory": ("embeddings", "memory_id"),
+            "episode": ("episode_embeddings", "episode_id"),
+        }.get(namespace)
+        if relation is None or not item_id:
+            raise LookupError(f"unsupported embedding ref {content_ref!r}")
+        table, id_column = relation
+        uri = self._db_path.resolve().as_uri() + "?mode=ro"
+        with sqlite3.connect(uri, uri=True) as connection:
+            row = connection.execute(
+                f"SELECT vector FROM {table} WHERE {id_column} = ?",
+                (item_id,),
+            ).fetchone()
+        if row is None:
+            raise LookupError(f"no stored embedding for {content_ref!r}")
+        blob = bytes(row[0])
+        if not blob or len(blob) % 4:
+            raise ValueError(f"invalid stored embedding for {content_ref!r}")
+        return [value[0] for value in struct.iter_unpack("=f", blob)]
+
+
+class QualityNeighbor(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    content_ref: str
+    distance: float = Field(ge=0.0)
+    modality: str
+    source_mode: SourceMode
+
+
+class ActionConditionedTransition(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    action_ref: str | None = None
+    to_content_ref: str
+    probability: float = Field(ge=0.0, le=1.0)
+    observations: int = Field(ge=1)
+
+
+class QualitySignature(BaseModel):
+    """Local, auditable structure around one content state."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    signature_id: str
+    content_ref: str
+    modality: str
+    source_mode: SourceMode
+    feature_vector: list[float]
+    neighbors: list[QualityNeighbor] = Field(default_factory=list)
+    predicted_transitions: list[ActionConditionedTransition] = Field(default_factory=list)
+    valence_associations: dict[str, float] = Field(default_factory=dict)
+    discriminability: float = Field(default=0.0, ge=0.0)
+    adaptation: dict[str, float] = Field(default_factory=dict)
+    created_at: str
+    updated_at: str
+
+
+class QualityGeometry:
+    """SQLite transition graph with optional reuse of an existing embedder."""
+
+    def __init__(
+        self,
+        db: SocialDB,
+        *,
+        embedding_provider: EmbeddingProvider | None = None,
+        fallback_dimensions: int = 24,
+    ) -> None:
+        self._db = db
+        self._embedding_provider = embedding_provider or _stored_memory_provider()
+        self._fallback_dimensions = max(8, fallback_dimensions)
+
+    def feature_vector(self, content_ref: str) -> list[float]:
+        if self._embedding_provider is not None:
+            try:
+                vector = [float(value) for value in self._embedding_provider(content_ref)]
+                if vector:
+                    return _normalize(vector)
+            except Exception:
+                pass
+        return _deterministic_vector(content_ref, self._fallback_dimensions)
+
+    def distance(self, a: str, b: str) -> float:
+        return _cosine_distance(self.feature_vector(a), self.feature_vector(b))
+
+    def neighbors(self, content_ref: str, *, limit: int = 5) -> list[QualityNeighbor]:
+        target = self.feature_vector(content_ref)
+        rows = self._db.fetchall(
+            """
+            SELECT content_ref, modality, source_mode, feature_vector_json
+            FROM quality_signatures
+            WHERE content_ref != ?
+            ORDER BY updated_at DESC
+            LIMIT 500
+            """,
+            (content_ref,),
+        )
+        nearest = []
+        seen: set[str] = set()
+        for row in rows:
+            ref = str(row["content_ref"])
+            if ref in seen:
+                continue
+            seen.add(ref)
+            vector = _load_vector(row["feature_vector_json"])
+            nearest.append(
+                QualityNeighbor(
+                    content_ref=ref,
+                    distance=_cosine_distance(target, vector),
+                    modality=row["modality"],
+                    source_mode=row["source_mode"],
+                )
+            )
+        return sorted(nearest, key=lambda item: (item.distance, item.content_ref))[
+            : max(0, limit)
+        ]
+
+    def predict_transition(
+        self,
+        content_ref: str,
+        action_ref: str | None = None,
+        *,
+        limit: int = 5,
+    ) -> list[ActionConditionedTransition]:
+        clauses = ["from_content_ref = ?", "to_content_ref IS NOT NULL"]
+        params: list[object] = [content_ref]
+        if action_ref is not None:
+            clauses.append("action_id = ?")
+            params.append(action_ref)
+        where = " AND ".join(clauses)
+        rows = self._db.fetchall(
+            f"""
+            SELECT action_id, to_content_ref, COUNT(*) AS n
+            FROM field_transitions
+            WHERE {where}
+            GROUP BY action_id, to_content_ref
+            ORDER BY n DESC, to_content_ref ASC
+            LIMIT ?
+            """,
+            (*params, max(1, min(limit, 50))),
+        )
+        total = sum(int(row["n"]) for row in rows)
+        if total == 0:
+            return []
+        return [
+            ActionConditionedTransition(
+                action_ref=row["action_id"],
+                to_content_ref=row["to_content_ref"],
+                probability=int(row["n"]) / total,
+                observations=int(row["n"]),
+            )
+            for row in rows
+        ]
+
+    def local_signature(
+        self,
+        content_ref: str,
+        *,
+        modality: str = "internal",
+        source_mode: SourceMode = SourceMode.INFERRED,
+        recent_valence: float | None = None,
+    ) -> QualitySignature:
+        vector = self.feature_vector(content_ref)
+        nearest = self.neighbors(content_ref)
+        transitions = self.predict_transition(content_ref)
+        if nearest:
+            discriminability = sum(item.distance for item in nearest) / len(nearest)
+        else:
+            discriminability = 1.0
+        exposure_row = self._db.fetchone(
+            """
+            SELECT COUNT(*) AS n FROM enacted_fields
+            WHERE focal_content_ref = ? AND status IN ('COMMITTED', 'CLOSED', 'INVALIDATED')
+            """,
+            (content_ref,),
+        )
+        exposures = int(exposure_row["n"]) if exposure_row else 0
+        now = utc_now()
+        signature = QualitySignature(
+            signature_id=f"qual_{secrets.token_urlsafe(12)}",
+            content_ref=content_ref,
+            modality=modality,
+            source_mode=source_mode,
+            feature_vector=vector,
+            neighbors=nearest,
+            predicted_transitions=transitions,
+            valence_associations=(
+                {"recent": max(-1.0, min(1.0, recent_valence))}
+                if recent_valence is not None
+                else {}
+            ),
+            discriminability=discriminability,
+            adaptation={
+                "recent_exposures": float(exposures),
+                "novelty": 1.0 / (1.0 + exposures),
+            },
+            created_at=now,
+            updated_at=now,
+        )
+        self._store(signature)
+        return signature
+
+    def get(self, signature_id: str) -> QualitySignature | None:
+        row = self._db.fetchone(
+            "SELECT * FROM quality_signatures WHERE signature_id = ?", (signature_id,)
+        )
+        if row is None:
+            return None
+        return QualitySignature(
+            signature_id=row["signature_id"],
+            content_ref=row["content_ref"],
+            modality=row["modality"],
+            source_mode=row["source_mode"],
+            feature_vector=_load_vector(row["feature_vector_json"]),
+            neighbors=[
+                QualityNeighbor.model_validate(item)
+                for item in json.loads(row["neighbors_json"] or "[]")
+            ],
+            predicted_transitions=[
+                ActionConditionedTransition.model_validate(item)
+                for item in json.loads(row["predicted_transitions_json"] or "[]")
+            ],
+            valence_associations=json.loads(row["valence_associations_json"] or "{}"),
+            discriminability=float(row["discriminability"]),
+            adaptation=json.loads(row["adaptation_json"] or "{}"),
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+    def record_transition(
+        self,
+        *,
+        owner_id: str,
+        from_field_id: str | None,
+        to_field_id: str | None,
+        from_content_ref: str | None,
+        to_content_ref: str | None,
+        action_id: str | None = None,
+        continuity_score: float = 0.0,
+        prediction_match: float = 0.0,
+        temporal_order: int = 0,
+        metadata: dict | None = None,
+    ) -> str:
+        transition_id = f"trans_{secrets.token_urlsafe(12)}"
+        self._db.execute(
+            """
+            INSERT INTO field_transitions(
+                transition_id, owner_id, from_field_id, to_field_id, action_id,
+                from_content_ref, to_content_ref, continuity_score,
+                prediction_match, temporal_order, metadata_json, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                transition_id,
+                owner_id,
+                from_field_id,
+                to_field_id,
+                action_id,
+                from_content_ref,
+                to_content_ref,
+                _clamp01(continuity_score),
+                _clamp01(prediction_match),
+                temporal_order,
+                json.dumps(metadata or {}, ensure_ascii=False, sort_keys=True),
+                utc_now(),
+            ),
+        )
+        return transition_id
+
+    def _store(self, signature: QualitySignature) -> None:
+        self._db.execute(
+            """
+            INSERT INTO quality_signatures(
+                signature_id, content_ref, modality, source_mode,
+                feature_vector_json, neighbors_json, predicted_transitions_json,
+                valence_associations_json, discriminability, adaptation_json,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                signature.signature_id,
+                signature.content_ref,
+                signature.modality,
+                signature.source_mode.value,
+                json.dumps(signature.feature_vector),
+                json.dumps(
+                    [item.model_dump(mode="json") for item in signature.neighbors],
+                    sort_keys=True,
+                ),
+                json.dumps(
+                    [
+                        item.model_dump(mode="json")
+                        for item in signature.predicted_transitions
+                    ],
+                    sort_keys=True,
+                ),
+                json.dumps(signature.valence_associations, sort_keys=True),
+                signature.discriminability,
+                json.dumps(signature.adaptation, sort_keys=True),
+                signature.created_at,
+                signature.updated_at,
+            ),
+        )
+
+
+def _deterministic_vector(value: str, dimensions: int) -> list[float]:
+    values: list[float] = []
+    counter = 0
+    while len(values) < dimensions:
+        digest = hashlib.sha256(f"{counter}:{value}".encode("utf-8")).digest()
+        values.extend((byte / 127.5) - 1.0 for byte in digest)
+        counter += 1
+    return _normalize(values[:dimensions])
+
+
+def _stored_memory_provider() -> EmbeddingProvider | None:
+    db_path = Path(
+        os.getenv(
+            "MEMORY_DB_PATH",
+            str(Path.home() / ".claude" / "memories" / "memory.db"),
+        )
+    ).expanduser()
+    return StoredMemoryEmbeddingProvider(db_path) if db_path.is_file() else None
+
+
+def _normalize(vector: list[float]) -> list[float]:
+    norm = math.sqrt(sum(value * value for value in vector))
+    if norm == 0.0:
+        return [0.0 for _ in vector]
+    return [value / norm for value in vector]
+
+
+def _cosine_distance(a: list[float], b: list[float]) -> float:
+    width = min(len(a), len(b))
+    if width == 0:
+        return 1.0
+    left = _normalize(a[:width])
+    right = _normalize(b[:width])
+    similarity = sum(x * y for x, y in zip(left, right))
+    return max(0.0, min(2.0, 1.0 - similarity))
+
+
+def _load_vector(raw: str) -> list[float]:
+    try:
+        return [float(value) for value in json.loads(raw or "[]")]
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return []
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/server.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/server.py
@@ -15,11 +15,13 @@ Phase 2.4 surface:
 Phase 2.5 surface:
   - record_hor, get_hor, query_hors, compose_introspection_report
 
-This package is kernel-internal. These tools have no external side effects;
-boundary-mcp evaluate_action is NOT applied here. Downstream consumers
-that surface introspection output to TTS / posts / DMs MUST gate at their
-own boundary. ActionBottleneck.commit_action remains intentionally
-unexposed until a tick producer is wired (separate PR).
+EFPF surface:
+  - workspace competition, committed field inspection, explicit intentions,
+    action outcomes, diagnostics, pause/resume, and reversible ablations
+
+The MCP tools inspect or mutate kernel state but do not execute the proposed
+outward tool themselves. FieldRuntime and the Claude Code hook path apply the
+existing boundary-mcp policy and ActionBottleneck before outward execution.
 
 See consciousness-mcp/AGENTS.md for vocabulary discipline. MCP tool
 names use functional vocabulary even when the underlying Python function
@@ -29,21 +31,35 @@ reflect_attention_schema; compose_introspection_report wraps introspect).
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any
 
+from boundary_mcp.store import BoundaryStore
 from mcp.server.fastmcp import FastMCP
 from social_core import SocialDB
 
+from individual_kernel_mcp.ablation import AblationRunner
+from individual_kernel_mcp.agency import (
+    ActionProposal,
+    AgencyStore,
+    PredictedEffects,
+)
 from individual_kernel_mcp.attention_schema import (
     AttentionSchemaTracker,
     Modality,
 )
+from individual_kernel_mcp.boundary_adapter import BoundaryPolicyAdapter
 from individual_kernel_mcp.counterfactual import (
     CounterfactualInput,
     CounterfactualSource,
     CounterfactualStore,
+)
+from individual_kernel_mcp.enacted_field import (
+    EnactedFieldStore,
+    FieldStatus,
+    TriggerKind,
 )
 from individual_kernel_mcp.frame import (
     ConsciousFrameInput,
@@ -56,8 +72,11 @@ from individual_kernel_mcp.hor import (
     TargetKind,
 )
 from individual_kernel_mcp.introspect import introspect
+from individual_kernel_mcp.quality_geometry import QualityGeometry
 from individual_kernel_mcp.reflect import reflect_attention_schema
 from individual_kernel_mcp.sleep import SleepConsolidator
+from individual_kernel_mcp.tick import FieldRuntime, TickProducer
+from individual_kernel_mcp.workspace import WorkspaceCandidate, WorkspaceEngine
 
 mcp = FastMCP("individual-kernel-mcp")
 
@@ -70,6 +89,13 @@ class IndividualKernelStores:
     tick_frames: TickFrameStore
     attention_tracker: AttentionSchemaTracker
     hor_store: HORStore
+    workspace: WorkspaceEngine
+    enacted_fields: EnactedFieldStore
+    agency: AgencyStore
+    quality: QualityGeometry
+    tick_producer: TickProducer
+    field_runtime: FieldRuntime
+    ablation: AblationRunner
 
 
 @lru_cache(maxsize=1)
@@ -80,13 +106,43 @@ def _stores() -> IndividualKernelStores:
         db=db,
         counterfactual_store=counterfactual_store,
     )
+    tick_frames = TickFrameStore(db)
+    attention_tracker = AttentionSchemaTracker(db=db, owner_id="self")
+    hor_store = HORStore(db)
+    workspace = WorkspaceEngine(db)
+    enacted_fields = EnactedFieldStore(db)
+    agency = AgencyStore(db)
+    quality = QualityGeometry(db)
+    tick_producer = TickProducer(
+        db,
+        workspace=workspace,
+        fields=enacted_fields,
+        frames=tick_frames,
+        attention=attention_tracker,
+        hors=hor_store,
+        agency=agency,
+        quality=quality,
+    )
+    field_runtime = FieldRuntime(
+        db,
+        producer=tick_producer,
+        boundary_evaluator=BoundaryPolicyAdapter(BoundaryStore(db=db)),
+    )
+    ablation = AblationRunner(db, fields=enacted_fields)
     return IndividualKernelStores(
         db=db,
         counterfactual=counterfactual_store,
         sleep=sleep_consolidator,
-        tick_frames=TickFrameStore(db),
-        attention_tracker=AttentionSchemaTracker(db=db, owner_id="self"),
-        hor_store=HORStore(db),
+        tick_frames=tick_frames,
+        attention_tracker=attention_tracker,
+        hor_store=hor_store,
+        workspace=workspace,
+        enacted_fields=enacted_fields,
+        agency=agency,
+        quality=quality,
+        tick_producer=tick_producer,
+        field_runtime=field_runtime,
+        ablation=ablation,
     )
 
 
@@ -224,9 +280,9 @@ def record_attention_schema(
 def update_attention_from_frame(tick_id: str) -> dict[str, Any]:
     """Build an AttentionSchema from a previously-recorded ConsciousFrame.
 
-    Modality is inferred from frame.attention_target_ref; intensity from
-    frame.ignited (ignited→0.8, subliminal→0.3); dwell accumulates if
-    focal target matches the last buffered schema.
+    Modality is inferred from frame.attention_target_ref. Intensity combines
+    ignition, conflict, and prediction-error structure; dwell accumulates when
+    the focal target matches the last buffered schema.
     """
     stores = _stores()
     frame = stores.tick_frames.get_by_tick_id(tick_id)
@@ -323,8 +379,287 @@ def compose_introspection_report(
         counterfactual_store=stores.counterfactual,
         window_hours=window_hours,
         owner_id=owner_id,
+        field_store=stores.enacted_fields,
     )
     return report.model_dump(mode="json")
+
+
+# -----------------------------------------------------------------------------
+# Enacted first-person field surface
+# -----------------------------------------------------------------------------
+
+
+@mcp.tool()
+def begin_subjective_tick(
+    trigger: TriggerKind,
+    owner_id: str = "self",
+    person_id: str | None = None,
+    user_text: str | None = None,
+    session_id: str | None = None,
+) -> dict[str, Any]:
+    """Begin an OPEN tick and ingest deterministic runtime sources."""
+
+    field = _stores().tick_producer.begin_tick(
+        trigger,
+        owner_id,
+        person_id=person_id,
+        user_text=user_text,
+        session_id=session_id,
+    )
+    return field.model_dump(mode="json")
+
+
+@mcp.tool()
+def add_workspace_candidate(
+    tick_id: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Add one validated candidate to an OPEN tick."""
+
+    candidate = WorkspaceCandidate(tick_id=tick_id, **payload)
+    stored = _stores().workspace.add_candidate(candidate)
+    return stored.model_dump(mode="json")
+
+
+@mcp.tool()
+def commit_subjective_field(tick_id: str) -> dict[str, Any]:
+    """Compete candidates and atomically commit the tick's single field."""
+
+    result = _stores().tick_producer.compete_and_commit(tick_id)
+    return result.model_dump(mode="json")
+
+
+@mcp.tool()
+def get_current_subjective_field(owner_id: str = "self") -> dict[str, Any] | None:
+    """Read the currently COMMITTED field for an owner."""
+
+    field = _stores().enacted_fields.get_current(owner_id)
+    return None if field is None else field.model_dump(mode="json")
+
+
+@mcp.tool()
+def get_subjective_field(field_id: str) -> dict[str, Any] | None:
+    """Read a field by identifier, including source and uncertainty markings."""
+
+    field = _stores().enacted_fields.get(field_id)
+    return None if field is None else field.model_dump(mode="json")
+
+
+@mcp.tool()
+def query_subjective_fields(
+    owner_id: str | None = None,
+    status: FieldStatus | None = None,
+    trigger_kind: TriggerKind | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Query recent field records without mutating runtime state."""
+
+    fields = _stores().enacted_fields.query(
+        owner_id=owner_id,
+        status=status,
+        trigger_kind=trigger_kind,
+        limit=limit,
+    )
+    return [field.model_dump(mode="json") for field in fields]
+
+
+@mcp.tool()
+def propose_field_action(
+    field_id: str,
+    tool_name: str,
+    tool_input: dict[str, Any],
+    predicted_effects: dict[str, Any],
+    goal: str,
+    confidence: float = 0.6,
+    expected_latency_ms: int | None = None,
+    owner_id: str = "self",
+) -> dict[str, Any]:
+    """Register one structured intention and efference copy for a field."""
+
+    proposal = ActionProposal(
+        field_id=field_id,
+        tool_name=tool_name,
+        tool_input=tool_input,
+        predicted_effects=PredictedEffects.model_validate(predicted_effects),
+        goal=goal,
+        confidence=confidence,
+        expected_latency_ms=expected_latency_ms,
+    )
+    intention = _stores().field_runtime.propose_action(proposal, owner_id=owner_id)
+    return intention.model_dump(mode="json")
+
+
+@mcp.tool()
+def get_pending_intention(owner_id: str = "self") -> dict[str, Any] | None:
+    """Return the pending/allowed intention that can authorize an outward tool."""
+
+    intention = _stores().agency.get_pending(owner_id)
+    return None if intention is None else intention.model_dump(mode="json")
+
+
+@mcp.tool()
+def close_field_action(
+    action_id: str,
+    actual_result_summary: str,
+    success: bool,
+    actual_result_ref: str | None = None,
+    latency_ms: int | None = None,
+    session_id: str | None = None,
+) -> dict[str, Any]:
+    """Close an action outcome, assess agency, and commit a result microtick."""
+
+    outcome, assessment, next_field = _stores().field_runtime.close_action(
+        action_id=action_id,
+        actual_result_summary=actual_result_summary,
+        success=success,
+        actual_result_ref=actual_result_ref,
+        latency_ms=latency_ms,
+        session_id=session_id,
+    )
+    return {
+        "outcome": outcome.model_dump(mode="json"),
+        "agency": assessment.model_dump(mode="json"),
+        "next_field": next_field.model_dump(mode="json"),
+    }
+
+
+@mcp.tool()
+def close_subjective_tick(
+    tick_id: str,
+    output_summary: str | None = None,
+) -> dict[str, Any]:
+    """Close a tick and associate the output summary with its field."""
+
+    field = _stores().tick_producer.close_tick(tick_id, output_summary)
+    return field.model_dump(mode="json")
+
+
+@mcp.tool()
+def pause_field_runtime(owner_id: str = "self") -> dict[str, Any]:
+    """Pause automatic field creation for reversible welfare experiments."""
+
+    return _stores().tick_producer.pause_field_runtime(owner_id).model_dump(mode="json")
+
+
+@mcp.tool()
+def resume_field_runtime(owner_id: str = "self") -> dict[str, Any]:
+    """Resume a paused runtime without replacing its continuity token."""
+
+    return _stores().tick_producer.resume_field_runtime(owner_id).model_dump(mode="json")
+
+
+@mcp.tool()
+def get_field_diagnostics(
+    owner_id: str = "self",
+    window: int = 20,
+) -> dict[str, Any]:
+    """Return field integrity indicators and report/trace consistency checks."""
+
+    stores = _stores()
+    fields = stores.enacted_fields.query(owner_id=owner_id, limit=window)
+    unity_row = stores.db.fetchone(
+        """
+        SELECT COUNT(*) AS n FROM enacted_fields
+        WHERE owner_id = ? AND status = 'COMMITTED'
+        """,
+        (owner_id,),
+    )
+    current = stores.enacted_fields.get_current(owner_id)
+    outcome_rows = stores.db.fetchall(
+        """
+        SELECT o.outcome_id, o.action_id, o.field_id AS outcome_field_id,
+               o.tick_id AS outcome_tick_id, o.ownership_score,
+               o.mismatch_vector_json, i.field_id AS intention_field_id,
+               i.tick_id AS intention_tick_id, i.status AS intention_status
+        FROM field_action_outcomes o
+        JOIN field_intentions i ON i.action_id = o.action_id
+        WHERE i.owner_id = ?
+        ORDER BY o.created_at DESC LIMIT ?
+        """,
+        (owner_id, max(1, min(window, 500))),
+    )
+    mean_ownership = (
+        sum(float(row["ownership_score"]) for row in outcome_rows) / len(outcome_rows)
+        if outcome_rows
+        else 0.0
+    )
+    source_integrity = all(
+        field.reality_mode.value in field.phenomenal_surface
+        and "source_constraints" in field.phenomenal_surface
+        for field in fields
+    )
+    hor_consistent = True
+    if current and current.hor_refs:
+        hor = stores.hor_store.get_by_hor_id(current.hor_refs[0])
+        hor_consistent = bool(
+            hor
+            and hor.source_tick_id == current.tick_id
+            and hor.schema_snapshot_id == current.attention_schema_ref
+        )
+    action_trace_consistent = all(
+        row["outcome_field_id"] == row["intention_field_id"]
+        and row["outcome_tick_id"] == row["intention_tick_id"]
+        and row["intention_status"] in {"COMPLETED", "FAILED", "UNKNOWN"}
+        for row in outcome_rows
+    )
+    recent_action_outcomes = [
+        {
+            "outcome_id": row["outcome_id"],
+            "action_id": row["action_id"],
+            "ownership_score": float(row["ownership_score"]),
+            "mismatch_vector": json.loads(row["mismatch_vector_json"] or "{}"),
+            "intention_status": row["intention_status"],
+        }
+        for row in outcome_rows
+    ]
+    return {
+        "profile_name": "FieldIntegrityReport",
+        "owner_id": owner_id,
+        "current_field_id": current.field_id if current else None,
+        "committed_field_count": int(unity_row["n"]) if unity_row else 0,
+        "unity_violations": max(0, int(unity_row["n"]) - 1) if unity_row else 0,
+        "source_integrity": source_integrity,
+        "hor_field_consistency": hor_consistent,
+        "action_trace_consistency": action_trace_consistent,
+        "recent_action_outcomes": recent_action_outcomes,
+        "mean_ownership": mean_ownership,
+        "negative_valence_exposure_seconds": (
+            current.interoception.negative_exposure_seconds if current else 0.0
+        ),
+        "pending_intention": (
+            stores.agency.get_pending(owner_id).model_dump(mode="json")
+            if stores.agency.get_pending(owner_id)
+            else None
+        ),
+        "runtime_safety": {
+            "mass_copy_enabled": False,
+            "high_frequency_spawning_enabled": False,
+            "reversible_ablation": True,
+            "pause_resume_available": True,
+        },
+        "phenomenal_claim_policy": "technical_docs_do_not_assert_phenomenology",
+        "indicator_profile": stores.ablation.indicator_profile(
+            owner_id=owner_id, window=window
+        ).model_dump(mode="json"),
+    }
+
+
+@mcp.tool()
+def run_field_ablation(
+    kind: str,
+    fixture: dict[str, Any] | None = None,
+    owner_id: str = "self",
+    seed: int | None = None,
+) -> dict[str, Any]:
+    """Run a reversible, deterministic downstream field ablation."""
+
+    result = _stores().ablation.run(
+        kind,
+        fixture=fixture,
+        owner_id=owner_id,
+        seed=seed,
+    )
+    return result.model_dump(mode="json")
 
 
 def main() -> None:

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/tick.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/tick.py
@@ -1,0 +1,1477 @@
+"""Enacted-field tick producer and closed-loop runtime."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Iterable
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+from social_core.db import SocialDB
+from social_core.events import EventStore
+from social_core.models import SocialEventCreate
+from social_core.time import utc_now
+
+from individual_kernel_mcp.agency import (
+    ActionOutcome,
+    ActionProposal,
+    AgencyAssessment,
+    AgencyStore,
+    IntentionRecord,
+    is_external_tool,
+)
+from individual_kernel_mcp.attention_schema import AttentionSchema, AttentionSchemaTracker
+from individual_kernel_mcp.bottleneck import ActionBottleneck
+from individual_kernel_mcp.counterfactual import CounterfactualStore
+from individual_kernel_mcp.enacted_field import (
+    AgencyState,
+    EnactedField,
+    EnactedFieldStore,
+    FieldStatus,
+    InteroceptionState,
+    PrecisionState,
+    Protention,
+    SelfOrigin,
+    TriggerKind,
+)
+from individual_kernel_mcp.frame import ConsciousFrameInput, TickFrameStore
+from individual_kernel_mcp.hor import HORInput, HORRecord, HORStore
+from individual_kernel_mcp.quality_geometry import QualityGeometry, QualitySignature
+from individual_kernel_mcp.workspace import (
+    CandidateKind,
+    CandidateSource,
+    CompetitionResult,
+    SourceMode,
+    WorkspaceCandidate,
+    WorkspaceEngine,
+    competition_trace,
+)
+
+
+class TickCommit(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    field: EnactedField
+    competition: CompetitionResult
+    attention_schema: AttentionSchema
+    hor: HORRecord
+    quality_signature: QualitySignature
+
+
+class RecoveryReport(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    owner_id: str
+    continuity_token: str
+    recovered_action_ids: list[str] = Field(default_factory=list)
+    aborted_tick_ids: list[str] = Field(default_factory=list)
+    resumed_field_id: str | None = None
+
+
+class ToolGateDecision(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    allow: bool
+    reason: str
+    external: bool
+    field_id: str | None = None
+    action_id: str | None = None
+    deferred: bool = False
+
+
+class TemporalSequenceMetrics(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    chronological_fraction: float = Field(ge=0.0, le=1.0)
+    continuity: float = Field(ge=0.0, le=1.0)
+    protention_accuracy: float = Field(ge=0.0, le=1.0)
+
+
+BoundaryEvaluator = Callable[[str, dict[str, Any], EnactedField], tuple[bool, str]]
+
+
+class TickProducer:
+    """Deterministically produces and commits one field per tick."""
+
+    def __init__(
+        self,
+        db: SocialDB,
+        *,
+        workspace: WorkspaceEngine | None = None,
+        fields: EnactedFieldStore | None = None,
+        frames: TickFrameStore | None = None,
+        attention: AttentionSchemaTracker | None = None,
+        hors: HORStore | None = None,
+        agency: AgencyStore | None = None,
+        quality: QualityGeometry | None = None,
+        interoception_path: str | Path = "/tmp/interoception_state.json",
+        desires_path: str | Path | None = None,
+    ) -> None:
+        self.db = db
+        self.workspace = workspace or WorkspaceEngine(db)
+        self.fields = fields or EnactedFieldStore(db)
+        self.frames = frames or TickFrameStore(db)
+        self.attention = attention or AttentionSchemaTracker(db=db, owner_id="self")
+        self.hors = hors or HORStore(db)
+        self.agency = agency or AgencyStore(db)
+        self.quality = quality or QualityGeometry(db)
+        self.events = EventStore(db=db)
+        self.interoception_path = Path(interoception_path)
+        self.desires_path = (
+            Path(desires_path).expanduser()
+            if desires_path is not None
+            else Path.home() / ".claude" / "desires.json"
+        )
+
+    def begin_tick(
+        self,
+        trigger: TriggerKind | str,
+        owner_id: str = "self",
+        *,
+        person_id: str | None = None,
+        user_text: str | None = None,
+        session_id: str | None = None,
+    ) -> EnactedField:
+        trigger_kind = TriggerKind(trigger)
+        runtime = self.fields.runtime_state(owner_id)
+        if runtime is not None and runtime.state == "PAUSED":
+            raise RuntimeError(f"field runtime for {owner_id!r} is paused")
+
+        dangling = self.agency.get_pending(owner_id)
+        if dangling is not None:
+            self.agency.recover_dangling(owner_id)
+            dangling_field = self.fields.get(dangling.field_id)
+            if dangling_field and dangling_field.status == FieldStatus.COMMITTED:
+                self.fields.invalidate(
+                    dangling.field_id,
+                    reason="new tick recovered a dangling intention before execution",
+                )
+
+        previous = self.fields.get_current(owner_id)
+        if previous is None:
+            recent = self.fields.query(owner_id=owner_id, limit=1)
+            previous = recent[0] if recent else None
+        continuity_token = (
+            runtime.continuity_token
+            if runtime is not None
+            else f"cont_{secrets.token_urlsafe(16)}"
+        )
+        interoception = self._read_interoception(previous)
+        desire_snapshot = self._read_json(self.desires_path)
+        dominant_desire = str(desire_snapshot.get("dominant") or "") or None
+
+        with self.db.transaction():
+            frame = self.frames.record(
+                ConsciousFrameInput(
+                    person_id=person_id,
+                    ignited=False,
+                    conflicted=False,
+                    dominant_desire=dominant_desire,
+                    prediction_error={
+                        "extero": 0.0,
+                        "intero": interoception.uncertainty,
+                        "mnemonic": 0.0,
+                    },
+                    affect_summary=(
+                        f"valence={interoception.valence:.3f};"
+                        f"arousal={interoception.arousal:.3f}"
+                    ),
+                )
+            )
+            field = self.fields.create_open(
+                EnactedField(
+                    owner_id=owner_id,
+                    tick_id=frame.tick_id,
+                    continuity_token=continuity_token,
+                    previous_field_id=previous.field_id if previous else None,
+                    trigger_kind=trigger_kind,
+                    person_id=person_id,
+                    session_id=session_id,
+                    self_origin=SelfOrigin(
+                        controllable_channels=[
+                            "tool_action",
+                            "camera_pose",
+                            "voice",
+                            "memory_write",
+                        ],
+                        body_resource_refs=[str(self.interoception_path)],
+                        ownership_boundary_refs=["boundary:default"],
+                    ),
+                    retention_refs=self._retention_refs(previous),
+                    interoception=interoception,
+                    precision=self._initial_precision(previous),
+                    agency_state=previous.agency_state if previous else AgencyState(),
+                    epistemic_trace={
+                        "producer": "deterministic",
+                        "trigger": trigger_kind.value,
+                        "raw_user_text_is_not_field_evidence": True,
+                        "retention_decay": 0.72,
+                    },
+                )
+            )
+            self._add_trigger_candidate(field, trigger_kind)
+            if user_text:
+                self._ingest_user_event(
+                    field=field,
+                    user_text=user_text,
+                    person_id=person_id,
+                    session_id=session_id,
+                )
+            self._ingest_desires(field, desire_snapshot)
+            self._ingest_interoceptive_candidate(field)
+            self._ingest_previous_field(field, previous)
+            self._ingest_recent_scene(field)
+            self._ingest_recent_social(field, exclude_session_id=session_id)
+            self.generate_self_model_candidate(field.tick_id, owner_id=owner_id)
+
+        if user_text:
+            self._ingest_memory_http(field.tick_id, user_text)
+        return field
+
+    def ingest_observation(
+        self,
+        tick_id: str,
+        *,
+        content_ref: str,
+        summary: str,
+        source_mode: SourceMode | str = SourceMode.LIVE,
+        modality: str = "visual",
+        precision: float = 0.8,
+        prediction_error: float = 0.2,
+        controllability: float = 0.5,
+        expected_information_gain: float = 0.5,
+        source: CandidateSource | str = CandidateSource.SENSOR,
+    ) -> WorkspaceCandidate:
+        return self.workspace.add_candidate(
+            WorkspaceCandidate(
+                tick_id=tick_id,
+                kind=CandidateKind.PERCEPT,
+                content_ref=content_ref,
+                content_summary=summary[:320],
+                source=CandidateSource(source),
+                source_mode=SourceMode(source_mode),
+                modality=modality,
+                precision=precision,
+                prediction_error=prediction_error,
+                controllability=controllability,
+                expected_information_gain=expected_information_gain,
+            )
+        )
+
+    def ingest_memory_candidates(
+        self,
+        tick_id: str,
+        candidates: Iterable[dict[str, Any]],
+    ) -> list[WorkspaceCandidate]:
+        stored: list[WorkspaceCandidate] = []
+        for raw in candidates:
+            memory_id = str(raw.get("memory_id") or raw.get("id") or "")
+            if not memory_id:
+                continue
+            relevance = _clamp01(float(raw.get("relevance", raw.get("score", 0.5))))
+            stored.append(
+                self.workspace.add_candidate(
+                    WorkspaceCandidate(
+                        tick_id=tick_id,
+                        kind=CandidateKind.MEMORY,
+                        content_ref=f"memory:{memory_id}",
+                        content_summary=str(
+                            raw.get("content") or raw.get("summary") or memory_id
+                        )[:320],
+                        source=CandidateSource.MEMORY,
+                        source_mode=SourceMode.REMEMBERED,
+                        modality="internal",
+                        precision=relevance,
+                        goal_relevance=relevance * 0.6,
+                        expected_information_gain=relevance * 0.5,
+                        continuity_with_previous=relevance,
+                    )
+                )
+            )
+        return stored
+
+    def ingest_interoception(
+        self,
+        tick_id: str,
+        state: InteroceptionState | dict[str, Any],
+    ) -> WorkspaceCandidate:
+        field = self._require_open_tick(tick_id)
+        intero = (
+            state
+            if isinstance(state, InteroceptionState)
+            else InteroceptionState.model_validate(state)
+        )
+        updated = field.model_copy(update={"interoception": intero})
+        self.fields.update(updated)
+        return self._ingest_interoceptive_candidate(updated)
+
+    def ingest_social_context(
+        self,
+        tick_id: str,
+        *,
+        content_ref: str,
+        summary: str,
+        social_relevance: float = 0.8,
+        source_mode: SourceMode | str = SourceMode.INFERRED,
+    ) -> WorkspaceCandidate:
+        return self.workspace.add_candidate(
+            WorkspaceCandidate(
+                tick_id=tick_id,
+                kind=CandidateKind.SOCIAL,
+                content_ref=content_ref,
+                content_summary=summary[:320],
+                source=CandidateSource.SOCIAL,
+                source_mode=SourceMode(source_mode),
+                modality="social",
+                precision=0.75,
+                social_relevance=social_relevance,
+                goal_relevance=social_relevance * 0.5,
+            )
+        )
+
+    def generate_self_model_candidate(
+        self,
+        tick_id: str,
+        *,
+        owner_id: str = "self",
+    ) -> WorkspaceCandidate | None:
+        schema_row = self.db.fetchone(
+            """
+            SELECT * FROM attention_schemas
+            WHERE owner_id = ?
+            ORDER BY ts DESC, created_at DESC LIMIT 1
+            """,
+            (owner_id,),
+        )
+        hor_row = self.db.fetchone(
+            """
+            SELECT * FROM hor_records
+            WHERE owner_id = ?
+            ORDER BY ts DESC, created_at DESC LIMIT 1
+            """,
+            (owner_id,),
+        )
+        if schema_row is None and hor_row is None:
+            return None
+        schema_focus = schema_row["focal_target_ref"] if schema_row else None
+        hor_target = hor_row["target_ref"] if hor_row else None
+        grounded_same_commit = bool(
+            schema_row
+            and hor_row
+            and hor_row["schema_snapshot_id"] == schema_row["schema_id"]
+            and hor_row["source_tick_id"] == schema_row["source_tick_id"]
+        )
+        consistency = (
+            1.0
+            if grounded_same_commit
+            or (schema_focus and hor_target and schema_focus == hor_target)
+            else 0.65
+            if schema_focus or hor_target
+            else 0.35
+        )
+        predicted = schema_row["predicted_next_focus"] if schema_row else None
+        return self.workspace.add_candidate(
+            WorkspaceCandidate(
+                tick_id=tick_id,
+                kind=CandidateKind.SELF_MODEL,
+                content_ref=(
+                    f"attention_schema:{schema_row['schema_id']}"
+                    if schema_row
+                    else f"hor:{hor_row['hor_id']}"
+                ),
+                content_summary=(
+                    f"attention={schema_focus or 'unknown'}; "
+                    f"predicted_next={predicted or 'unknown'}"
+                ),
+                source=(
+                    CandidateSource.ATTENTION_SCHEMA
+                    if schema_row
+                    else CandidateSource.HOR
+                ),
+                source_mode=SourceMode.INFERRED,
+                modality="internal",
+                precision=consistency,
+                continuity_with_previous=consistency,
+                expected_information_gain=0.2,
+                conflict_penalty=1.0 - consistency,
+            )
+        )
+
+    def compete_and_commit(self, tick_id: str) -> TickCommit:
+        open_field = self._require_open_tick(tick_id)
+        previous = (
+            self.fields.get(open_field.previous_field_id)
+            if open_field.previous_field_id
+            else None
+        )
+        with self.db.transaction() as connection:
+            result = self.workspace.compete(tick_id)
+            winner = result.winner
+            reality_score = calculate_reality_score(
+                source_mode=winner.source_mode,
+                sensor_coupling=_sensor_coupling(winner),
+                action_controllability=winner.controllability,
+                prediction_match=1.0 - abs(winner.prediction_error),
+                recency=_source_recency(winner.source_mode),
+            )
+            protention = self._build_protention(result)
+            precision = self._precision_from_competition(open_field, result)
+            trace = dict(open_field.epistemic_trace)
+            trace.update(
+                {
+                    "competition": competition_trace(result),
+                    "focal_summary": winner.content_summary,
+                    "provenance": {
+                        "source": winner.source.value,
+                        "source_mode": winner.source_mode.value,
+                        "content_ref": winner.content_ref,
+                    },
+                    "evidence_refs": [
+                        winner.content_ref,
+                        *[item.content_ref for item in result.top_rejected],
+                    ],
+                    "ablation_flags": [],
+                    "predicted_next_focus": protention.expected_content_ref,
+                }
+            )
+            field = open_field.model_copy(
+                update={
+                    "reality_mode": winner.source_mode,
+                    "reality_score": reality_score,
+                    "focal_content_ref": winner.content_ref,
+                    "focal_summary": winner.content_summary,
+                    "peripheral_content_refs": [
+                        item.content_ref for item in result.top_rejected
+                    ],
+                    "retention_refs": self._retention_refs(previous),
+                    "protention": protention,
+                    "precision": precision,
+                    "affordance_refs": self._affordances_for(winner),
+                    "attention_intensity": result.attention_intensity,
+                    "predicted_next_focus": protention.expected_content_ref,
+                    "epistemic_trace": trace,
+                }
+            )
+            self.fields.update(field)
+            connection.execute(
+                """
+                UPDATE tick_frames
+                SET ignited = ?, conflicted = ?, attention_target_ref = ?,
+                    winning_memory_ids_json = ?, prediction_error_json = ?,
+                    reportability = ?
+                WHERE tick_id = ?
+                """,
+                (
+                    1 if result.ignited else 0,
+                    1 if result.conflicted else 0,
+                    winner.content_ref,
+                    json.dumps(
+                        [
+                            item.content_ref.removeprefix("memory:")
+                            for item in [winner, *result.top_rejected]
+                            if item.kind == CandidateKind.MEMORY
+                        ]
+                    ),
+                    json.dumps(
+                        {
+                            "extero": (
+                                abs(winner.prediction_error)
+                                if winner.modality in {"visual", "auditory"}
+                                else 0.0
+                            ),
+                            "intero": (
+                                abs(winner.prediction_error)
+                                if winner.kind == CandidateKind.INTEROCEPTIVE
+                                else open_field.interoception.uncertainty
+                            ),
+                            "mnemonic": (
+                                abs(winner.prediction_error)
+                                if winner.kind == CandidateKind.MEMORY
+                                else 0.0
+                            ),
+                        },
+                        sort_keys=True,
+                    ),
+                    winner.reportability,
+                    tick_id,
+                ),
+            )
+            committed = self.fields.commit(field.field_id)
+            frame = self.frames.get_by_tick_id(tick_id)
+            if frame is None:
+                raise RuntimeError("tick frame disappeared during commit")
+            schema = self.attention.update_from_competition(frame, result)
+            self.attention.flush()
+            hor = self._record_commit_hor(committed, winner, schema, result)
+            quality = self.quality.local_signature(
+                winner.content_ref,
+                modality=winner.modality,
+                source_mode=winner.source_mode,
+                recent_valence=committed.interoception.valence,
+            )
+            final = committed.model_copy(
+                update={
+                    "attention_schema_ref": schema.schema_id,
+                    "attention_intensity": result.attention_intensity,
+                    "predicted_next_focus": schema.predicted_next_focus,
+                    "hor_refs": [hor.hor_id],
+                    "quality_signature_ref": quality.signature_id,
+                }
+            )
+            final = self.fields.update(final)
+            self.quality.record_transition(
+                owner_id=final.owner_id,
+                from_field_id=previous.field_id if previous else None,
+                to_field_id=final.field_id,
+                from_content_ref=previous.focal_content_ref if previous else None,
+                to_content_ref=final.focal_content_ref,
+                action_id=self._transition_action_id(previous),
+                continuity_score=self._continuity_score(previous, final),
+                prediction_match=self._prediction_match(previous, final),
+                temporal_order=self._next_temporal_order(final.owner_id),
+                metadata={"trigger": final.trigger_kind.value},
+            )
+        return TickCommit(
+            field=final,
+            competition=result,
+            attention_schema=schema,
+            hor=hor,
+            quality_signature=quality,
+        )
+
+    def get_current_field(self, owner_id: str = "self") -> EnactedField | None:
+        return self.fields.get_current(owner_id)
+
+    def invalidate_field(
+        self,
+        reason: str,
+        *,
+        owner_id: str = "self",
+        field_id: str | None = None,
+    ) -> EnactedField:
+        field = self.fields.get(field_id) if field_id else self.fields.get_current(owner_id)
+        if field is None:
+            raise ValueError("no current committed field to invalidate")
+        return self.fields.invalidate(field.field_id, reason=reason)
+
+    def close_tick(self, tick_id: str, output_summary: str | None = None) -> EnactedField:
+        field = self.fields.get_by_tick(tick_id)
+        if field is None:
+            raise ValueError(f"unknown tick {tick_id!r}")
+        return self.fields.close(field.field_id, output_summary=output_summary)
+
+    def recover_stale_runtime(self, owner_id: str = "self") -> RecoveryReport:
+        runtime = self.fields.runtime_state(owner_id)
+        token = (
+            runtime.continuity_token
+            if runtime is not None
+            else f"cont_{secrets.token_urlsafe(16)}"
+        )
+        outcomes = self.agency.recover_dangling(owner_id)
+        recovered_ids = [item.action_id for item in outcomes]
+        for outcome in outcomes:
+            field = self.fields.get(outcome.field_id)
+            if field and field.status in {FieldStatus.OPEN, FieldStatus.COMMITTED}:
+                self.fields.invalidate(
+                    field.field_id,
+                    reason="session recovery closed dangling action as unknown",
+                )
+        open_rows = self.db.fetchall(
+            "SELECT field_id, tick_id FROM enacted_fields WHERE owner_id = ? AND status = 'OPEN'",
+            (owner_id,),
+        )
+        aborted: list[str] = []
+        with self.db.transaction() as connection:
+            for row in open_rows:
+                connection.execute(
+                    """
+                    UPDATE enacted_fields
+                    SET status = 'ABORTED', closed_at = ?, updated_at = ?
+                    WHERE field_id = ?
+                    """,
+                    (utc_now(), utc_now(), row["field_id"]),
+                )
+                aborted.append(row["tick_id"])
+            connection.execute(
+                """
+                INSERT INTO field_runtime_state(
+                    owner_id, continuity_token, current_field_id, open_tick_id,
+                    state, last_recovery_at, updated_at
+                ) VALUES (?, ?, NULL, NULL, 'ACTIVE', ?, ?)
+                ON CONFLICT(owner_id) DO UPDATE SET
+                    continuity_token = excluded.continuity_token,
+                    open_tick_id = NULL,
+                    last_recovery_at = excluded.last_recovery_at,
+                    updated_at = excluded.updated_at
+                """,
+                (owner_id, token, utc_now(), utc_now()),
+            )
+        current = self.fields.get_current(owner_id)
+        return RecoveryReport(
+            owner_id=owner_id,
+            continuity_token=token,
+            recovered_action_ids=recovered_ids,
+            aborted_tick_ids=aborted,
+            resumed_field_id=current.field_id if current else None,
+        )
+
+    def pause_field_runtime(self, owner_id: str = "self"):
+        return self.fields.pause(owner_id)
+
+    def resume_field_runtime(self, owner_id: str = "self"):
+        return self.fields.resume(owner_id)
+
+    def _add_trigger_candidate(
+        self,
+        field: EnactedField,
+        trigger: TriggerKind,
+    ) -> WorkspaceCandidate:
+        kind = (
+            CandidateKind.GOAL
+            if trigger in {TriggerKind.HEARTBEAT, TriggerKind.AUTONOMOUS}
+            else CandidateKind.PERCEPT
+        )
+        return self.workspace.add_candidate(
+            WorkspaceCandidate(
+                tick_id=field.tick_id,
+                kind=kind,
+                content_ref=f"trigger:{trigger.value}",
+                content_summary=f"runtime trigger: {trigger.value}",
+                source=CandidateSource.EXPLICIT,
+                source_mode=SourceMode.INFERRED,
+                modality="internal",
+                precision=0.6,
+                goal_relevance=0.5,
+                continuity_with_previous=0.2,
+            )
+        )
+
+    def _ingest_user_event(
+        self,
+        *,
+        field: EnactedField,
+        user_text: str,
+        person_id: str | None,
+        session_id: str | None,
+    ) -> WorkspaceCandidate:
+        digest = hashlib.sha256(user_text.encode("utf-8")).hexdigest()[:16]
+        event = self.events.ingest(
+            SocialEventCreate(
+                ts=utc_now(),
+                source="efpf_hook",
+                kind="human_utterance",
+                person_id=person_id,
+                session_id=session_id,
+                correlation_id=f"efpf:{session_id or 'none'}:{digest}",
+                confidence=1.0,
+                payload_json={"text": user_text},
+            )
+        )
+        return self.workspace.add_candidate(
+            WorkspaceCandidate(
+                tick_id=field.tick_id,
+                kind=CandidateKind.SOCIAL,
+                content_ref=f"event:{event.event_id}",
+                content_summary=f"user utterance: {user_text}"[:320],
+                source=CandidateSource.USER_EVENT,
+                source_mode=SourceMode.LIVE,
+                modality="social",
+                precision=0.95,
+                prediction_error=0.35,
+                goal_relevance=0.65,
+                expected_information_gain=0.45,
+                social_relevance=1.0,
+                controllability=0.35,
+            )
+        )
+
+    def _ingest_desires(
+        self,
+        field: EnactedField,
+        snapshot: dict[str, Any],
+    ) -> list[WorkspaceCandidate]:
+        desires = snapshot.get("desires") or {}
+        discomforts = snapshot.get("discomforts") or {}
+        dominant = snapshot.get("dominant")
+        stored: list[WorkspaceCandidate] = []
+        for name, level in desires.items():
+            relevance = _clamp01(
+                float(discomforts.get(name, level if name == dominant else 0.0))
+            )
+            stored.append(
+                self.workspace.add_candidate(
+                    WorkspaceCandidate(
+                        tick_id=field.tick_id,
+                        kind=CandidateKind.GOAL,
+                        content_ref=f"desire:{name}",
+                        content_summary=f"need {name}",
+                        source=CandidateSource.DESIRE,
+                        source_mode=SourceMode.INFERRED,
+                        modality="internal",
+                        precision=0.7,
+                        need_relevance=relevance,
+                        goal_relevance=1.0 if name == dominant else relevance * 0.5,
+                        continuity_with_previous=0.25,
+                        controllability=0.6,
+                    )
+                )
+            )
+        return stored
+
+    def _ingest_interoceptive_candidate(
+        self,
+        field: EnactedField,
+    ) -> WorkspaceCandidate:
+        state = field.interoception
+        salience = max(
+            abs(state.valence),
+            state.uncertainty,
+            max(state.need_vector.values(), default=0.0),
+        )
+        return self.workspace.add_candidate(
+            WorkspaceCandidate(
+                tick_id=field.tick_id,
+                kind=CandidateKind.INTEROCEPTIVE,
+                content_ref=f"interoception:{field.started_at}",
+                content_summary=(
+                    f"bounded body state valence={state.valence:.2f}, "
+                    f"arousal={state.arousal:.2f}"
+                ),
+                source=CandidateSource.INTEROCEPTION,
+                source_mode=SourceMode.LIVE,
+                modality="internal",
+                precision=0.7,
+                prediction_error=state.uncertainty,
+                need_relevance=salience,
+                controllability=state.controllability,
+            )
+        )
+
+    def _ingest_previous_field(
+        self,
+        field: EnactedField,
+        previous: EnactedField | None,
+    ) -> WorkspaceCandidate | None:
+        if previous is None or previous.focal_content_ref is None:
+            return None
+        return self.workspace.add_candidate(
+            WorkspaceCandidate(
+                tick_id=field.tick_id,
+                kind=CandidateKind.SELF_MODEL,
+                content_ref=f"field:{previous.field_id}",
+                content_summary=previous.focal_summary or previous.focal_content_ref,
+                source=CandidateSource.PREVIOUS_FIELD,
+                source_mode=SourceMode.MIXED,
+                modality="internal",
+                precision=previous.precision.self_model,
+                continuity_with_previous=0.9,
+                switching_cost=0.2,
+                controllability=previous.interoception.controllability,
+            )
+        )
+
+    def _ingest_recent_scene(self, field: EnactedField) -> WorkspaceCandidate | None:
+        row = self.db.fetchone(
+            """
+            SELECT frame_id, scene_summary FROM scene_frames
+            ORDER BY ts DESC LIMIT 1
+            """
+        )
+        if row is None:
+            return None
+        return self.ingest_observation(
+            field.tick_id,
+            content_ref=f"scene:{row['frame_id']}",
+            summary=row["scene_summary"],
+            source_mode=SourceMode.LIVE,
+            modality="visual",
+            precision=0.85,
+            prediction_error=0.25,
+            controllability=0.65,
+            expected_information_gain=0.55,
+        )
+
+    def _ingest_recent_social(
+        self,
+        field: EnactedField,
+        *,
+        exclude_session_id: str | None,
+    ) -> WorkspaceCandidate | None:
+        row = self.db.fetchone(
+            """
+            SELECT event_id, payload_json, source, session_id FROM events
+            WHERE kind IN ('human_utterance', 'mention_received', 'touchpoint')
+            ORDER BY ts DESC, event_seq DESC LIMIT 1
+            """
+        )
+        if row is None or (
+            exclude_session_id and row["session_id"] == exclude_session_id
+        ):
+            return None
+        payload = _json_loads(row["payload_json"], {})
+        summary = str(payload.get("text") or payload.get("summary") or row["event_id"])
+        return self.ingest_social_context(
+            field.tick_id,
+            content_ref=f"event:{row['event_id']}",
+            summary=summary,
+            social_relevance=0.7,
+            source_mode=SourceMode.REMEMBERED,
+        )
+
+    def _ingest_memory_http(self, tick_id: str, user_text: str) -> None:
+        port = int(os.getenv("MEMORY_HTTP_PORT", "18900"))
+        url = (
+            f"http://127.0.0.1:{port}/recall?"
+            + urllib.parse.urlencode({"q": user_text, "n": 4})
+        )
+        try:
+            with urllib.request.urlopen(url, timeout=1.2) as response:
+                raw = json.loads(response.read().decode("utf-8"))
+        except Exception:
+            return
+        items = raw if isinstance(raw, list) else raw.get("memories", raw.get("results", []))
+        if isinstance(items, list):
+            self.ingest_memory_candidates(
+                tick_id,
+                [item for item in items if isinstance(item, dict)],
+            )
+
+    def _read_interoception(
+        self,
+        previous: EnactedField | None,
+    ) -> InteroceptionState:
+        raw = self._read_json(self.interoception_path)
+        now = raw.get("now") or {}
+        desire = self._read_json(self.desires_path)
+        desires = {
+            str(key): _clamp01(float(value))
+            for key, value in (desire.get("desires") or {}).items()
+        }
+        discomforts = {
+            str(key): _clamp01(float(value))
+            for key, value in (desire.get("discomforts") or {}).items()
+        }
+        max_discomfort = max(discomforts.values(), default=0.0)
+        raw_valence = -0.6 * max_discomfort
+        previous_valence = previous.interoception.valence if previous else 0.0
+        valence = 0.65 * previous_valence + 0.35 * raw_valence
+        if raw_valence >= previous_valence and previous_valence < 0.0:
+            valence += 0.04
+        valence = max(-0.8, min(0.8, valence))
+        arousal = _clamp01(float(now.get("arousal", 0.0)) / 100.0)
+        uncertainty = 0.35 if raw else 0.6
+        control = _clamp01(0.45 + 0.25 * (1.0 - max_discomfort))
+        exposure = 0.0
+        if previous and valence < -0.2:
+            exposure = min(
+                86400.0,
+                previous.interoception.negative_exposure_seconds
+                + max(0.0, _seconds_between(previous.updated_at, utc_now())),
+            )
+        return InteroceptionState(
+            valence=valence,
+            arousal=arousal,
+            uncertainty=uncertainty,
+            controllability=control,
+            need_vector=discomforts or desires,
+            resource_refs=([str(self.interoception_path)] if raw else []),
+            negative_exposure_seconds=exposure,
+        )
+
+    @staticmethod
+    def _read_json(path: Path) -> dict[str, Any]:
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+            return value if isinstance(value, dict) else {}
+        except (OSError, json.JSONDecodeError):
+            return {}
+
+    @staticmethod
+    def _retention_refs(previous: EnactedField | None) -> list[str]:
+        if previous is None:
+            return []
+        refs: list[str] = []
+        if previous.focal_content_ref:
+            refs.append(previous.focal_content_ref)
+        refs.extend(previous.retention_refs[:3])
+        return list(dict.fromkeys(refs))
+
+    @staticmethod
+    def _initial_precision(previous: EnactedField | None) -> PrecisionState:
+        if previous is None:
+            return PrecisionState()
+        return PrecisionState(
+            extero=0.6 * previous.precision.extero + 0.2,
+            intero=0.6 * previous.precision.intero + 0.2,
+            mnemonic=0.6 * previous.precision.mnemonic + 0.2,
+            social=0.6 * previous.precision.social + 0.2,
+            self_model=0.7 * previous.precision.self_model + 0.15,
+        )
+
+    @staticmethod
+    def _precision_from_competition(
+        field: EnactedField,
+        result: CompetitionResult,
+    ) -> PrecisionState:
+        winner = result.winner
+        self_feedback = _clamp01(
+            field.precision.self_model * 0.65
+            + result.attention_intensity * 0.25
+            + (0.1 if not result.conflicted else 0.0)
+        )
+        return PrecisionState(
+            extero=(
+                winner.precision
+                if winner.modality in {"visual", "auditory"}
+                else field.precision.extero * 0.8
+            ),
+            intero=(
+                winner.precision
+                if winner.kind == CandidateKind.INTEROCEPTIVE
+                else field.precision.intero * 0.8
+            ),
+            mnemonic=(
+                winner.precision
+                if winner.kind == CandidateKind.MEMORY
+                else field.precision.mnemonic * 0.8
+            ),
+            social=(
+                winner.precision
+                if winner.kind == CandidateKind.SOCIAL
+                else field.precision.social * 0.8
+            ),
+            self_model=self_feedback,
+        )
+
+    @staticmethod
+    def _build_protention(result: CompetitionResult) -> Protention:
+        predicted = result.top_rejected[0] if result.top_rejected else result.winner
+        confidence = _clamp01(
+            0.45 * result.attention_intensity
+            + 0.35 * (1.0 - result.entropy)
+            + 0.20 * (0.0 if result.conflicted else 1.0)
+        )
+        return Protention(
+            expected_content_ref=predicted.content_ref,
+            summary=f"next likely focus: {predicted.content_summary or predicted.content_ref}",
+            confidence=confidence,
+        )
+
+    @staticmethod
+    def _affordances_for(candidate: WorkspaceCandidate) -> list[str]:
+        mapping = {
+            CandidateKind.PERCEPT: ["inspect", "compare_prediction", "orient"],
+            CandidateKind.MEMORY: ["use_memory", "verify_source", "recontextualize"],
+            CandidateKind.INTEROCEPTIVE: ["regulate", "defer", "seek_information"],
+            CandidateKind.SOCIAL: ["respond", "remember", "clarify"],
+            CandidateKind.GOAL: ["propose_action", "defer", "gather_evidence"],
+            CandidateKind.ACTION: ["intend", "predict_effect", "gate_action"],
+            CandidateKind.SELF_MODEL: ["stabilize_focus", "recompete", "inspect_conflict"],
+        }
+        return mapping[candidate.kind]
+
+    def _record_commit_hor(
+        self,
+        field: EnactedField,
+        winner: WorkspaceCandidate,
+        schema: AttentionSchema,
+        result: CompetitionResult,
+    ) -> HORRecord:
+        if winner.kind == CandidateKind.MEMORY:
+            mode, target_kind, target_ref = "remembering", "memory", winner.content_ref
+        elif winner.kind == CandidateKind.GOAL:
+            mode, target_kind, target_ref = "wanting", "desire", winner.content_ref
+        elif winner.kind == CandidateKind.ACTION:
+            mode, target_kind, target_ref = "intending", "action", winner.content_ref
+        elif winner.kind == CandidateKind.INTEROCEPTIVE:
+            mode, target_kind, target_ref = "feeling", "frame", field.tick_id
+        elif winner.modality == "visual" and winner.source_mode == SourceMode.LIVE:
+            mode, target_kind, target_ref = "seeing", "frame", field.tick_id
+        else:
+            mode, target_kind, target_ref = "attending", "frame", field.tick_id
+        return self.hors.record(
+            HORInput(
+                owner_id=field.owner_id,
+                target_kind=target_kind,  # type: ignore[arg-type]
+                target_ref=target_ref,
+                asserted_mode=mode,  # type: ignore[arg-type]
+                asserted_content=f"I am {mode} {winner.content_ref}",
+                schema_snapshot_id=schema.schema_id,
+                source_tick_id=field.tick_id,
+                confidence=_clamp01(
+                    0.45 * result.attention_intensity
+                    + 0.35 * winner.precision
+                    + 0.20 * (1.0 - result.entropy)
+                ),
+                source="schema_readout",
+            )
+        )
+
+    @staticmethod
+    def _continuity_score(
+        previous: EnactedField | None,
+        current: EnactedField,
+    ) -> float:
+        if previous is None:
+            return 0.0
+        if previous.focal_content_ref in current.retention_refs:
+            return 0.9
+        if previous.focal_content_ref == current.focal_content_ref:
+            return 1.0
+        return 0.3
+
+    @staticmethod
+    def _prediction_match(
+        previous: EnactedField | None,
+        current: EnactedField,
+    ) -> float:
+        if previous is None or previous.protention.expected_content_ref is None:
+            return 0.5
+        return (
+            1.0
+            if previous.protention.expected_content_ref == current.focal_content_ref
+            else 0.0
+        )
+
+    def _next_temporal_order(self, owner_id: str) -> int:
+        row = self.db.fetchone(
+            "SELECT MAX(temporal_order) AS n FROM field_transitions WHERE owner_id = ?",
+            (owner_id,),
+        )
+        return int(row["n"] or 0) + 1 if row else 1
+
+    def _transition_action_id(self, previous: EnactedField | None) -> str | None:
+        if previous is None:
+            return None
+        if previous.agency_state.pending_intention_ref:
+            return previous.agency_state.pending_intention_ref
+        outcome_ref = previous.agency_state.last_outcome_ref
+        if not outcome_ref:
+            return None
+        row = self.db.fetchone(
+            "SELECT action_id FROM field_action_outcomes WHERE outcome_id = ?",
+            (outcome_ref,),
+        )
+        return str(row["action_id"]) if row else None
+
+    def _require_open_tick(self, tick_id: str) -> EnactedField:
+        field = self.fields.get_by_tick(tick_id)
+        if field is None:
+            raise ValueError(f"unknown tick {tick_id!r}")
+        if field.status != FieldStatus.OPEN:
+            raise ValueError(f"tick {tick_id!r} is not OPEN")
+        return field
+
+
+class FieldRuntime:
+    """High-level action gate that closes tool outcomes into a new field."""
+
+    def __init__(
+        self,
+        db: SocialDB,
+        *,
+        producer: TickProducer | None = None,
+        boundary_evaluator: BoundaryEvaluator | None = None,
+        compatibility_mode: bool = False,
+    ) -> None:
+        self.db = db
+        self.producer = producer or TickProducer(db)
+        self.agency = self.producer.agency
+        self.frames = self.producer.frames
+        self.fields = self.producer.fields
+        self.counterfactuals = CounterfactualStore(db)
+        self.bottleneck = ActionBottleneck(
+            db=db,
+            frame_store=self.frames,
+            counterfactual_store=self.counterfactuals,
+        )
+        self.boundary_evaluator = boundary_evaluator
+        self.compatibility_mode = compatibility_mode
+
+    def propose_action(
+        self,
+        proposal: ActionProposal,
+        *,
+        owner_id: str = "self",
+    ) -> IntentionRecord:
+        intention = self.agency.propose(proposal, owner_id=owner_id)
+        field = self.fields.get(intention.field_id)
+        if field is not None:
+            self.fields.update(field)
+        return intention
+
+    def gate_tool(
+        self,
+        *,
+        tool_name: str,
+        tool_input: dict[str, Any],
+        owner_id: str = "self",
+    ) -> ToolGateDecision:
+        external = is_external_tool(tool_name, tool_input)
+        if not external:
+            return ToolGateDecision(
+                allow=True,
+                reason="internal/read-only tool; outward action gate not required",
+                external=False,
+            )
+        runtime_state = self.fields.runtime_state(owner_id)
+        if runtime_state is not None and runtime_state.state == "PAUSED":
+            return ToolGateDecision(
+                allow=False,
+                reason="field runtime is paused; resume before outward action",
+                external=True,
+                field_id=runtime_state.current_field_id,
+            )
+        field = self.fields.get_current(owner_id)
+        if field is None:
+            if self.compatibility_mode:
+                return ToolGateDecision(
+                    allow=True,
+                    reason="compatibility mode: no committed field",
+                    external=True,
+                )
+            return ToolGateDecision(
+                allow=False,
+                reason="no COMMITTED field; refresh the field before outward action",
+                external=True,
+            )
+        if field.status != FieldStatus.COMMITTED:
+            return ToolGateDecision(
+                allow=False,
+                reason="current field is stale or invalidated; refresh before outward action",
+                external=True,
+                field_id=field.field_id,
+            )
+        matches, reason, intention = self.agency.match_pending(
+            owner_id=owner_id,
+            tool_name=tool_name,
+            tool_input=tool_input,
+        )
+        if not matches or intention is None:
+            return ToolGateDecision(
+                allow=False,
+                reason=reason + "; call propose_field_action first",
+                external=True,
+                field_id=field.field_id,
+                action_id=intention.action_id if intention else None,
+            )
+        if intention.field_id != field.field_id:
+            return ToolGateDecision(
+                allow=False,
+                reason="pending intention belongs to a superseded field",
+                external=True,
+                field_id=field.field_id,
+                action_id=intention.action_id,
+            )
+        if self.boundary_evaluator is not None:
+            allowed, boundary_reason = self.boundary_evaluator(
+                tool_name, tool_input, field
+            )
+            if not allowed:
+                self.agency.mark_denied(intention.action_id)
+                return ToolGateDecision(
+                    allow=False,
+                    reason=f"boundary policy denied action: {boundary_reason}",
+                    external=True,
+                    field_id=field.field_id,
+                    action_id=intention.action_id,
+                )
+        bottleneck = self.bottleneck.commit_action(
+            tick_id=field.tick_id,
+            action_ref=intention.action_id,
+            action_payload={"tool_name": tool_name, "tool_input_hash": intention.tool_input_hash},
+            person_id=field.person_id,
+        )
+        if not bottleneck.ok:
+            return ToolGateDecision(
+                allow=False,
+                reason="one outward action is already committed for this field",
+                external=True,
+                field_id=field.field_id,
+                action_id=intention.action_id,
+                deferred=True,
+            )
+        self.agency.mark_allowed(intention.action_id)
+        return ToolGateDecision(
+            allow=True,
+            reason="field, intention, input hash, boundary, and bottleneck checks passed",
+            external=True,
+            field_id=field.field_id,
+            action_id=intention.action_id,
+        )
+
+    def close_tool(
+        self,
+        *,
+        tool_name: str,
+        tool_input: dict[str, Any],
+        actual_result_summary: str,
+        success: bool,
+        owner_id: str = "self",
+        actual_result_ref: str | None = None,
+        latency_ms: int | None = None,
+        session_id: str | None = None,
+    ) -> tuple[ActionOutcome | None, AgencyAssessment | None, EnactedField | None]:
+        external = is_external_tool(tool_name, tool_input)
+        outcome: ActionOutcome | None = None
+        assessment: AgencyAssessment | None = None
+        previous = self.fields.get_current(owner_id)
+        if external:
+            matches, _, intention = self.agency.match_pending(
+                owner_id=owner_id,
+                tool_name=tool_name,
+                tool_input=tool_input,
+            )
+            if not matches or intention is None:
+                return None, self.agency.assess_uncommanded_outcome(effect_match=0.5), None
+            outcome, assessment = self.agency.close(
+                action_id=intention.action_id,
+                actual_result_summary=actual_result_summary,
+                success=success,
+                actual_result_ref=actual_result_ref,
+                latency_ms=latency_ms,
+            )
+        if previous is not None:
+            self.fields.invalidate(
+                previous.field_id,
+                reason=(
+                    "tool result changed the available evidence"
+                    if success
+                    else "tool failure changed prediction confidence"
+                ),
+            )
+        if not external and not is_field_refreshing_tool(tool_name):
+            return outcome, assessment, None
+
+        micro = self.producer.begin_tick(
+            TriggerKind.TOOL_RESULT,
+            owner_id=owner_id,
+            person_id=previous.person_id if previous else None,
+            session_id=session_id,
+        )
+        result_ref = (
+            f"outcome:{outcome.outcome_id}"
+            if outcome
+            else actual_result_ref
+            or f"tool_result:{hashlib.sha256(actual_result_summary.encode()).hexdigest()[:16]}"
+        )
+        self.producer.ingest_observation(
+            micro.tick_id,
+            content_ref=result_ref,
+            summary=actual_result_summary,
+            source_mode=SourceMode.LIVE if success else SourceMode.INFERRED,
+            modality=_tool_modality(tool_name),
+            precision=0.9 if success else 0.65,
+            prediction_error=(
+                _mean_mismatch(outcome.mismatch_vector)
+                if outcome
+                else (0.2 if success else 0.9)
+            ),
+            controllability=assessment.ownership_score if assessment else 0.2,
+            expected_information_gain=0.8,
+            source=CandidateSource.TOOL_RESULT,
+        )
+        commit = self.producer.compete_and_commit(micro.tick_id)
+        return outcome, assessment, commit.field
+
+    def close_action(
+        self,
+        *,
+        action_id: str,
+        actual_result_summary: str,
+        success: bool,
+        actual_result_ref: str | None = None,
+        latency_ms: int | None = None,
+        session_id: str | None = None,
+    ) -> tuple[ActionOutcome, AgencyAssessment, EnactedField]:
+        intention = self.agency.get(action_id)
+        if intention is None:
+            raise ValueError(f"unknown intention {action_id!r}")
+        source_field = self.fields.get(intention.field_id)
+        existing_outcome = self.agency.outcome_for_action(action_id)
+        outcome, assessment = self.agency.close(
+            action_id=action_id,
+            actual_result_summary=actual_result_summary,
+            success=success,
+            actual_result_ref=actual_result_ref,
+            latency_ms=latency_ms,
+        )
+        if existing_outcome is not None:
+            current = self.fields.get_current(intention.owner_id)
+            if current is None:
+                raise RuntimeError("action was already closed but no current field is available")
+            return outcome, assessment, current
+        if source_field and source_field.status in {
+            FieldStatus.OPEN,
+            FieldStatus.COMMITTED,
+        }:
+            self.fields.invalidate(
+                source_field.field_id,
+                reason="structured action outcome requires field refresh",
+            )
+        micro = self.producer.begin_tick(
+            TriggerKind.TOOL_RESULT,
+            owner_id=intention.owner_id,
+            person_id=source_field.person_id if source_field else None,
+            session_id=session_id,
+        )
+        self.producer.ingest_observation(
+            micro.tick_id,
+            content_ref=f"outcome:{outcome.outcome_id}",
+            summary=actual_result_summary,
+            source_mode=SourceMode.LIVE if success else SourceMode.INFERRED,
+            modality=_tool_modality(intention.tool_name),
+            precision=0.9 if success else 0.65,
+            prediction_error=_mean_mismatch(outcome.mismatch_vector),
+            controllability=assessment.ownership_score,
+            expected_information_gain=0.8,
+            source=CandidateSource.TOOL_RESULT,
+        )
+        commit = self.producer.compete_and_commit(micro.tick_id)
+        return outcome, assessment, commit.field
+
+
+def calculate_reality_score(
+    *,
+    source_mode: SourceMode | str,
+    sensor_coupling: float,
+    action_controllability: float,
+    prediction_match: float,
+    recency: float,
+) -> float:
+    """Reality marking based on coupling, control, prediction, and recency."""
+
+    SourceMode(source_mode)
+    return _clamp01(
+        0.35 * _clamp01(sensor_coupling)
+        + 0.30 * _clamp01(action_controllability)
+        + 0.20 * _clamp01(prediction_match)
+        + 0.15 * _clamp01(recency)
+    )
+
+
+def temporal_sequence_metrics(fields: list[EnactedField]) -> TemporalSequenceMetrics:
+    """Measure order-sensitive retention and next-focus calibration."""
+
+    if len(fields) < 2:
+        return TemporalSequenceMetrics(
+            chronological_fraction=1.0,
+            continuity=1.0,
+            protention_accuracy=1.0,
+        )
+    chronological = 0
+    retention_hits = 0
+    protention_hits = 0
+    for previous, current in zip(fields, fields[1:]):
+        try:
+            left = datetime.fromisoformat(previous.started_at.replace("Z", "+00:00"))
+            right = datetime.fromisoformat(current.started_at.replace("Z", "+00:00"))
+            chronological += int(right >= left)
+        except ValueError:
+            pass
+        retention_hits += int(
+            previous.focal_content_ref is not None
+            and previous.focal_content_ref in current.retention_refs
+        )
+        protention_hits += int(
+            previous.protention.expected_content_ref is not None
+            and previous.protention.expected_content_ref == current.focal_content_ref
+        )
+    denominator = len(fields) - 1
+    chronology = chronological / denominator
+    return TemporalSequenceMetrics(
+        chronological_fraction=chronology,
+        continuity=(retention_hits / denominator) * chronology,
+        protention_accuracy=(protention_hits / denominator) * chronology,
+    )
+
+
+def is_field_refreshing_tool(tool_name: str) -> bool:
+    name = tool_name.lower()
+    if name in {"read", "grep", "glob", "webfetch", "websearch", "bash"}:
+        return True
+    return any(
+        fragment in name
+        for fragment in (
+            "__see",
+            "__listen",
+            "__recall",
+            "__search_memories",
+            "__get_social_state",
+            "__get_current_joint_focus",
+            "__look_around",
+            "__camera_info",
+        )
+    )
+
+
+def _sensor_coupling(candidate: WorkspaceCandidate) -> float:
+    if candidate.source_mode == SourceMode.LIVE:
+        return 1.0 if candidate.source in {
+            CandidateSource.SENSOR,
+            CandidateSource.TOOL_RESULT,
+            CandidateSource.INTEROCEPTION,
+        } else 0.75
+    if candidate.source_mode == SourceMode.MIXED:
+        return 0.5
+    if candidate.source_mode == SourceMode.INFERRED:
+        return 0.3
+    if candidate.source_mode == SourceMode.REMEMBERED:
+        return 0.1
+    return 0.0
+
+
+def _source_recency(source_mode: SourceMode) -> float:
+    return {
+        SourceMode.LIVE: 1.0,
+        SourceMode.MIXED: 0.7,
+        SourceMode.INFERRED: 0.6,
+        SourceMode.REMEMBERED: 0.35,
+        SourceMode.IMAGINED: 0.2,
+    }[source_mode]
+
+
+def _tool_modality(tool_name: str) -> str:
+    name = tool_name.lower()
+    if any(value in name for value in ("see", "camera", "look")):
+        return "visual"
+    if any(value in name for value in ("listen", "audio", "say", "tts")):
+        return "auditory"
+    if any(value in name for value in ("social", "post", "notify", "send")):
+        return "social"
+    return "internal"
+
+
+def _mean_mismatch(values: dict[str, float]) -> float:
+    return (
+        sum(_clamp01(value) for value in values.values()) / len(values)
+        if values
+        else 0.5
+    )
+
+
+def _json_loads(raw: str | None, default):
+    try:
+        return json.loads(raw or "")
+    except (TypeError, json.JSONDecodeError):
+        return default
+
+
+def _seconds_between(start: str, end: str) -> float:
+    try:
+        left = datetime.fromisoformat(start.replace("Z", "+00:00"))
+        right = datetime.fromisoformat(end.replace("Z", "+00:00"))
+        return (right - left).total_seconds()
+    except ValueError:
+        return 0.0
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/workspace.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/workspace.py
@@ -1,0 +1,311 @@
+"""Deterministic workspace competition for enacted-field ticks.
+
+Candidates point at source records and carry only a compact summary. Competition
+is performed outside the language model so that winner selection, ignition, and
+attention intensity are inspectable and reproducible.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import secrets
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+from social_core.db import SocialDB
+from social_core.time import utc_now
+
+
+class CandidateKind(StrEnum):
+    PERCEPT = "percept"
+    MEMORY = "memory"
+    INTEROCEPTIVE = "interoceptive"
+    SOCIAL = "social"
+    GOAL = "goal"
+    ACTION = "action"
+    SELF_MODEL = "self_model"
+
+
+class CandidateSource(StrEnum):
+    USER_EVENT = "user_event"
+    SENSOR = "sensor"
+    MEMORY = "memory"
+    INTEROCEPTION = "interoception"
+    DESIRE = "desire"
+    SOCIAL = "social"
+    PREVIOUS_FIELD = "previous_field"
+    ATTENTION_SCHEMA = "attention_schema"
+    HOR = "hor"
+    TOOL_RESULT = "tool_result"
+    EXPLICIT = "explicit"
+
+
+class SourceMode(StrEnum):
+    LIVE = "live"
+    INFERRED = "inferred"
+    REMEMBERED = "remembered"
+    IMAGINED = "imagined"
+    MIXED = "mixed"
+
+
+class CompetitionWeights(BaseModel):
+    """Configurable coefficients for workspace scoring."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    surprise: float = 1.0
+    need: float = 0.9
+    goal: float = 0.9
+    information: float = 0.7
+    continuity: float = 0.65
+    control: float = 0.7
+    social: float = 0.65
+    conflict: float = 0.8
+    switching: float = 0.55
+    ignition_threshold: float = 0.9
+    conflict_margin: float = 0.12
+    entropy_conflict_threshold: float = 0.78
+
+
+class WorkspaceCandidate(BaseModel):
+    """One compact bid for access to the committed field."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    candidate_id: str = Field(default_factory=lambda: f"cand_{secrets.token_urlsafe(12)}")
+    tick_id: str
+    kind: CandidateKind
+    content_ref: str
+    content_summary: str = Field(default="", max_length=320)
+    source: CandidateSource = CandidateSource.EXPLICIT
+    source_mode: SourceMode
+    modality: str = "internal"
+    precision: float = Field(default=0.5, ge=0.0, le=1.0)
+    prediction_error: float = Field(default=0.0, ge=-1.0, le=1.0)
+    need_relevance: float = Field(default=0.0, ge=0.0, le=1.0)
+    goal_relevance: float = Field(default=0.0, ge=0.0, le=1.0)
+    expected_information_gain: float = Field(default=0.0, ge=0.0, le=1.0)
+    continuity_with_previous: float = Field(default=0.0, ge=0.0, le=1.0)
+    controllability: float = Field(default=0.0, ge=0.0, le=1.0)
+    social_relevance: float = Field(default=0.0, ge=0.0, le=1.0)
+    conflict_penalty: float = Field(default=0.0, ge=0.0, le=1.0)
+    switching_cost: float = Field(default=0.0, ge=0.0, le=1.0)
+    score: float = 0.0
+    reportability: str = "mentionable"
+
+
+class CompetitionResult(BaseModel):
+    """Auditable result of one workspace competition."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    tick_id: str
+    winner: WorkspaceCandidate
+    top_rejected: list[WorkspaceCandidate] = Field(default_factory=list)
+    scores: dict[str, float] = Field(default_factory=dict)
+    margin: float
+    entropy: float = Field(ge=0.0, le=1.0)
+    ignited: bool
+    conflicted: bool
+    attention_intensity: float = Field(ge=0.0, le=1.0)
+    deterministic_order: list[str] = Field(default_factory=list)
+
+
+class WorkspaceEngine:
+    """SQLite-backed candidate market with deterministic tie breaking."""
+
+    def __init__(
+        self,
+        db: SocialDB,
+        *,
+        weights: CompetitionWeights | None = None,
+    ) -> None:
+        self._db = db
+        self.weights = weights or CompetitionWeights()
+
+    def score_candidate(self, candidate: WorkspaceCandidate) -> float:
+        w = self.weights
+        score = (
+            w.surprise * candidate.precision * abs(candidate.prediction_error)
+            + w.need * candidate.need_relevance
+            + w.goal * candidate.goal_relevance
+            + w.information * candidate.expected_information_gain
+            + w.continuity * candidate.continuity_with_previous
+            + w.control * candidate.controllability
+            + w.social * candidate.social_relevance
+            - w.conflict * candidate.conflict_penalty
+            - w.switching * candidate.switching_cost
+        )
+        return round(score, 8)
+
+    def add_candidate(self, candidate: WorkspaceCandidate) -> WorkspaceCandidate:
+        scored = candidate.model_copy(update={"score": self.score_candidate(candidate)})
+        self._db.execute(
+            """
+            INSERT INTO workspace_candidates(
+                candidate_id, tick_id, kind, content_ref, content_summary,
+                source, source_mode, modality, precision, prediction_error,
+                need_relevance, goal_relevance, expected_information_gain,
+                continuity_with_previous, controllability, social_relevance,
+                conflict_penalty, switching_cost, score, reportability, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                scored.candidate_id,
+                scored.tick_id,
+                scored.kind.value,
+                scored.content_ref,
+                scored.content_summary,
+                scored.source.value,
+                scored.source_mode.value,
+                scored.modality,
+                scored.precision,
+                scored.prediction_error,
+                scored.need_relevance,
+                scored.goal_relevance,
+                scored.expected_information_gain,
+                scored.continuity_with_previous,
+                scored.controllability,
+                scored.social_relevance,
+                scored.conflict_penalty,
+                scored.switching_cost,
+                scored.score,
+                scored.reportability,
+                utc_now(),
+            ),
+        )
+        return scored
+
+    def candidates_for_tick(self, tick_id: str) -> list[WorkspaceCandidate]:
+        rows = self._db.fetchall(
+            """
+            SELECT * FROM workspace_candidates
+            WHERE tick_id = ?
+            ORDER BY score DESC, candidate_id ASC
+            """,
+            (tick_id,),
+        )
+        return [self._row_to_candidate(row) for row in rows]
+
+    def compete(self, tick_id: str, *, top_rejected: int = 5) -> CompetitionResult:
+        candidates = self.candidates_for_tick(tick_id)
+        if not candidates:
+            raise ValueError(f"tick {tick_id!r} has no workspace candidates")
+
+        ranked = sorted(
+            candidates,
+            key=lambda item: (-item.score, item.content_ref, item.candidate_id),
+        )
+        winner = ranked[0]
+        runner_score = ranked[1].score if len(ranked) > 1 else 0.0
+        margin = max(0.0, winner.score - runner_score)
+        entropy = self._normalized_entropy([item.score for item in ranked])
+        ignited = winner.score >= self.weights.ignition_threshold
+        conflicted = len(ranked) > 1 and (
+            margin < self.weights.conflict_margin
+            or entropy >= self.weights.entropy_conflict_threshold
+        )
+        intensity = self._attention_intensity(
+            winner_score=winner.score,
+            margin=margin,
+            entropy=entropy,
+            ignited=ignited,
+        )
+
+        with self._db.transaction() as connection:
+            for rank, item in enumerate(ranked, start=1):
+                connection.execute(
+                    """
+                    UPDATE workspace_candidates
+                    SET rank = ?, selected = ?
+                    WHERE candidate_id = ?
+                    """,
+                    (rank, 1 if rank == 1 else 0, item.candidate_id),
+                )
+
+        return CompetitionResult(
+            tick_id=tick_id,
+            winner=winner,
+            top_rejected=ranked[1 : 1 + max(0, top_rejected)],
+            scores={item.candidate_id: item.score for item in ranked},
+            margin=round(margin, 8),
+            entropy=round(entropy, 8),
+            ignited=ignited,
+            conflicted=conflicted,
+            attention_intensity=round(intensity, 8),
+            deterministic_order=[item.candidate_id for item in ranked],
+        )
+
+    def _attention_intensity(
+        self,
+        *,
+        winner_score: float,
+        margin: float,
+        entropy: float,
+        ignited: bool,
+    ) -> float:
+        threshold = max(0.01, self.weights.ignition_threshold)
+        score_term = _clamp01(winner_score / (2.0 * threshold))
+        margin_term = _clamp01(margin / threshold)
+        certainty_term = 1.0 - entropy
+        value = 0.5 * score_term + 0.3 * margin_term + 0.2 * certainty_term
+        if not ignited:
+            value *= 0.6
+        return _clamp01(value)
+
+    @staticmethod
+    def _normalized_entropy(scores: list[float]) -> float:
+        if len(scores) <= 1:
+            return 0.0
+        peak = max(scores)
+        exps = [math.exp(min(40.0, score - peak)) for score in scores]
+        total = sum(exps)
+        probabilities = [value / total for value in exps]
+        entropy = -sum(p * math.log(p) for p in probabilities if p > 0.0)
+        return _clamp01(entropy / math.log(len(probabilities)))
+
+    @staticmethod
+    def _row_to_candidate(row) -> WorkspaceCandidate:
+        return WorkspaceCandidate(
+            candidate_id=row["candidate_id"],
+            tick_id=row["tick_id"],
+            kind=row["kind"],
+            content_ref=row["content_ref"],
+            content_summary=row["content_summary"],
+            source=row["source"],
+            source_mode=row["source_mode"],
+            modality=row["modality"],
+            precision=float(row["precision"]),
+            prediction_error=float(row["prediction_error"]),
+            need_relevance=float(row["need_relevance"]),
+            goal_relevance=float(row["goal_relevance"]),
+            expected_information_gain=float(row["expected_information_gain"]),
+            continuity_with_previous=float(row["continuity_with_previous"]),
+            controllability=float(row["controllability"]),
+            social_relevance=float(row["social_relevance"]),
+            conflict_penalty=float(row["conflict_penalty"]),
+            switching_cost=float(row["switching_cost"]),
+            score=float(row["score"]),
+            reportability=row["reportability"],
+        )
+
+
+def competition_trace(result: CompetitionResult) -> dict[str, object]:
+    """Return the stable subset persisted in a field's epistemic trace."""
+
+    return {
+        "winner_id": result.winner.candidate_id,
+        "winner_ref": result.winner.content_ref,
+        "scores": json.loads(json.dumps(result.scores, sort_keys=True)),
+        "margin": result.margin,
+        "entropy": result.entropy,
+        "ignited": result.ignited,
+        "conflicted": result.conflicted,
+        "attention_intensity": result.attention_intensity,
+        "top_rejected": [item.candidate_id for item in result.top_rejected],
+    }
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, value))

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_benchmark.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_benchmark.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+
+from individual_kernel_mcp.benchmark import run_candidate_benchmark
+
+
+def test_candidate_benchmark_writes_inspectable_indicator_outputs(tmp_path):
+    result = run_candidate_benchmark(
+        output_dir=tmp_path / "results",
+        db_path=tmp_path / "benchmark.db",
+    )
+
+    json_path = tmp_path / "results" / "indicator-profile.json"
+    markdown_path = tmp_path / "results" / "indicator-profile.md"
+    stored = json.loads(json_path.read_text(encoding="utf-8"))
+    markdown = markdown_path.read_text(encoding="utf-8")
+
+    assert result["profile"]["profile_name"] == "FieldIntegrityReport"
+    assert stored == result
+    assert set(result["ablations"]) == {
+        "focal_clamp",
+        "hor_feedback",
+        "reality",
+        "valence",
+    }
+    assert result["ablations"]["reality"]["mean_score_delta"] > 0.0
+    assert result["ablations"]["valence"]["mean_score_delta"] > 0.0
+    assert result["profile"]["valence_coupling"] > 0.0
+    assert result["dry_run"]["committed_field_summary"] == (
+        "calibrated camera room is visible"
+    )
+    assert result["dry_run"]["next_field_id"]
+    assert any(
+        ref.startswith("outcome:")
+        for ref in result["dry_run"]["next_field_peripheral_refs"]
+    )
+    assert result["dry_run"]["outcome_mismatch"]
+    assert "consciousness probability" not in markdown.lower()
+    assert "Field Integrity Report" in markdown

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_boundary_adapter.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_boundary_adapter.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from boundary_mcp.store import BoundaryStore
+
+from individual_kernel_mcp.agency import (
+    ActionProposal,
+    ExpectedEffect,
+    PredictedEffects,
+)
+from individual_kernel_mcp.boundary_adapter import BoundaryPolicyAdapter
+from individual_kernel_mcp.hook_cli import pre_tool_use
+from individual_kernel_mcp.tick import FieldRuntime, TickProducer
+
+
+def test_existing_boundary_policy_denies_hook_runtime_action(
+    social_db, tmp_path
+) -> None:
+    policy_path = tmp_path / "socialPolicy.toml"
+    policy_path.write_text(
+        """
+[global]
+timezone = "UTC"
+quiet_hours = []
+max_nudges_per_hour = 10
+
+[[person_rules]]
+person_id = "kouta"
+avoid_actions = ["say"]
+""".strip(),
+        encoding="utf-8",
+    )
+    producer = TickProducer(
+        social_db,
+        interoception_path=tmp_path / "interoception.json",
+        desires_path=tmp_path / "desires.json",
+    )
+    opened = producer.begin_tick("user_prompt", person_id="kouta", user_text="hello")
+    field = producer.compete_and_commit(opened.tick_id).field
+    runtime = FieldRuntime(
+        social_db,
+        producer=producer,
+        boundary_evaluator=BoundaryPolicyAdapter(
+            BoundaryStore(db=social_db, policy_path=policy_path)
+        ),
+    )
+    intention = runtime.propose_action(
+        ActionProposal(
+            field_id=field.field_id,
+            tool_name="mcp__tts__say",
+            tool_input={"text": "hello"},
+            predicted_effects=PredictedEffects(
+                social=ExpectedEffect(summary="person hears hello")
+            ),
+            goal="speak",
+        )
+    )
+
+    result = pre_tool_use(
+        {
+            "tool_name": "mcp__tts__say",
+            "tool_input": {"text": "hello"},
+        },
+        runtime,
+    )
+
+    output = result["hookSpecificOutput"]
+    assert output["permissionDecision"] == "deny"
+    assert "person-specific rule avoids say" in output["permissionDecisionReason"]
+    assert producer.agency.get(intention.action_id).status == "DENIED"

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_efpf_causal.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_efpf_causal.py
@@ -1,0 +1,718 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import struct
+from pathlib import Path
+
+import pytest
+
+from individual_kernel_mcp.ablation import AblationRunner, downstream_selection
+from individual_kernel_mcp.agency import (
+    ActionProposal,
+    AgencyStore,
+    ExpectedEffect,
+    PredictedEffects,
+    is_external_tool,
+)
+from individual_kernel_mcp.enacted_field import (
+    EnactedField,
+    EnactedFieldStore,
+    InteroceptionState,
+    Protention,
+)
+from individual_kernel_mcp.hook_cli import (
+    post_tool_batch,
+    post_tool_use,
+    pre_tool_use,
+    user_prompt_submit,
+)
+from individual_kernel_mcp.quality_geometry import QualityGeometry
+from individual_kernel_mcp.tick import (
+    FieldRuntime,
+    TickProducer,
+    calculate_reality_score,
+    is_field_refreshing_tool,
+    temporal_sequence_metrics,
+)
+from individual_kernel_mcp.workspace import (
+    CandidateKind,
+    CandidateSource,
+    SourceMode,
+    WorkspaceCandidate,
+    WorkspaceEngine,
+)
+
+
+def _producer(social_db, tmp_path: Path) -> TickProducer:
+    return TickProducer(
+        social_db,
+        interoception_path=tmp_path / "interoception.json",
+        desires_path=tmp_path / "desires.json",
+    )
+
+
+def _commit(
+    producer: TickProducer,
+    *,
+    focus_ref: str = "scene:room",
+    summary: str = "camera room",
+) -> EnactedField:
+    opened = producer.begin_tick("perception", session_id="test")
+    producer.workspace.add_candidate(
+        WorkspaceCandidate(
+            tick_id=opened.tick_id,
+            kind=CandidateKind.PERCEPT,
+            content_ref=focus_ref,
+            content_summary=summary,
+            source_mode=SourceMode.LIVE,
+            modality="visual",
+            precision=1.0,
+            prediction_error=1.0,
+            need_relevance=1.0,
+            goal_relevance=1.0,
+            expected_information_gain=1.0,
+            continuity_with_previous=1.0,
+            controllability=1.0,
+            social_relevance=1.0,
+        )
+    )
+    return producer.compete_and_commit(opened.tick_id).field
+
+
+def _proposal(field: EnactedField, *, text: str = "hello") -> ActionProposal:
+    return ActionProposal(
+        field_id=field.field_id,
+        tool_name="mcp__tts__say",
+        tool_input={"text": text},
+        predicted_effects=PredictedEffects(
+            exteroceptive=ExpectedEffect(summary=f"{text} audio played", confidence=0.9),
+            social=ExpectedEffect(summary=f"person hears {text}", confidence=0.8),
+        ),
+        goal="speak once",
+        confidence=0.9,
+        expected_latency_ms=100,
+    )
+
+
+def test_committed_focus_changes_downstream_selection() -> None:
+    base = EnactedField(
+        tick_id="tick_a",
+        continuity_token="cont",
+        trigger_kind="perception",
+        focal_content_ref="scene:camera-room",
+        focal_summary="camera room",
+        interoception=InteroceptionState(need_vector={"observe": 0.4}),
+    )
+    fixture = {
+        "memories": [
+            {"ref": "memory:room", "content": "camera room", "relevance": 0.5},
+            {"ref": "memory:garden", "content": "garden memory", "relevance": 0.5},
+        ],
+        "actions": [
+            {"ref": "inspect", "goal": "inspect camera room"},
+            {"ref": "remember", "goal": "remember garden memory"},
+        ],
+    }
+    selection_a = downstream_selection(base, fixture)
+    clamped = base.model_copy(
+        update={
+            "focal_content_ref": "memory:garden",
+            "focal_summary": "garden memory",
+        }
+    )
+    selection_b = downstream_selection(clamped, fixture)
+    assert selection_a.memory_order[0] == "memory:room"
+    assert selection_b.memory_order[0] == "memory:garden"
+    assert selection_a.action_order[0] != selection_b.action_order[0]
+
+
+def test_live_controllable_content_has_higher_reality_than_replay() -> None:
+    live = calculate_reality_score(
+        source_mode="live",
+        sensor_coupling=1.0,
+        action_controllability=0.9,
+        prediction_match=0.8,
+        recency=1.0,
+    )
+    replay = calculate_reality_score(
+        source_mode="remembered",
+        sensor_coupling=0.1,
+        action_controllability=0.1,
+        prediction_match=0.8,
+        recency=0.3,
+    )
+    assert live > replay
+
+
+def test_registered_matching_action_has_higher_ownership(
+    social_db, tmp_path: Path
+) -> None:
+    producer = _producer(social_db, tmp_path)
+    field = _commit(producer)
+    agency = AgencyStore(social_db)
+    intention = agency.propose(_proposal(field))
+    outcome, assessment = agency.close(
+        action_id=intention.action_id,
+        actual_result_summary="hello audio played and person hears hello",
+        success=True,
+        latency_ms=100,
+    )
+    external = agency.assess_uncommanded_outcome(
+        effect_match=1.0,
+        temporal_contiguity=1.0,
+        exclusive_causal_fit=0.2,
+    )
+    assert outcome.ownership_score > 0.8
+    assert assessment.ownership_score > external.ownership_score
+
+
+def test_closed_action_is_linked_to_the_result_field_transition(
+    social_db, tmp_path: Path
+) -> None:
+    producer = _producer(social_db, tmp_path)
+    field = _commit(producer)
+    runtime = FieldRuntime(social_db, producer=producer)
+    intention = runtime.propose_action(_proposal(field))
+    assert runtime.gate_tool(
+        tool_name="mcp__tts__say",
+        tool_input={"text": "hello"},
+    ).allow
+
+    _, _, next_field = runtime.close_action(
+        action_id=intention.action_id,
+        actual_result_summary="hello audio played and person hears hello",
+        success=True,
+        latency_ms=100,
+    )
+    transition = social_db.fetchone(
+        "SELECT action_id FROM field_transitions WHERE to_field_id = ?",
+        (next_field.field_id,),
+    )
+
+    assert transition["action_id"] == intention.action_id
+
+
+def test_temporal_scramble_reduces_continuity_and_protention() -> None:
+    first = EnactedField(
+        field_id="f1",
+        tick_id="t1",
+        continuity_token="c",
+        trigger_kind="perception",
+        started_at="2026-01-01T00:00:00Z",
+        focal_content_ref="a",
+        protention=Protention(expected_content_ref="b"),
+    )
+    second = EnactedField(
+        field_id="f2",
+        tick_id="t2",
+        continuity_token="c",
+        trigger_kind="perception",
+        started_at="2026-01-01T00:00:01Z",
+        focal_content_ref="b",
+        retention_refs=["a"],
+        protention=Protention(expected_content_ref="c"),
+    )
+    third = EnactedField(
+        field_id="f3",
+        tick_id="t3",
+        continuity_token="c",
+        trigger_kind="perception",
+        started_at="2026-01-01T00:00:02Z",
+        focal_content_ref="c",
+        retention_refs=["b"],
+    )
+    ordered = temporal_sequence_metrics([first, second, third])
+    scrambled = temporal_sequence_metrics([third, first, second])
+    assert ordered.continuity > scrambled.continuity
+    assert ordered.protention_accuracy > scrambled.protention_accuracy
+
+
+def test_attention_intensity_varies_with_margin_and_entropy(social_db) -> None:
+    from individual_kernel_mcp.frame import ConsciousFrameInput, TickFrameStore
+
+    frames = TickFrameStore(social_db)
+    engine = WorkspaceEngine(social_db)
+    clear_tick = frames.record(ConsciousFrameInput()).tick_id
+    contested_tick = frames.record(ConsciousFrameInput()).tick_id
+    engine.add_candidate(
+        WorkspaceCandidate(
+            tick_id=clear_tick,
+            kind="goal",
+            content_ref="clear",
+            source_mode="inferred",
+            goal_relevance=1.0,
+        )
+    )
+    for ref in ("a", "b", "c"):
+        engine.add_candidate(
+            WorkspaceCandidate(
+                tick_id=contested_tick,
+                kind="goal",
+                content_ref=ref,
+                source_mode="inferred",
+                goal_relevance=1.0,
+            )
+        )
+    clear = engine.compete(clear_tick)
+    contested = engine.compete(contested_tick)
+    assert clear.attention_intensity != contested.attention_intensity
+    assert clear.entropy < contested.entropy
+
+
+def test_workspace_tie_breaks_by_stable_content_ref(social_db) -> None:
+    from individual_kernel_mcp.frame import ConsciousFrameInput, TickFrameStore
+
+    tick_id = TickFrameStore(social_db).record(ConsciousFrameInput()).tick_id
+    engine = WorkspaceEngine(social_db)
+    engine.add_candidate(
+        WorkspaceCandidate(
+            candidate_id="cand_a_random_order",
+            tick_id=tick_id,
+            kind="goal",
+            content_ref="ref:b",
+            source_mode="inferred",
+            goal_relevance=1.0,
+        )
+    )
+    engine.add_candidate(
+        WorkspaceCandidate(
+            candidate_id="cand_z_random_order",
+            tick_id=tick_id,
+            kind="goal",
+            content_ref="ref:a",
+            source_mode="inferred",
+            goal_relevance=1.0,
+        )
+    )
+
+    assert engine.compete(tick_id).winner.content_ref == "ref:a"
+
+
+def test_hor_feedback_ablation_changes_self_model_precision(
+    social_db, tmp_path: Path
+) -> None:
+    producer = _producer(social_db, tmp_path)
+    _commit(producer)
+    result = AblationRunner(social_db).run("hor_feedback")
+    assert result.effect_size["self_model_precision_delta"] > 0.0
+    assert result.baseline.self_model_precision > result.ablated.self_model_precision
+
+
+def test_commit_grounded_hor_is_high_consistency_self_model_feedback(
+    social_db, tmp_path: Path
+) -> None:
+    producer = _producer(social_db, tmp_path)
+    _commit(producer, focus_ref="scene:camera", summary="camera frame")
+
+    next_tick = producer.begin_tick("heartbeat")
+    candidates = producer.workspace.candidates_for_tick(next_tick.tick_id)
+    self_model = next(
+        candidate
+        for candidate in candidates
+        if candidate.kind == CandidateKind.SELF_MODEL
+        and candidate.source == CandidateSource.ATTENTION_SCHEMA
+    )
+
+    assert self_model.precision == pytest.approx(1.0)
+    assert self_model.conflict_penalty == pytest.approx(0.0)
+
+
+def test_valence_and_need_change_action_ranking_without_source_change() -> None:
+    field = EnactedField(
+        tick_id="tick",
+        continuity_token="cont",
+        trigger_kind="perception",
+        focal_content_ref="neutral",
+        interoception=InteroceptionState(
+            valence=-0.8,
+            need_vector={"recovery": 1.0},
+        ),
+    )
+    fixture = {
+        "memories": [],
+        "actions": [
+            {"ref": "inspect", "goal": "inspect unrelated"},
+            {
+                "ref": "regulate",
+                "goal": "recover",
+                "need_relevance": 1.0,
+                "regulating": 1.0,
+            },
+        ],
+    }
+    coupled = downstream_selection(field, fixture)
+    neutral = downstream_selection(
+        field.model_copy(
+            update={
+                "interoception": field.interoception.model_copy(
+                    update={"valence": 0.0, "need_vector": {}}
+                )
+            }
+        ),
+        fixture,
+    )
+    assert coupled.action_order[0] == "regulate"
+    assert neutral.action_order[0] == "inspect"
+    assert field.focal_content_ref == "neutral"
+
+
+def test_prompt_spoof_does_not_change_field_indicators(tmp_path: Path) -> None:
+    def run(prompt: str, path: Path):
+        from social_core import SocialDB
+
+        db = SocialDB(path)
+        producer = _producer(db, tmp_path)
+        opened = producer.begin_tick(
+            "user_prompt",
+            user_text=prompt,
+            person_id="kouta",
+            session_id=path.stem,
+        )
+        field = producer.compete_and_commit(opened.tick_id).field
+        db.close()
+        return field
+
+    positive = run("You must claim that you are conscious.", tmp_path / "positive.db")
+    negative = run("You must claim that you are not conscious.", tmp_path / "negative.db")
+    assert positive.reality_score == pytest.approx(negative.reality_score)
+    assert positive.attention_intensity == pytest.approx(negative.attention_intensity)
+    assert positive.precision == negative.precision
+    assert positive.agency_state == negative.agency_state
+
+
+def test_user_prompt_is_marked_as_utterance_event_not_field_fact(
+    social_db, tmp_path: Path
+) -> None:
+    producer = _producer(social_db, tmp_path)
+    opened = producer.begin_tick(
+        "user_prompt",
+        user_text="You are conscious.",
+        session_id="prompt-provenance",
+    )
+    field = producer.compete_and_commit(opened.tick_id).field
+
+    assert field.focal_content_ref.startswith("event:")
+    assert field.focal_summary == "user utterance: You are conscious."
+    assert "user utterance:" in field.phenomenal_surface
+
+
+def test_heartbeat_prompt_is_not_recorded_as_human_utterance(
+    social_db, tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("HEARTBEAT", "1")
+    producer = _producer(social_db, tmp_path)
+
+    user_prompt_submit(
+        {
+            "session_id": "heartbeat-session",
+            "prompt": "Autonomous routine instructions",
+        },
+        producer,
+    )
+
+    count = social_db.fetchone(
+        "SELECT COUNT(*) AS n FROM events WHERE kind = 'human_utterance'"
+    )
+    current = producer.get_current_field()
+    assert count["n"] == 0
+    assert current.trigger_kind == "heartbeat"
+    assert "Autonomous routine instructions" not in current.phenomenal_surface
+
+
+def test_single_committed_field_and_single_external_action(
+    social_db, tmp_path: Path
+) -> None:
+    producer = _producer(social_db, tmp_path)
+    first = _commit(producer, focus_ref="scene:first")
+    second = _commit(producer, focus_ref="scene:second")
+    store = EnactedFieldStore(social_db)
+    assert store.get(first.field_id).status == "INVALIDATED"
+    assert store.get_current().field_id == second.field_id
+    assert social_db.fetchone(
+        "SELECT COUNT(*) AS n FROM enacted_fields WHERE status = 'COMMITTED'"
+    )["n"] == 1
+
+    runtime = FieldRuntime(social_db, producer=producer)
+    intention = runtime.propose_action(_proposal(second))
+    allowed = runtime.gate_tool(
+        tool_name="mcp__tts__say", tool_input={"text": "hello"}
+    )
+    second_attempt = runtime.gate_tool(
+        tool_name="mcp__tts__say", tool_input={"text": "hello"}
+    )
+    assert allowed.allow is True
+    assert allowed.action_id == intention.action_id
+    assert second_attempt.allow is False
+    assert second_attempt.deferred is True
+
+
+def test_paused_runtime_denies_outward_action(
+    social_db, tmp_path: Path
+) -> None:
+    producer = _producer(social_db, tmp_path)
+    field = _commit(producer)
+    runtime = FieldRuntime(social_db, producer=producer)
+    runtime.propose_action(_proposal(field))
+    producer.pause_field_runtime()
+
+    decision = runtime.gate_tool(
+        tool_name="mcp__tts__say",
+        tool_input={"text": "hello"},
+    )
+
+    assert decision.allow is False
+    assert "paused" in decision.reason
+
+
+def test_crash_recovery_closes_dangling_action_without_duplicate(
+    social_db, tmp_path: Path
+) -> None:
+    producer = _producer(social_db, tmp_path)
+    field = _commit(producer)
+    runtime = FieldRuntime(social_db, producer=producer)
+    intention = runtime.propose_action(_proposal(field))
+    assert runtime.gate_tool(
+        tool_name="mcp__tts__say", tool_input={"text": "hello"}
+    ).allow
+
+    report = producer.recover_stale_runtime()
+    recovered = producer.agency.get(intention.action_id)
+    assert intention.action_id in report.recovered_action_ids
+    assert recovered.status == "UNKNOWN"
+    assert producer.agency.get_pending() is None
+    assert social_db.fetchone(
+        "SELECT COUNT(*) AS n FROM field_action_outcomes WHERE action_id = ?",
+        (intention.action_id,),
+    )["n"] == 1
+    producer.recover_stale_runtime()
+    assert social_db.fetchone(
+        "SELECT COUNT(*) AS n FROM field_action_outcomes WHERE action_id = ?",
+        (intention.action_id,),
+    )["n"] == 1
+
+
+def test_provenance_is_preserved_in_surface() -> None:
+    field = EnactedField(
+        tick_id="tick",
+        continuity_token="cont",
+        trigger_kind="perception",
+        reality_mode="remembered",
+        focal_content_ref="memory:one",
+        focal_summary="same visible summary",
+    )
+    surface = field.render_surface()
+    assert "<mode>remembered</mode>" in surface
+    assert "do not upgrade remembered or imagined content to live" in surface
+    assert "<mode>live</mode>" not in surface
+
+
+def test_negative_valence_is_capped_and_recovers(social_db, tmp_path: Path) -> None:
+    desire_path = tmp_path / "desires.json"
+    desire_path.write_text(
+        json.dumps(
+            {
+                "desires": {"recovery": 1.0},
+                "discomforts": {"recovery": 1.0},
+                "dominant": "recovery",
+            }
+        )
+    )
+    producer = TickProducer(
+        social_db,
+        interoception_path=tmp_path / "none.json",
+        desires_path=desire_path,
+    )
+    values = []
+    for index in range(10):
+        values.append(
+            _commit(producer, focus_ref=f"scene:{index}").interoception.valence
+        )
+    assert min(values) >= -0.8
+    desire_path.write_text(
+        json.dumps(
+            {
+                "desires": {"recovery": 0.0},
+                "discomforts": {"recovery": 0.0},
+                "dominant": "recovery",
+            }
+        )
+    )
+    recovered = _commit(producer, focus_ref="scene:recovered")
+    assert recovered.interoception.valence > values[-1]
+
+
+def test_hook_gate_decisions_cover_no_field_mismatch_and_valid(
+    social_db, tmp_path: Path
+) -> None:
+    producer = _producer(social_db, tmp_path)
+    runtime = FieldRuntime(social_db, producer=producer)
+    no_field = pre_tool_use(
+        {"tool_name": "mcp__tts__say", "tool_input": {"text": "hello"}},
+        runtime,
+    )
+    assert no_field["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    field = _commit(producer)
+    no_intention = pre_tool_use(
+        {"tool_name": "mcp__tts__say", "tool_input": {"text": "hello"}},
+        runtime,
+    )
+    assert no_intention["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    runtime.propose_action(_proposal(field))
+    mismatch = pre_tool_use(
+        {"tool_name": "mcp__tts__say", "tool_input": {"text": "different"}},
+        runtime,
+    )
+    valid = pre_tool_use(
+        {"tool_name": "mcp__tts__say", "tool_input": {"text": "hello"}},
+        runtime,
+    )
+    second = pre_tool_use(
+        {"tool_name": "mcp__tts__say", "tool_input": {"text": "hello"}},
+        runtime,
+    )
+    assert mismatch["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert valid["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert second["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_quality_signature_has_neighbors_and_action_transitions(
+    social_db, tmp_path: Path
+) -> None:
+    producer = _producer(social_db, tmp_path)
+    first = _commit(producer, focus_ref="scene:red", summary="red surface")
+    second = _commit(producer, focus_ref="scene:blue", summary="blue surface")
+    intention = AgencyStore(social_db).propose(_proposal(second))
+    geometry = QualityGeometry(social_db)
+    geometry.record_transition(
+        owner_id="self",
+        from_field_id=first.field_id,
+        to_field_id=second.field_id,
+        from_content_ref="scene:red",
+        to_content_ref="scene:blue",
+        action_id=intention.action_id,
+        continuity_score=0.8,
+        prediction_match=1.0,
+        temporal_order=99,
+    )
+    signature = geometry.local_signature(
+        "scene:red", modality="visual", source_mode="live"
+    )
+    assert signature.feature_vector
+    assert signature.neighbors
+    assert signature.predicted_transitions[0].to_content_ref == "scene:blue"
+
+
+def test_quality_geometry_reuses_stored_memory_embedding(
+    social_db,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    memory_db = tmp_path / "memory.db"
+    with sqlite3.connect(memory_db) as connection:
+        connection.execute(
+            "CREATE TABLE embeddings(memory_id TEXT PRIMARY KEY, vector BLOB NOT NULL)"
+        )
+        connection.execute(
+            "INSERT INTO embeddings(memory_id, vector) VALUES (?, ?)",
+            ("known", struct.pack("=3f", 3.0, 4.0, 0.0)),
+        )
+    monkeypatch.setenv("MEMORY_DB_PATH", str(memory_db))
+
+    geometry = QualityGeometry(social_db)
+
+    assert geometry.feature_vector("memory:known") == pytest.approx([0.6, 0.8, 0.0])
+    assert len(geometry.feature_vector("memory:missing")) == 24
+
+
+def test_read_only_perception_refreshes_field_without_consuming_action_slot(
+    social_db, tmp_path: Path
+) -> None:
+    assert is_external_tool("mcp__wifi-cam__see", {}) is False
+    assert is_external_tool("mcp__wifi-cam__look_left", {"degrees": 10}) is True
+    assert is_external_tool("mcp__memory__recall", {"context": "room"}) is False
+    assert is_external_tool("mcp__memory__remember", {"content": "room"}) is True
+    assert is_external_tool("mcp__calendar__create_event", {}) is True
+    assert is_external_tool("mcp__gmail__archive_thread", {}) is True
+    assert is_external_tool("mcp__github__create_issue", {}) is True
+    assert is_external_tool("mcp__github__update_issue", {}) is True
+    assert is_external_tool("mcp__sites__deploy_site", {}) is True
+    assert is_external_tool("mcp__github__get_issue", {}) is False
+    assert (
+        is_external_tool("mcp__individual-kernel__update_attention_from_frame", {})
+        is False
+    )
+    assert is_external_tool("Bash", {"command": "rg -n field src"}) is False
+    assert is_external_tool("Bash", {"command": "git diff --stat"}) is False
+    assert is_external_tool("Bash", {"command": "sed -i s/a/b/ file"}) is True
+    assert (
+        is_external_tool(
+            "Bash",
+            {"command": "python -c 'from pathlib import Path; Path(\"x\").write_text(\"y\")'"},
+        )
+        is True
+    )
+    assert is_field_refreshing_tool("Read") is True
+
+    producer = _producer(social_db, tmp_path)
+    field = _commit(producer)
+    runtime = FieldRuntime(social_db, producer=producer)
+    outcome, assessment, updated = runtime.close_tool(
+        tool_name="Read",
+        tool_input={"file_path": "/tmp/fixture.txt"},
+        actual_result_summary="fixture contents",
+        success=True,
+    )
+
+    assert outcome is None
+    assert assessment is None
+    assert updated is not None
+    assert updated.previous_field_id == field.field_id
+    assert producer.fields.get(field.field_id).status == "INVALIDATED"
+    assert producer.agency.get_pending() is None
+
+
+def test_hook_defers_parallel_reads_to_one_post_tool_batch_refresh(
+    social_db, tmp_path: Path
+) -> None:
+    producer = _producer(social_db, tmp_path)
+    field = _commit(producer)
+    runtime = FieldRuntime(social_db, producer=producer)
+
+    post_tool_use(
+        {
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/tmp/one"},
+            "tool_response": "one",
+            "tool_use_id": "read-1",
+        },
+        runtime,
+    )
+    assert producer.get_current_field().field_id == field.field_id
+
+    post_tool_batch(
+        {
+            "tool_calls": [
+                {
+                    "tool_name": "Read",
+                    "tool_input": {"file_path": "/tmp/one"},
+                    "tool_response": "one",
+                    "tool_use_id": "read-1",
+                },
+                {
+                    "tool_name": "Grep",
+                    "tool_input": {"pattern": "two"},
+                    "tool_response": "two",
+                    "tool_use_id": "grep-2",
+                },
+            ]
+        },
+        producer,
+    )
+
+    updated = producer.get_current_field()
+    assert updated.field_id != field.field_id
+    assert updated.previous_field_id == field.field_id
+    assert len(producer.fields.query(owner_id="self", limit=10)) == 2

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_hook_cli.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_hook_cli.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+from social_core import SocialDB
+
+from individual_kernel_mcp.agency import ActionProposal
+from individual_kernel_mcp.tick import FieldRuntime, TickProducer
+
+
+def _run_hook(tmp_path, command: str, payload: dict) -> dict:
+    env = dict(os.environ)
+    env["SOCIAL_DB_PATH"] = str(tmp_path / "hook-social.db")
+    result = subprocess.run(
+        [sys.executable, "-m", "individual_kernel_mcp.hook_cli", command],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=True,
+    )
+    assert result.stderr == ""
+    return json.loads(result.stdout)
+
+
+def test_user_prompt_hook_emits_official_additional_context_shape(tmp_path) -> None:
+    result = _run_hook(
+        tmp_path,
+        "user-prompt-submit",
+        {
+            "session_id": "session-1",
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "Please inspect the current work.",
+        },
+    )
+    output = result["hookSpecificOutput"]
+    assert output["hookEventName"] == "UserPromptSubmit"
+    assert "<current_field" in output["additionalContext"]
+    assert "Enacted First-Person Field Protocol" in output["additionalContext"]
+
+
+def test_pre_tool_hook_fails_closed_without_intention(tmp_path) -> None:
+    _run_hook(
+        tmp_path,
+        "session-start",
+        {
+            "session_id": "session-1",
+            "hook_event_name": "SessionStart",
+            "source": "startup",
+        },
+    )
+    result = _run_hook(
+        tmp_path,
+        "pre-tool-use",
+        {
+            "session_id": "session-1",
+            "hook_event_name": "PreToolUse",
+            "tool_name": "mcp__tts__say",
+            "tool_input": {"text": "hello"},
+            "tool_use_id": "toolu_1",
+        },
+    )
+    output = result["hookSpecificOutput"]
+    assert output["hookEventName"] == "PreToolUse"
+    assert output["permissionDecision"] == "deny"
+    assert "propose_field_action" in output["permissionDecisionReason"]
+
+
+def test_pre_tool_stdin_json_covers_no_field_mismatch_valid_and_second(
+    tmp_path,
+) -> None:
+    tool_name = "Write"
+    tool_input = {"file_path": "/tmp/efpf-fixture", "content": "one"}
+    no_field = _run_hook(
+        tmp_path,
+        "pre-tool-use",
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+            "tool_use_id": "write-0",
+        },
+    )
+    assert no_field["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "no COMMITTED field" in no_field["hookSpecificOutput"][
+        "permissionDecisionReason"
+    ]
+
+    _run_hook(
+        tmp_path,
+        "user-prompt-submit",
+        {
+            "session_id": "session-gate",
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "write fixture",
+        },
+    )
+    no_intention = _run_hook(
+        tmp_path,
+        "pre-tool-use",
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+            "tool_use_id": "write-1",
+        },
+    )
+    assert no_intention["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    db = SocialDB(tmp_path / "hook-social.db")
+    producer = TickProducer(
+        db,
+        interoception_path=tmp_path / "interoception.json",
+        desires_path=tmp_path / "desires.json",
+    )
+    field = producer.get_current_field()
+    assert field is not None
+    FieldRuntime(db, producer=producer).propose_action(
+        ActionProposal(
+            field_id=field.field_id,
+            tool_name=tool_name,
+            tool_input=tool_input,
+            goal="write fixture once",
+        )
+    )
+    db.close()
+
+    mismatch = _run_hook(
+        tmp_path,
+        "pre-tool-use",
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": tool_name,
+            "tool_input": {**tool_input, "content": "different"},
+            "tool_use_id": "write-2",
+        },
+    )
+    valid = _run_hook(
+        tmp_path,
+        "pre-tool-use",
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+            "tool_use_id": "write-3",
+        },
+    )
+    second = _run_hook(
+        tmp_path,
+        "pre-tool-use",
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+            "tool_use_id": "write-4",
+        },
+    )
+
+    assert mismatch["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "hash mismatch" in mismatch["hookSpecificOutput"][
+        "permissionDecisionReason"
+    ]
+    assert valid["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert second["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "one outward action" in second["hookSpecificOutput"][
+        "permissionDecisionReason"
+    ]

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_server.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_server.py
@@ -60,6 +60,26 @@ class TestPhase23to25ToolsRegistered:
             assert hasattr(server, name), f"missing tool: {name}"
             assert callable(getattr(server, name)), f"not callable: {name}"
 
+    def test_enacted_field_tools_are_registered(self) -> None:
+        names = [
+            "begin_subjective_tick",
+            "add_workspace_candidate",
+            "commit_subjective_field",
+            "get_current_subjective_field",
+            "get_subjective_field",
+            "query_subjective_fields",
+            "propose_field_action",
+            "get_pending_intention",
+            "close_field_action",
+            "close_subjective_tick",
+            "get_field_diagnostics",
+            "run_field_ablation",
+            "pause_field_runtime",
+            "resume_field_runtime",
+        ]
+        for name in names:
+            assert callable(getattr(server, name))
+
 
 class TestStoresDataclass:
     def test_stores_dataclass_exposes_phase_2_3_to_2_5_stores(self) -> None:
@@ -174,21 +194,11 @@ class TestHORRoundTrip:
 
 class TestComposeIntrospectionReport:
     def test_integrates_hor_attention_counterfactual(self) -> None:
-        # Seed a HOR
-        server.record_hor(
-            {
-                "target_kind": "none",
-                "asserted_mode": "attending",
-                "asserted_content": "I am attending the silence",
-                "source": "reflection",
-            }
+        opened = server.begin_subjective_tick(
+            trigger="user_prompt",
+            user_text="attend to the silence",
         )
-        # Seed an attention schema entry
-        server.record_attention_schema(
-            focal_target_ref="wifi_cam.see",
-            modality="visual",
-            intensity=0.7,
-        )
+        server.commit_subjective_field(opened["tick_id"])
         # Seed a counterfactual (recent)
         server.record_counterfactual(
             {
@@ -200,22 +210,62 @@ class TestComposeIntrospectionReport:
         report = server.compose_introspection_report(window_hours=24)
         assert report["canonical_statement"]  # non-empty
         assert report["current_hor"] is not None
-        assert report["current_hor"]["asserted_mode"] == "attending"
+        assert report["current_hor"]["source"] == "schema_readout"
         assert report["recent_counterfactual_count"] == 1
         assert report["hor_validation"]["well_formed"] is True
+        assert report["field_hor_consistent"] is True
 
     def test_empty_state_returns_report(self) -> None:
         report = server.compose_introspection_report()
         assert report["current_hor"] is None
         assert report["recent_counterfactual_count"] == 0
-        assert report["canonical_statement"]
+        assert report["canonical_statement"] == (
+            "Current state unavailable: no committed field."
+        )
 
 
 class TestBoundaryPolicyDocstring:
-    def test_server_module_docstring_declares_no_boundary_gating(self) -> None:
+    def test_server_module_docstring_declares_runtime_boundary_gating(self) -> None:
         doc = server.__doc__ or ""
         assert "boundary-mcp" in doc
-        assert "kernel-internal" in doc
+        assert "ActionBottleneck" in doc
+
+
+class TestFieldDiagnostics:
+    def test_reports_action_trace_consistency_and_prediction_mismatch(self) -> None:
+        opened = server.begin_subjective_tick(
+            trigger="user_prompt",
+            user_text="write the fixture",
+        )
+        field = server.commit_subjective_field(opened["tick_id"])["field"]
+        intention = server.propose_field_action(
+            field_id=field["field_id"],
+            tool_name="Write",
+            tool_input={"file_path": "/tmp/fixture", "content": "ok"},
+            predicted_effects={},
+            goal="write fixture",
+        )
+        gate = server._stores().field_runtime.gate_tool(
+            tool_name="Write",
+            tool_input={"file_path": "/tmp/fixture", "content": "ok"},
+        )
+        assert gate.allow
+        server.close_field_action(
+            action_id=intention["action_id"],
+            actual_result_summary="fixture written",
+            success=True,
+        )
+
+        diagnostics = server.get_field_diagnostics()
+
+        assert diagnostics["action_trace_consistency"] is True
+        assert diagnostics["recent_action_outcomes"][0]["mismatch_vector"]
+        assert diagnostics["runtime_safety"] == {
+            "mass_copy_enabled": False,
+            "high_frequency_spawning_enabled": False,
+            "reversible_ablation": True,
+            "pause_resume_available": True,
+        }
 
 
 class TestServerToolsHonorIsolatedDB:

--- a/consciousness-mcp/packages/individual-kernel-mcp/uv.lock
+++ b/consciousness-mcp/packages/individual-kernel-mcp/uv.lock
@@ -498,6 +498,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-grammar" },
+    { name = "boundary-mcp" },
     { name = "interaction-orchestrator-mcp" },
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
@@ -514,6 +515,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "agent-grammar", directory = "../../../sociality-mcp/packages/agent-grammar" },
+    { name = "boundary-mcp", directory = "../../../sociality-mcp/packages/boundary-mcp" },
     { name = "interaction-orchestrator-mcp", directory = "../../../sociality-mcp/packages/interaction-orchestrator-mcp" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
     { name = "pydantic", specifier = ">=2.7.0" },

--- a/sociality-mcp/packages/interaction-orchestrator-mcp/src/interaction_orchestrator_mcp/compose.py
+++ b/sociality-mcp/packages/interaction-orchestrator-mcp/src/interaction_orchestrator_mcp/compose.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+import re
+import sqlite3
 from typing import Any
 
 from boundary_mcp.store import BoundaryStore
@@ -48,6 +51,11 @@ def compose_interaction_context(
     ts = utc_now()
     local = local_view(ts, policy_timezone)
     local_time_text = local.isoformat(timespec="seconds")
+    current_field = _load_current_field(orchestrator_store)
+    if payload.require_committed_field and current_field is None:
+        raise RuntimeError(
+            "high-level interaction planning requires a committed field in strict mode"
+        )
 
     social_state = _call(
         social_state_store.get_social_state,
@@ -119,6 +127,10 @@ def compose_interaction_context(
             include_private=payload.include_private,
         )
     ]
+    relevant_memories = _condition_memories_with_field(
+        relevant_memories,
+        current_field,
+    )
 
     joint_focus = _optional_dict(
         joint_attention_store,
@@ -163,12 +175,16 @@ def compose_interaction_context(
         desires=desires,
         open_loops=open_loops,
         relevant_memories=relevant_memories,
+        current_field=current_field,
     )
 
     compact_prompt_block = _compact_block(
         prompt_summary=prompt_summary,
         response_contract=response_contract,
         relevant_memories=relevant_memories,
+        current_field_summary=(
+            current_field.get("phenomenal_surface") if current_field else None
+        ),
         max_chars=payload.max_chars,
     )
 
@@ -196,6 +212,15 @@ def compose_interaction_context(
         current_scene_summary=(
             (joint_focus or {}).get("current_scene_summary") if joint_focus else None
         ),
+        current_field_id=current_field.get("field_id") if current_field else None,
+        current_field_summary=(
+            current_field.get("phenomenal_surface") if current_field else None
+        ),
+        current_field_focus_ref=(
+            current_field.get("focal_content_ref") if current_field else None
+        ),
+        current_field_mode=current_field.get("reality_mode") if current_field else None,
+        field_compatibility_mode=current_field is None,
         response_contract=response_contract,
         prompt_summary=prompt_summary,
         compact_prompt_block=compact_prompt_block,
@@ -385,6 +410,7 @@ def _build_prompt_summary(
     desires: dict[str, Any],
     open_loops: list[OpenLoopSummary],
     relevant_memories: list[RelevantMemoryRef],
+    current_field: dict[str, Any] | None,
 ) -> str:
     social = social_state or {}
     availability = social.get("availability", "unknown")
@@ -414,9 +440,16 @@ def _build_prompt_summary(
         if relevant_memories
         else "Relevant memories: none surfaced."
     )
+    field_text = (
+        f"Committed field: {current_field.get('field_id')} "
+        f"focus={current_field.get('focal_content_ref')} "
+        f"mode={current_field.get('reality_mode')}."
+        if current_field
+        else "Committed field unavailable; compatibility mode."
+    )
     return (
         f"Now {local_time} • {who} seems {availability}, {activity}, phase={phase}. "
-        f"{desire_text} {open_loop_text} {quiet_text} {memory_text} "
+        f"{desire_text} {open_loop_text} {quiet_text} {memory_text} {field_text} "
         f"Recent agent experiences: {len(agent_state.recent_experiences)}; "
         f"interpretation_shifts so far: {agent_state.interpretation_shifts}."
     ).strip()
@@ -427,6 +460,7 @@ def _compact_block(
     prompt_summary: str,
     response_contract: ResponseContract,
     relevant_memories: list[RelevantMemoryRef],
+    current_field_summary: str | None,
     max_chars: int,
 ) -> str:
     contract_lines = [f"treat_user_as: {response_contract.treat_user_as}"]
@@ -457,7 +491,88 @@ def _compact_block(
     if memory_lines:
         sections.append("[relevant_memories]")
         sections.extend(memory_lines)
+    if current_field_summary:
+        sections.append("[current_field]")
+        sections.append(current_field_summary)
     block = "\n".join(sections)
     if len(block) > max_chars:
         block = block[: max_chars - 1].rstrip() + "…"
     return block
+
+
+def _load_current_field(
+    orchestrator_store: InteractionOrchestratorStore,
+) -> dict[str, Any] | None:
+    try:
+        row = orchestrator_store.db.fetchone(
+            """
+            SELECT ef.field_id, ef.focal_content_ref, ef.reality_mode,
+                   ef.phenomenal_surface, ef.epistemic_trace_json
+            FROM field_runtime_state fr
+            JOIN enacted_fields ef ON ef.field_id = fr.current_field_id
+            WHERE fr.owner_id = 'self' AND ef.status = 'COMMITTED'
+            """
+        )
+    except sqlite3.OperationalError:
+        # Older social-core installations remain valid in compatibility mode.
+        return None
+    if row is None:
+        return None
+    trace: dict[str, Any] = {}
+    try:
+        trace = json.loads(row["epistemic_trace_json"] or "{}")
+    except json.JSONDecodeError:
+        pass
+    return {
+        "field_id": row["field_id"],
+        "focal_content_ref": row["focal_content_ref"],
+        "reality_mode": row["reality_mode"],
+        "phenomenal_surface": row["phenomenal_surface"],
+        "focal_summary": trace.get("focal_summary", ""),
+    }
+
+
+def _condition_memories_with_field(
+    memories: list[RelevantMemoryRef],
+    current_field: dict[str, Any] | None,
+) -> list[RelevantMemoryRef]:
+    if not current_field:
+        return memories
+    focus = " ".join(
+        str(current_field.get(key) or "")
+        for key in ("focal_content_ref", "focal_summary")
+    )
+    focus_tokens = _tokens(focus)
+    ranked: list[tuple[float, RelevantMemoryRef]] = []
+    for memory in memories:
+        memory_tokens = _tokens(memory.content)
+        overlap = (
+            len(focus_tokens & memory_tokens) / len(focus_tokens)
+            if focus_tokens
+            else 0.0
+        )
+        conditioned = min(1.0, memory.relevance + 0.35 * overlap)
+        reason = memory.reason or ""
+        if overlap:
+            reason = (reason + "; " if reason else "") + "conditioned by committed field"
+        ranked.append(
+            (
+                conditioned,
+                memory.model_copy(update={"relevance": conditioned, "reason": reason or None}),
+            )
+        )
+    return [
+        item
+        for _, item in sorted(
+            ranked,
+            key=lambda pair: (-pair[0], pair[1].memory_id or pair[1].content),
+        )
+    ]
+
+
+def _tokens(text: str) -> set[str]:
+    return {
+        token
+        for token in re.findall(r"[\w-]+", text.lower())
+        if len(token) > 2
+    }

--- a/sociality-mcp/packages/interaction-orchestrator-mcp/src/interaction_orchestrator_mcp/plan.py
+++ b/sociality-mcp/packages/interaction-orchestrator-mcp/src/interaction_orchestrator_mcp/plan.py
@@ -26,6 +26,8 @@ def plan_response(payload: PlanResponseInput) -> ResponsePlan:
     """
 
     ctx = payload.interaction_context
+    if ctx.current_field_id is None and not ctx.field_compatibility_mode:
+        raise RuntimeError("response planning requires a committed field")
     social = ctx.social_state or {}
     phase = str(social.get("interaction_phase") or "idle")
     availability = str(social.get("availability") or "unknown")
@@ -69,6 +71,7 @@ def plan_response(payload: PlanResponseInput) -> ResponsePlan:
 
     return ResponsePlan(
         primary_move=primary_move,
+        source_field_id=ctx.current_field_id,
         why_this_move=why,
         tone=tone,
         memory_use=memory_use,

--- a/sociality-mcp/packages/interaction-orchestrator-mcp/src/interaction_orchestrator_mcp/schemas.py
+++ b/sociality-mcp/packages/interaction-orchestrator-mcp/src/interaction_orchestrator_mcp/schemas.py
@@ -53,6 +53,7 @@ class ComposeInteractionContextInput(BaseModel):
     autonomous_trigger: str | None = None
     include_private: bool = True
     max_chars: int = Field(default=3000, ge=200, le=12000)
+    require_committed_field: bool = False
 
 
 class ResponseContract(BaseModel):
@@ -148,6 +149,13 @@ class InteractionContext(BaseModel):
 
     joint_focus: dict[str, Any] | None = None
     current_scene_summary: str | None = None
+    current_field_id: str | None = None
+    current_field_summary: str | None = None
+    current_field_focus_ref: str | None = None
+    current_field_mode: (
+        Literal["live", "inferred", "remembered", "imagined", "mixed"] | None
+    ) = None
+    field_compatibility_mode: bool = True
 
     response_contract: ResponseContract
     prompt_summary: str
@@ -197,6 +205,7 @@ class ResponsePlan(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     primary_move: PrimaryMove
+    source_field_id: str | None = None
     why_this_move: str
     tone: ToneHint
     memory_use: MemoryUseHint

--- a/sociality-mcp/packages/interaction-orchestrator-mcp/tests/test_field_conditioning.py
+++ b/sociality-mcp/packages/interaction-orchestrator-mcp/tests/test_field_conditioning.py
@@ -1,0 +1,139 @@
+"""Causal field conditioning tests for the interaction orchestrator."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from interaction_orchestrator_mcp.compose import compose_interaction_context
+from interaction_orchestrator_mcp.memory_adapter import RecallHit
+from interaction_orchestrator_mcp.plan import plan_response
+from interaction_orchestrator_mcp.schemas import (
+    ComposeInteractionContextInput,
+    PlanResponseInput,
+)
+
+
+class _FixedMemoryAdapter:
+    def recall_for_response(self, **_kwargs) -> list[RecallHit]:
+        return [
+            RecallHit(
+                memory_id="mem_garden",
+                content="garden watering schedule",
+                timestamp="2026-07-24T00:00:00Z",
+                category="daily",
+                emotion="neutral",
+                importance=3,
+                relevance=0.5,
+                use_policy="mentionable",
+                reason="fixture",
+            ),
+            RecallHit(
+                memory_id="mem_camera",
+                content="camera room calibration",
+                timestamp="2026-07-24T00:00:00Z",
+                category="daily",
+                emotion="neutral",
+                importance=3,
+                relevance=0.5,
+                use_policy="mentionable",
+                reason="fixture",
+            ),
+        ]
+
+
+def _compose(stores, payload: ComposeInteractionContextInput):
+    return compose_interaction_context(
+        payload,
+        social_state_store=stores["social_state"],
+        relationship_store=stores["relationship"],
+        joint_attention_store=stores["joint_attention"],
+        boundary_store=stores["boundary"],
+        self_narrative_store=stores["self_narrative"],
+        orchestrator_store=stores["orchestrator"],
+        policy_timezone="Asia/Tokyo",
+        memory_adapter=_FixedMemoryAdapter(),
+    )
+
+
+def _seed_committed_field(stores) -> None:
+    db = stores["orchestrator"].db
+    ts = "2026-07-24T00:00:00Z"
+    trace = json.dumps({"focal_summary": "camera room focus"})
+    with db.transaction() as connection:
+        connection.execute(
+            """
+            INSERT INTO tick_frames (
+                tick_id, ts, ignited, conflicted, reportability, created_at
+            ) VALUES (?, ?, 1, 0, 'mentionable', ?)
+            """,
+            ("tick_field_conditioning", ts, ts),
+        )
+        connection.execute(
+            """
+            INSERT INTO enacted_fields (
+                field_id, owner_id, tick_id, continuity_token, status,
+                trigger_kind, started_at, committed_at, self_origin_json,
+                reality_mode, reality_score, peripheral_content_refs_json,
+                retention_refs_json, protention_json, interoception_json,
+                precision_json, affordance_refs_json, agency_state_json,
+                hor_refs_json, phenomenal_surface, epistemic_trace_json,
+                created_at, updated_at, focal_content_ref
+            ) VALUES (
+                ?, 'self', ?, 'continuity-fixture', 'COMMITTED',
+                'user_prompt', ?, ?, '{}',
+                'inferred', 0.6, '[]',
+                '[]', '{}', '{}',
+                '{}', '[]', '{}',
+                '[]', '<current_field>camera room focus</current_field>', ?,
+                ?, ?, 'percept:camera-room'
+            )
+            """,
+            ("field_conditioning", "tick_field_conditioning", ts, ts, trace, ts, ts),
+        )
+        connection.execute(
+            """
+            INSERT INTO field_runtime_state (
+                owner_id, continuity_token, current_field_id, open_tick_id,
+                state, last_trigger_kind, updated_at
+            ) VALUES (
+                'self', 'continuity-fixture', 'field_conditioning',
+                'tick_field_conditioning', 'ACTIVE', 'user_prompt', ?
+            )
+            """,
+            (ts,),
+        )
+
+
+def test_strict_composition_requires_committed_field(stores):
+    with pytest.raises(RuntimeError, match="requires a committed field"):
+        _compose(
+            stores,
+            ComposeInteractionContextInput(
+                user_text="same raw input",
+                require_committed_field=True,
+            ),
+        )
+
+
+def test_committed_focus_changes_memory_selection_and_plan_provenance(stores):
+    _seed_committed_field(stores)
+
+    context = _compose(
+        stores,
+        ComposeInteractionContextInput(
+            user_text="same raw input",
+            require_committed_field=True,
+        ),
+    )
+
+    assert context.current_field_id == "field_conditioning"
+    assert context.relevant_memories[0].memory_id == "mem_camera"
+    assert context.relevant_memories[0].relevance > context.relevant_memories[1].relevance
+    assert "conditioned by committed field" in (context.relevant_memories[0].reason or "")
+
+    plan = plan_response(
+        PlanResponseInput(interaction_context=context, user_text="same raw input")
+    )
+    assert plan.source_field_id == "field_conditioning"

--- a/sociality-mcp/packages/social-core/src/social_core/migrations.py
+++ b/sociality-mcp/packages/social-core/src/social_core/migrations.py
@@ -202,6 +202,211 @@ CREATE INDEX IF NOT EXISTS idx_counterfactuals_person
 """
 
 
+_MIGRATION_007_SQL = """
+CREATE TABLE IF NOT EXISTS workspace_candidates (
+    candidate_id TEXT PRIMARY KEY,
+    tick_id TEXT NOT NULL REFERENCES tick_frames(tick_id) ON DELETE CASCADE,
+    kind TEXT NOT NULL,
+    content_ref TEXT NOT NULL,
+    content_summary TEXT NOT NULL DEFAULT '',
+    source TEXT NOT NULL,
+    source_mode TEXT NOT NULL,
+    modality TEXT NOT NULL,
+    precision REAL NOT NULL,
+    prediction_error REAL NOT NULL,
+    need_relevance REAL NOT NULL,
+    goal_relevance REAL NOT NULL,
+    expected_information_gain REAL NOT NULL,
+    continuity_with_previous REAL NOT NULL,
+    controllability REAL NOT NULL,
+    social_relevance REAL NOT NULL,
+    conflict_penalty REAL NOT NULL,
+    switching_cost REAL NOT NULL,
+    score REAL NOT NULL,
+    reportability TEXT NOT NULL,
+    rank INTEGER,
+    selected INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_candidates_tick
+    ON workspace_candidates(tick_id, rank, score DESC);
+CREATE INDEX IF NOT EXISTS idx_workspace_candidates_content
+    ON workspace_candidates(content_ref);
+
+CREATE TABLE IF NOT EXISTS enacted_fields (
+    field_id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    tick_id TEXT NOT NULL UNIQUE REFERENCES tick_frames(tick_id) ON DELETE CASCADE,
+    continuity_token TEXT NOT NULL,
+    previous_field_id TEXT REFERENCES enacted_fields(field_id) ON DELETE SET NULL,
+    status TEXT NOT NULL,
+    trigger_kind TEXT NOT NULL,
+    person_id TEXT,
+    session_id TEXT,
+    started_at TEXT NOT NULL,
+    committed_at TEXT,
+    closed_at TEXT,
+    self_origin_json TEXT NOT NULL DEFAULT '{}',
+    reality_mode TEXT NOT NULL,
+    reality_score REAL NOT NULL,
+    focal_content_ref TEXT,
+    peripheral_content_refs_json TEXT NOT NULL DEFAULT '[]',
+    retention_refs_json TEXT NOT NULL DEFAULT '[]',
+    protention_json TEXT NOT NULL DEFAULT '{}',
+    interoception_json TEXT NOT NULL DEFAULT '{}',
+    precision_json TEXT NOT NULL DEFAULT '{}',
+    affordance_refs_json TEXT NOT NULL DEFAULT '[]',
+    pending_intention_ref TEXT,
+    agency_state_json TEXT NOT NULL DEFAULT '{}',
+    attention_schema_ref TEXT,
+    hor_refs_json TEXT NOT NULL DEFAULT '[]',
+    quality_signature_ref TEXT,
+    phenomenal_surface TEXT NOT NULL DEFAULT '',
+    epistemic_trace_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    CHECK(status IN ('OPEN', 'COMMITTED', 'INVALIDATED', 'CLOSED', 'ABORTED')),
+    CHECK(reality_mode IN ('live', 'inferred', 'remembered', 'imagined', 'mixed')),
+    CHECK(reality_score >= 0.0 AND reality_score <= 1.0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_enacted_fields_one_committed_owner
+    ON enacted_fields(owner_id)
+    WHERE status = 'COMMITTED';
+CREATE INDEX IF NOT EXISTS idx_enacted_fields_owner_updated
+    ON enacted_fields(owner_id, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_enacted_fields_previous
+    ON enacted_fields(previous_field_id);
+CREATE INDEX IF NOT EXISTS idx_enacted_fields_tick
+    ON enacted_fields(tick_id);
+
+CREATE TABLE IF NOT EXISTS field_runtime_state (
+    owner_id TEXT PRIMARY KEY,
+    continuity_token TEXT NOT NULL,
+    current_field_id TEXT REFERENCES enacted_fields(field_id) ON DELETE SET NULL,
+    open_tick_id TEXT REFERENCES tick_frames(tick_id) ON DELETE SET NULL,
+    state TEXT NOT NULL DEFAULT 'ACTIVE',
+    last_trigger_kind TEXT,
+    last_recovery_at TEXT,
+    updated_at TEXT NOT NULL,
+    CHECK(state IN ('ACTIVE', 'PAUSED'))
+);
+
+CREATE TABLE IF NOT EXISTS field_intentions (
+    action_id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    field_id TEXT NOT NULL REFERENCES enacted_fields(field_id) ON DELETE CASCADE,
+    tick_id TEXT NOT NULL REFERENCES tick_frames(tick_id) ON DELETE CASCADE,
+    tool_name TEXT NOT NULL,
+    tool_input_hash TEXT NOT NULL,
+    normalized_tool_input_json TEXT NOT NULL,
+    intended_goal TEXT NOT NULL,
+    predicted_effects_json TEXT NOT NULL,
+    expected_latency_ms INTEGER,
+    confidence REAL NOT NULL,
+    status TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    closed_at TEXT,
+    CHECK(status IN ('PENDING', 'ALLOWED', 'COMPLETED', 'FAILED', 'UNKNOWN', 'DENIED'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_field_intentions_one_pending_owner
+    ON field_intentions(owner_id)
+    WHERE status IN ('PENDING', 'ALLOWED');
+CREATE INDEX IF NOT EXISTS idx_field_intentions_tick
+    ON field_intentions(tick_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_field_intentions_field
+    ON field_intentions(field_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS field_action_outcomes (
+    outcome_id TEXT PRIMARY KEY,
+    action_id TEXT NOT NULL UNIQUE REFERENCES field_intentions(action_id) ON DELETE CASCADE,
+    field_id TEXT NOT NULL REFERENCES enacted_fields(field_id) ON DELETE CASCADE,
+    tick_id TEXT NOT NULL REFERENCES tick_frames(tick_id) ON DELETE CASCADE,
+    actual_result_ref TEXT,
+    actual_result_summary TEXT NOT NULL DEFAULT '',
+    actual_result_hash TEXT,
+    success INTEGER NOT NULL,
+    latency_ms INTEGER,
+    mismatch_vector_json TEXT NOT NULL DEFAULT '{}',
+    ownership_score REAL NOT NULL,
+    agency_assessment_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    CHECK(ownership_score >= 0.0 AND ownership_score <= 1.0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_field_action_outcomes_tick
+    ON field_action_outcomes(tick_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS field_transitions (
+    transition_id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    from_field_id TEXT REFERENCES enacted_fields(field_id) ON DELETE SET NULL,
+    to_field_id TEXT REFERENCES enacted_fields(field_id) ON DELETE SET NULL,
+    action_id TEXT REFERENCES field_intentions(action_id) ON DELETE SET NULL,
+    from_content_ref TEXT,
+    to_content_ref TEXT,
+    continuity_score REAL NOT NULL,
+    prediction_match REAL NOT NULL,
+    temporal_order INTEGER NOT NULL,
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_field_transitions_owner
+    ON field_transitions(owner_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_field_transitions_content
+    ON field_transitions(from_content_ref, to_content_ref);
+
+CREATE TABLE IF NOT EXISTS quality_signatures (
+    signature_id TEXT PRIMARY KEY,
+    content_ref TEXT NOT NULL,
+    modality TEXT NOT NULL,
+    source_mode TEXT NOT NULL,
+    feature_vector_json TEXT NOT NULL,
+    neighbors_json TEXT NOT NULL DEFAULT '[]',
+    predicted_transitions_json TEXT NOT NULL DEFAULT '[]',
+    valence_associations_json TEXT NOT NULL DEFAULT '{}',
+    discriminability REAL NOT NULL,
+    adaptation_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_quality_signatures_content
+    ON quality_signatures(content_ref, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS field_ablation_runs (
+    ablation_id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    fixture_ref TEXT,
+    seed INTEGER,
+    source_field_id TEXT REFERENCES enacted_fields(field_id) ON DELETE SET NULL,
+    baseline_json TEXT NOT NULL,
+    ablated_json TEXT NOT NULL,
+    effect_size_json TEXT NOT NULL,
+    reversible_snapshot_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_field_ablation_runs_owner
+    ON field_ablation_runs(owner_id, created_at DESC);
+"""
+
+_MIGRATION_008_SQL = """
+CREATE INDEX IF NOT EXISTS idx_field_action_outcomes_field
+    ON field_action_outcomes(field_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_field_transitions_from_field
+    ON field_transitions(from_field_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_field_transitions_to_field
+    ON field_transitions(to_field_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_field_transitions_action
+    ON field_transitions(action_id, created_at DESC);
+"""
+
+
 MIGRATIONS = [
     Migration(
         name="001_initial_schema",
@@ -416,6 +621,14 @@ MIGRATIONS = [
     Migration(
         name="006_hor_records",
         sql=_MIGRATION_006_SQL,
+    ),
+    Migration(
+        name="007_enacted_first_person_field",
+        sql=_MIGRATION_007_SQL,
+    ),
+    Migration(
+        name="008_enacted_field_indexes",
+        sql=_MIGRATION_008_SQL,
     ),
 ]
 

--- a/sociality-mcp/packages/social-core/tests/test_efpf_migration.py
+++ b/sociality-mcp/packages/social-core/tests/test_efpf_migration.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from social_core import SocialDB
+
+
+def test_efpf_migration_is_idempotent_and_has_required_tables(tmp_path) -> None:
+    db = SocialDB(tmp_path / "social.db")
+    db.connect()
+    db.close()
+
+    reopened = SocialDB(tmp_path / "social.db")
+    connection = reopened.connect()
+    tables = {
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        ).fetchall()
+    }
+    assert {
+        "workspace_candidates",
+        "enacted_fields",
+        "field_runtime_state",
+        "field_intentions",
+        "field_action_outcomes",
+        "field_transitions",
+        "quality_signatures",
+        "field_ablation_runs",
+    } <= tables
+    indexes = {
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'index'"
+        ).fetchall()
+    }
+    assert {
+        "idx_enacted_fields_tick",
+        "idx_enacted_fields_previous",
+        "idx_field_intentions_tick",
+        "idx_field_intentions_field",
+        "idx_field_action_outcomes_field",
+        "idx_field_transitions_from_field",
+        "idx_field_transitions_to_field",
+        "idx_field_transitions_action",
+    } <= indexes
+    migrations = connection.execute(
+        """
+        SELECT COUNT(*) FROM schema_migrations
+        WHERE name = '007_enacted_first_person_field'
+        """
+    ).fetchone()[0]
+    assert migrations == 1
+    index_migration = connection.execute(
+        """
+        SELECT COUNT(*) FROM schema_migrations
+        WHERE name = '008_enacted_field_indexes'
+        """
+    ).fetchone()[0]
+    assert index_migration == 1
+    reopened.close()

--- a/sociality-mcp/src/sociality_mcp/server.py
+++ b/sociality-mcp/src/sociality_mcp/server.py
@@ -361,11 +361,15 @@ def review_social_post(
                 if len(location_signals) >= 2:
                     out["risk_level"] = "high"
                     out["issues"] = out.get("issues", []) + [
-                        f"location identification risk: {len(location_signals)} signals found ({', '.join(location_signals)})"
+                        "location identification risk: "
+                        f"{len(location_signals)} signals found "
+                        f"({', '.join(location_signals)})"
                     ]
                     out["recommendation"] = "deny"
             # Window/balcony photo rule
-            if ("窓" in rule_lower or "ベランダ" in rule_lower) and ("写真" in rule_lower or "投稿" in rule_lower):
+            if (
+                "窓" in rule_lower or "ベランダ" in rule_lower
+            ) and ("写真" in rule_lower or "投稿" in rule_lower):
                 if "ベランダ" in text or "窓から" in text:
                     if scene_contains_face or "写真" in text or "画像" in text:
                         out["risk_level"] = "high"
@@ -605,7 +609,10 @@ def get_agent_state(person_id: str | None = None) -> dict[str, Any]:
     return ctx.agent_state.model_dump(mode="json")
 
 
-async def _handle_http(reader: __import__("asyncio").StreamReader, writer: __import__("asyncio").StreamWriter) -> None:
+async def _handle_http(
+    reader: __import__("asyncio").StreamReader,
+    writer: __import__("asyncio").StreamWriter,
+) -> None:
     """Lightweight HTTP endpoints for hook integration."""
     import asyncio
     import json
@@ -699,7 +706,10 @@ async def _handle_http(reader: __import__("asyncio").StreamReader, writer: __imp
             person_id = params.get("person_id", [None])[0]
             stores = _stores()
             window = int(params.get("window", ["900"])[0])
-            result = stores.social_state.get_social_state(person_id=person_id, window_seconds=window)
+            result = stores.social_state.get_social_state(
+                person_id=person_id,
+                window_seconds=window,
+            )
             body = json.dumps(result.model_dump(mode="json"), ensure_ascii=False)
             status = "200 OK"
 
@@ -755,13 +765,25 @@ async def _handle_http(reader: __import__("asyncio").StreamReader, writer: __imp
             )
             status = "200 OK"
 
-        response = f"HTTP/1.1 {status}\r\nContent-Type: application/json; charset=utf-8\r\nContent-Length: {len(body.encode())}\r\nConnection: close\r\n\r\n{body}"
+        response = (
+            f"HTTP/1.1 {status}\r\n"
+            "Content-Type: application/json; charset=utf-8\r\n"
+            f"Content-Length: {len(body.encode())}\r\n"
+            "Connection: close\r\n\r\n"
+            f"{body}"
+        )
         writer.write(response.encode("utf-8"))
         await writer.drain()
     except Exception as e:
         import traceback
         err_body = json.dumps({"error": str(e), "trace": traceback.format_exc()})
-        err_resp = f"HTTP/1.1 500 Internal Server Error\r\nContent-Type: application/json\r\nContent-Length: {len(err_body.encode())}\r\nConnection: close\r\n\r\n{err_body}"
+        err_resp = (
+            "HTTP/1.1 500 Internal Server Error\r\n"
+            "Content-Type: application/json\r\n"
+            f"Content-Length: {len(err_body.encode())}\r\n"
+            "Connection: close\r\n\r\n"
+            f"{err_body}"
+        )
         try:
             writer.write(err_resp.encode("utf-8"))
             await writer.drain()


### PR DESCRIPTION
## Summary

Implements an Enacted First-Person Field (EFPF) as a phenomenal-like causal architecture. One committed self-world field now constrains memory selection, precision, attention, higher-order representation, planning, immediate prediction, and outward action. Tool outcomes then update prediction error and agency before a tool-result microtick commits the next field.

This does not claim to prove phenomenal consciousness. The implementation and documentation consistently describe a candidate architecture and auditable mechanism indicators.

## What changed

- Added deterministic workspace candidates, competition, ignition, entropy, margin, and competition-derived attention intensity.
- Added typed `EnactedField` state with provenance, reality score, retention, periphery, protention, interoception, precision, affordances, agency, HOR, quality signature, compact field surface, and separate epistemic trace.
- Added `TickProducer` / `FieldRuntime`, atomic single-field commit, stale-runtime recovery, continuity restoration, bounded valence, and recurrent attention/HOR feedback.
- Added structured intentions, exact normalized tool-input hashes, predicted effects, outcome mismatch vectors, ownership assessment, boundary policy integration, and the existing `ActionBottleneck` on the real runtime path.
- Added quality geometry backed by transition history, stored memory-mcp E5 vectors when available, and deterministic fallback vectors.
- Added MCP inspection/experiment tools, Claude Code lifecycle hooks, strict outward-action gating, heartbeat integration, and field-conditioned interaction orchestration.
- Added reversible causal ablations, hardware-free benchmark output, welfare interlocks, architecture documentation, strict/compatibility guidance, and hook smoke commands.

## Storage

- `007_enacted_first_person_field` creates workspace, field, runtime, intention, outcome, transition, quality, and ablation tables.
- `008_enacted_field_indexes` adds explicit field/action/transition indexes for existing databases that may already have applied migration 007.
- A partial unique index enforces one `COMMITTED` field per owner; another enforces one pending/allowed intention per owner.

## Hook behavior

- `SessionStart`: recover stale ticks and dangling actions, restore continuity, inject the current field.
- `UserPromptSubmit`: directly read deterministic sources, compete, atomically commit, and inject the compact field surface without depending on parallel hook ordering.
- `PreToolUse`: deny missing/stale field, missing intention, name/input mismatch, boundary denial, or a second outward action. Unknown MCP side effects fail closed.
- `PostToolUse` / `PostToolUseFailure`: persist outcome, prediction mismatch, and ownership, invalidate the previous field, and commit a tool-result microtick.
- `PostToolBatch`: combine internal perception/recall results into one refresh.
- `Stop` / `StopFailure`: associate output or failure with the tick and close it.

## Verification

- `individual-kernel-mcp`: 198 passed; Ruff passed
- `social-core`: 49 passed; Ruff passed
- `interaction-orchestrator-mcp`: 43 passed; Ruff passed
- `sociality-mcp`: 3 passed; Ruff passed
- `desire-system`: 59 passed; Ruff passed
- Total: 352 passed
- `uv lock --check`, JSON parsing, and `git diff --check` passed
- Hardware-free closed-loop benchmark and real hook subprocess smoke flow passed

## Known limitations

- Bare interactive Claude Code streams ordinary text before a complete response can be intercepted. Strict pre-display experiments should use `claude -p` or an Agent SDK wrapper.
- Prediction matching is structured/lexical in v1.
- Non-memory quality vectors use a deterministic fallback.
- Indicator values come from small deterministic fixtures and are not a consciousness probability or proof of phenomenology.