### PR TITLE
fix(individual-kernel): force utf-8 stdin/stdout in efpf hook on Windows

### DIFF
--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/hook_cli.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/hook_cli.py
@@ -342,6 +342,10 @@ def _heartbeat_continuation(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def main() -> None:
+    if hasattr(sys.stdin, "reconfigure"):
+        sys.stdin.reconfigure(encoding="utf-8")
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
     parser = argparse.ArgumentParser(prog="efpf-hook")
     parser.add_argument(
         "command",


### PR DESCRIPTION
## Summary
- Windows defaults Python's stdin/stdout to a locale-dependent encoding (e.g. cp932), which cannot round-trip surrogate-pair characters like emoji.
- `_read_input()` / `_emit()` in `hook_cli.py` then hit `UnicodeEncodeError: 'utf-8' codec can't encode character '\udcXX' ... surrogates not allowed`, and the hook fails closed on every PreToolUse/UserPromptSubmit/PostToolUse check.
- Fix: reconfigure both streams to utf-8 at the start of `main()`.

## Test plan
- [x] Ran `efpf-hook user-prompt-submit` directly with an emoji-containing prompt (`🏠 test surrogate 🌸`) on Windows; previously failed with the surrogate error, now returns a normal `<current_field>` JSON payload.
- [ ] Confirm no regression on non-Windows hosts (stdin/stdout already utf-8 there, reconfigure is a no-op).