### PR TITLE
feat(individual-kernel): add the count-based generative field model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ All notable changes to embodied-claude are documented here.
 - docs: `phenomenal-architecture-current-state.md` and
   `generative-field-model-design.md`.
 
+### Fixed
+
+- individual-kernel: the mismatch-vector tokenizer now compares non-ASCII
+  runs as character bigrams, so Japanese result summaries no longer inflate
+  prediction error and deflate ownership scores. ASCII behavior is unchanged.
+
 ## [0.3.0] - 2026-07-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to embodied-claude are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- individual-kernel: generative field model (count_v1). Registering an
+  intention now persists a ProtentionDistribution (action branch plus a
+  no-action branch, probabilities summing to 1); every arrived-at field
+  records one ExperiencedTransition with component prediction errors and
+  affect deltas; the Dirichlet count model learns from each transition
+  exactly once, so the next rollout for the same context and action changes
+  measurably. Trajectories follow a strict status lifecycle
+  (imagined/intended/enacted/observed/contradicted/partially_observed) and
+  imagined records never auto-promote. Additive-only and flag-guarded via
+  `[individual-kernel]` in mcpBehavior.toml: action selection, workspace
+  competition, the field surface, and the boundary gate are unchanged.
+- individual-kernel: prediction-calibration metrics (Brier, log loss, ECE,
+  top-1, per-component MAE) with persistence/uniform baselines and a
+  reliability floor; `IndicatorProfile.prediction_calibration` upgrades to
+  1-Brier when enough resolutions exist. The phenomenal-candidate benchmark
+  now also writes `prediction-calibration.{json,md}` and `run.py` gains
+  `--check`.
+- individual-kernel: MCP tools `rollout_protention`,
+  `query_imagined_trajectories`, `query_experienced_transitions`, and
+  `get_generative_model_calibration`.
+- social-core: migration `009_generative_field_model`
+  (protention_distributions, imagined_trajectories, experienced_transitions,
+  generative_transition_stats, prediction_resolutions).
+- docs: `phenomenal-architecture-current-state.md` and
+  `generative-field-model-design.md`.
+
 ## [0.3.0] - 2026-07-24
 
 ### Added

--- a/benchmarks/phenomenal_candidate/run.py
+++ b/benchmarks/phenomenal_candidate/run.py
@@ -18,11 +18,25 @@ def main() -> None:
         default=Path(__file__).parent / "latest",
     )
     parser.add_argument("--db-path", type=Path)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit non-zero unless every mandated report file was written",
+    )
     args = parser.parse_args()
     db_path = args.db_path or Path(tempfile.mkdtemp(prefix="efpf-benchmark-")) / "field.db"
     result = run_candidate_benchmark(output_dir=args.output_dir, db_path=db_path)
     print(args.output_dir / "indicator-profile.json")
+    print(args.output_dir / "prediction-calibration.json")
     print(result["profile"]["profile_name"])
+    if args.check:
+        missing = [
+            name
+            for name in ("indicator-profile.md", "prediction-calibration.md")
+            if not (args.output_dir / name).is_file()
+        ]
+        if missing:
+            raise SystemExit(f"missing benchmark reports: {', '.join(missing)}")
 
 
 if __name__ == "__main__":

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/_behavior.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/_behavior.py
@@ -1,0 +1,44 @@
+"""Behavior configuration loader -- reads mcpBehavior.toml at project root.
+
+This package sits one level deeper than the other MCP packages
+(consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp),
+so the repo root is parents[5] instead of parents[3].
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef,unused-ignore]
+
+_TOML_PATH = Path(
+    os.getenv("MCP_BEHAVIOR_TOML", "")
+    or str(Path(__file__).resolve().parents[5] / "mcpBehavior.toml")
+)
+
+
+def load_behavior(section: str) -> dict[str, Any]:
+    """Load a section from mcpBehavior.toml.
+
+    Returns empty dict if file doesn't exist or section is missing.
+    Reads the file on every call (no caching) so changes are picked up immediately.
+    """
+    toml_path = Path(os.getenv("MCP_BEHAVIOR_TOML", "") or str(_TOML_PATH))
+    if not toml_path.is_file():
+        return {}
+    try:
+        with toml_path.open("rb") as f:
+            data = tomllib.load(f)
+        return dict(data.get(section, {}))
+    except Exception:
+        return {}
+
+
+def get_behavior(section: str, key: str, default: Any = None) -> Any:
+    """Get a single value from mcpBehavior.toml."""
+    return load_behavior(section).get(key, default)

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/ablation.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/ablation.py
@@ -52,6 +52,7 @@ class IndicatorProfile(BaseModel):
     report_independence: float = Field(ge=0.0, le=1.0)
     unity_violations: int = Field(ge=0)
     prediction_calibration: float = Field(ge=0.0, le=1.0)
+    prediction_calibration_detail: dict[str, Any] = Field(default_factory=dict)
     uncertainty_notes: list[str] = Field(default_factory=list)
 
 
@@ -245,6 +246,24 @@ class AblationRunner:
             """,
             (owner_id, limit),
         )
+        legacy_binary = _clamp01(
+            _mean([float(row["prediction_match"]) for row in transition_rows])
+        )
+        calibration_detail: dict[str, Any] = {
+            "source": "legacy_binary",
+            "legacy_binary": legacy_binary,
+        }
+        prediction_calibration = legacy_binary
+        try:
+            from individual_kernel_mcp.calibration import CalibrationScorer
+
+            detail = CalibrationScorer(self._db).detail(owner_id=owner_id, window=limit)
+            calibration_detail.update(detail)
+            if detail.get("reliable"):
+                prediction_calibration = _clamp01(1.0 - float(detail["brier"]))
+                calibration_detail["source"] = "generative"
+        except Exception:
+            calibration_detail["source"] = "legacy_binary_fallback"
         return IndicatorProfile(
             causal_centrality=_clamp01(causal),
             recurrent_closure=_clamp01(recurrent),
@@ -254,9 +273,8 @@ class AblationRunner:
             qualitative_transition_structure=_clamp01(qualitative),
             report_independence=_clamp01(report_independence),
             unity_violations=max(0, active - 1),
-            prediction_calibration=_clamp01(
-                _mean([float(row["prediction_match"]) for row in transition_rows])
-            ),
+            prediction_calibration=prediction_calibration,
+            prediction_calibration_detail=calibration_detail,
             uncertainty_notes=[
                 "Indicators measure implemented causal organization, not phenomenology.",
                 "Small fixture counts make effect sizes provisional.",

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/agency.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/agency.py
@@ -718,7 +718,24 @@ def _git_is_read_only(arguments: list[str]) -> bool:
 
 
 def _tokens(text: str) -> set[str]:
-    return {token for token in re.findall(r"[\w-]+", text.lower()) if len(token) > 2}
+    """Tokenize for mismatch overlap; ASCII words plus non-ASCII bigrams.
+
+    Whole-word matching collapses Japanese summaries into one giant token, so
+    non-ASCII runs are compared as character bigrams instead. ASCII behavior
+    is unchanged.
+    """
+    lowered = text.lower()
+    tokens = {
+        token
+        for token in re.findall(r"[a-z0-9_-]+", lowered)
+        if len(token) > 2
+    }
+    for run in re.findall(r"[^\x00-\x7f]+", lowered):
+        if len(run) == 1:
+            tokens.add(run)
+        else:
+            tokens.update(run[i : i + 2] for i in range(len(run) - 1))
+    return tokens
 
 
 def _temporal_contiguity(

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/benchmark.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/benchmark.py
@@ -158,6 +158,9 @@ def run_candidate_benchmark(
             for kind in ("focal_clamp", "hor_feedback", "reality", "valence")
         }
         profile = runner.indicator_profile(window=50)
+        from individual_kernel_mcp.calibration import CalibrationScorer
+
+        calibration = CalibrationScorer(db).report(window=200)
         result = {
             "benchmark": "phenomenal_candidate_v1",
             "generated_at": utc_now(),
@@ -184,6 +187,7 @@ def run_candidate_benchmark(
                 kind: item.effect_size for kind, item in ablations.items()
             },
             "profile": profile.model_dump(mode="json"),
+            "calibration": calibration.model_dump(mode="json"),
         }
         (target / "indicator-profile.json").write_text(
             json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
@@ -191,6 +195,17 @@ def run_candidate_benchmark(
         )
         (target / "indicator-profile.md").write_text(
             _render_markdown(result),
+            encoding="utf-8",
+        )
+        (target / "prediction-calibration.json").write_text(
+            json.dumps(
+                result["calibration"], ensure_ascii=False, indent=2, sort_keys=True
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (target / "prediction-calibration.md").write_text(
+            _render_calibration_markdown(result),
             encoding="utf-8",
         )
         return result
@@ -230,4 +245,33 @@ def _render_markdown(result: dict[str, Any]) -> str:
         lines.append(f"- `{kind}`: `{json.dumps(effect, sort_keys=True)}`")
     lines.extend(["", "## Uncertainty", ""])
     lines.extend(f"- {note}" for note in profile["uncertainty_notes"])
+    return "\n".join(lines) + "\n"
+
+
+def _render_calibration_markdown(result: dict[str, Any]) -> str:
+    calibration = result["calibration"]
+    lines = [
+        "# Prediction Calibration",
+        "",
+        result["claim_policy"],
+        "",
+        f"- n_resolved: `{calibration['n_resolved']}`",
+        f"- reliable: `{calibration['reliable']}`",
+        f"- brier: `{calibration['brier']:.4f}`",
+        f"- log_loss: `{calibration['log_loss']:.4f}`",
+        f"- ece: `{calibration['ece']:.4f}`",
+        f"- top_1: `{calibration['top_1']:.4f}`",
+        (
+            "- baseline_persistence_brier: "
+            f"`{calibration['baseline_persistence_brier']:.4f}`"
+        ),
+        f"- baseline_uniform_brier: `{calibration['baseline_uniform_brier']:.4f}`",
+        "",
+        "## Per-Component Mean Absolute Error",
+        "",
+    ]
+    for key, value in sorted(calibration["per_component_mae"].items()):
+        lines.append(f"- {key}: `{value:.4f}`")
+    lines.extend(["", "## Uncertainty", ""])
+    lines.extend(f"- {note}" for note in calibration["uncertainty_notes"])
     return "\n".join(lines) + "\n"

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/calibration.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/calibration.py
@@ -1,0 +1,231 @@
+"""Prediction-calibration metrics over stored trajectory predictions.
+
+Pure scoring functions (no database) plus a `CalibrationScorer` that resolves
+step-1 predictions against experienced transitions and reports Brier score,
+log loss, expected calibration error, and per-component mean absolute errors,
+always alongside persistence and uniform baselines. Numbers below the
+reliability floor are reported but flagged provisional. Deeper-step (horizon
+>= 2) resolution reuses the `prediction_resolutions` table and lands with the
+calibration batch work in a later change.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import secrets
+import sqlite3
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+from social_core.db import SocialDB
+from social_core.time import utc_now
+
+from .generative_model import parse_outcome_bucket
+
+RELIABLE_FLOOR = 20
+LOG_LOSS_EPSILON = 1e-3
+ECE_BINS = 10
+UNIFORM_BASELINE_PROBABILITY = 1.0 / 3.0
+
+_COMPONENT_KEYS = (
+    "exteroceptive",
+    "interoceptive",
+    "social",
+    "mnemonic",
+    "latency",
+    "focus_kind_error",
+    "valence_delta_error",
+)
+
+
+def brier_score(pairs: list[tuple[float, bool]]) -> float:
+    if not pairs:
+        return 0.0
+    return sum((p - (1.0 if hit else 0.0)) ** 2 for p, hit in pairs) / len(pairs)
+
+
+def log_loss(pairs: list[tuple[float, bool]], *, epsilon: float = LOG_LOSS_EPSILON) -> float:
+    if not pairs:
+        return 0.0
+    total = 0.0
+    for p, hit in pairs:
+        clipped = min(1.0 - epsilon, max(epsilon, p))
+        total += -math.log(clipped if hit else 1.0 - clipped)
+    return total / len(pairs)
+
+
+def expected_calibration_error(
+    pairs: list[tuple[float, bool]], *, bins: int = ECE_BINS
+) -> tuple[float, list[dict[str, float]]]:
+    if not pairs:
+        return 0.0, []
+    buckets: list[list[tuple[float, bool]]] = [[] for _ in range(bins)]
+    for p, hit in pairs:
+        index = min(bins - 1, int(p * bins))
+        buckets[index].append((p, hit))
+    total = len(pairs)
+    ece = 0.0
+    summaries: list[dict[str, float]] = []
+    for index, bucket in enumerate(buckets):
+        if not bucket:
+            continue
+        mean_confidence = sum(p for p, _ in bucket) / len(bucket)
+        hit_rate = sum(1.0 for _, hit in bucket if hit) / len(bucket)
+        ece += (len(bucket) / total) * abs(mean_confidence - hit_rate)
+        summaries.append(
+            {
+                "bin": float(index),
+                "mean_confidence": mean_confidence,
+                "hit_rate": hit_rate,
+                "count": float(len(bucket)),
+            }
+        )
+    return ece, summaries
+
+
+class CalibrationReport(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    n_resolved: int = Field(ge=0)
+    reliable: bool
+    brier: float = Field(ge=0.0)
+    log_loss: float = Field(ge=0.0)
+    ece: float = Field(ge=0.0)
+    bins: list[dict[str, float]] = Field(default_factory=list)
+    top_1: float = Field(ge=0.0, le=1.0)
+    per_component_mae: dict[str, float] = Field(default_factory=dict)
+    baseline_persistence_brier: float = Field(ge=0.0)
+    baseline_uniform_brier: float = Field(ge=0.0)
+    uncertainty_notes: list[str] = Field(default_factory=list)
+
+
+class CalibrationScorer:
+    def __init__(self, db: SocialDB) -> None:
+        self._db = db
+
+    def resolve_step_one(self, owner_id: str = "self") -> int:
+        """Match linked step-1 predictions to their observed transitions.
+
+        Idempotent: `prediction_resolutions` is unique per (trajectory, step).
+        """
+        rows = self._db.fetchall(
+            """
+            SELECT t.transition_id, t.outcome_bucket, t.intended_trajectory_id,
+                   t.prediction_errors_json, tr.steps_json
+            FROM experienced_transitions t
+            JOIN imagined_trajectories tr
+              ON tr.trajectory_id = t.intended_trajectory_id
+            WHERE t.owner_id = ? AND t.intended_trajectory_id IS NOT NULL
+            """,
+            (owner_id,),
+        )
+        resolved = 0
+        for row in rows:
+            steps = json.loads(row["steps_json"])
+            if not steps:
+                continue
+            predicted_bucket = str(steps[0]["outcome_bucket"])
+            hit = predicted_bucket == row["outcome_bucket"]
+            errors = json.loads(row["prediction_errors_json"])
+            component_errors = {
+                key: float(errors[key]) for key in _COMPONENT_KEYS if key in errors
+            }
+            try:
+                with self._db.transaction() as connection:
+                    connection.execute(
+                        """
+                        INSERT INTO prediction_resolutions(
+                            resolution_id, trajectory_id, step_index,
+                            transition_id, hit, component_errors_json, resolved_at
+                        ) VALUES (?, ?, 1, ?, ?, ?, ?)
+                        """,
+                        (
+                            f"res_{secrets.token_urlsafe(12)}",
+                            row["intended_trajectory_id"],
+                            row["transition_id"],
+                            1 if hit else 0,
+                            json.dumps(component_errors, sort_keys=True),
+                            utc_now(),
+                        ),
+                    )
+                resolved += 1
+            except sqlite3.IntegrityError:
+                continue
+        return resolved
+
+    def report(self, *, owner_id: str = "self", window: int = 200) -> CalibrationReport:
+        self.resolve_step_one(owner_id)
+        limit = max(1, min(int(window), 1000))
+        rows = self._db.fetchall(
+            """
+            SELECT r.hit, r.component_errors_json, tr.steps_json,
+                   t.context_signature, t.outcome_bucket
+            FROM prediction_resolutions r
+            JOIN imagined_trajectories tr ON tr.trajectory_id = r.trajectory_id
+            JOIN experienced_transitions t
+              ON t.intended_trajectory_id = r.trajectory_id
+            WHERE tr.owner_id = ? AND r.step_index = 1
+            ORDER BY r.resolved_at DESC, r.resolution_id LIMIT ?
+            """,
+            (owner_id, limit),
+        )
+        pairs: list[tuple[float, bool]] = []
+        persistence_pairs: list[tuple[float, bool]] = []
+        uniform_pairs: list[tuple[float, bool]] = []
+        component_sums: dict[str, list[float]] = {}
+        for row in rows:
+            steps = json.loads(row["steps_json"])
+            probability = float(steps[0]["conditional_probability"]) if steps else 0.0
+            hit = bool(row["hit"])
+            pairs.append((probability, hit))
+            uniform_pairs.append((UNIFORM_BASELINE_PROBABILITY, hit))
+            previous_focus = row["context_signature"].split("|", 1)[0]
+            observed_focus = parse_outcome_bucket(row["outcome_bucket"])[
+                "next_focus_kind"
+            ]
+            persistence_pairs.append((1.0, previous_focus == observed_focus))
+            for key, value in json.loads(row["component_errors_json"]).items():
+                component_sums.setdefault(key, []).append(float(value))
+
+        n_resolved = len(pairs)
+        ece, bins = expected_calibration_error(pairs)
+        reliable = n_resolved >= RELIABLE_FLOOR
+        notes = [
+            "Calibration measures the count model's stated probabilities against "
+            "observed outcome buckets; it is not a phenomenal claim.",
+        ]
+        if not reliable:
+            notes.append(
+                f"Provisional: only {n_resolved} resolved predictions "
+                f"(reliability floor is {RELIABLE_FLOOR})."
+            )
+        return CalibrationReport(
+            n_resolved=n_resolved,
+            reliable=reliable,
+            brier=brier_score(pairs),
+            log_loss=log_loss(pairs),
+            ece=ece,
+            bins=bins,
+            top_1=(
+                sum(1.0 for _, hit in pairs if hit) / n_resolved if n_resolved else 0.0
+            ),
+            per_component_mae={
+                key: sum(values) / len(values)
+                for key, values in sorted(component_sums.items())
+            },
+            baseline_persistence_brier=brier_score(persistence_pairs),
+            baseline_uniform_brier=brier_score(uniform_pairs),
+            uncertainty_notes=notes,
+        )
+
+    def detail(self, *, owner_id: str = "self", window: int = 200) -> dict[str, Any]:
+        report = self.report(owner_id=owner_id, window=window)
+        return {
+            "brier": report.brier,
+            "log_loss": report.log_loss,
+            "ece": report.ece,
+            "top_1": report.top_1,
+            "n_resolved": report.n_resolved,
+            "reliable": report.reliable,
+        }

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/experienced_transition.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/experienced_transition.py
@@ -1,0 +1,288 @@
+"""Unified experienced-transition records.
+
+One row per arrived-at field: previous state, attributed action, observed
+result, component prediction errors, and affect deltas. `next_field_id` is
+UNIQUE, so recording is idempotent; learning consumption is guarded by
+`applied_at` (see `CountBasedGenerativeFieldModel.update`).
+
+Source discipline: a transition row never carries imagined or remembered
+source modes, and `knowledge_source` is fixed to 'experienced' in this
+version (told/imagined/replayed ingestion arrives with the fork experiments;
+the schema already reserves the values).
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import sqlite3
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from social_core.db import SocialDB
+from social_core.time import utc_now
+
+from .workspace import SourceMode
+
+_ALLOWED_SOURCE_MODES = {SourceMode.LIVE, SourceMode.INFERRED, SourceMode.MIXED}
+_KNOWLEDGE_SOURCES_V1 = {"experienced"}
+
+
+class ExperiencedTransition(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    transition_id: str = Field(default_factory=lambda: f"etx_{secrets.token_urlsafe(12)}")
+    owner_id: str = "self"
+    previous_field_id: str | None = None
+    next_field_id: str
+    previous_tick_id: str | None = None
+    next_tick_id: str
+    action_ref: str | None = None
+    outcome_ref: str | None = None
+    intended_trajectory_id: str | None = None
+    distribution_id: str | None = None
+    context_signature: str
+    action_kind: str
+    outcome_bucket: str
+    observed_external: dict[str, Any] = Field(default_factory=dict)
+    observed_internal: dict[str, float] = Field(default_factory=dict)
+    observed_social: dict[str, Any] = Field(default_factory=dict)
+    prediction_errors: dict[str, float] = Field(default_factory=dict)
+    mean_prediction_error: float = Field(ge=0.0, le=1.0)
+    valence_before: float = Field(ge=-1.0, le=1.0)
+    valence_after: float = Field(ge=-1.0, le=1.0)
+    valence_change: float = Field(ge=-2.0, le=2.0)
+    arousal_before: float = Field(ge=0.0, le=1.0)
+    arousal_after: float = Field(ge=0.0, le=1.0)
+    controllability_delta: float = Field(default=0.0, ge=-1.0, le=1.0)
+    agency_confidence: float = Field(ge=0.0, le=1.0)
+    ownership_confidence: float = Field(ge=0.0, le=1.0)
+    success: bool | None = None
+    latency_ms: int | None = None
+    expected_latency_ms: int | None = None
+    source_mode: SourceMode
+    knowledge_source: str = "experienced"
+    info_content_hash: str | None = None
+    pose_before_ref: str | None = None
+    pose_after_ref: str | None = None
+    body_delta: dict[str, Any] = Field(default_factory=dict)
+    process_meta_ref: str | None = None
+    allostatic_snapshot: dict[str, Any] = Field(default_factory=dict)
+    hor_ref: str | None = None
+    fork_id: str | None = None
+    applied_at: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: str = Field(default_factory=utc_now)
+
+    @field_validator("source_mode")
+    @classmethod
+    def _reject_non_enacted_sources(cls, value: SourceMode) -> SourceMode:
+        if value not in _ALLOWED_SOURCE_MODES:
+            raise ValueError(
+                "experienced transitions require live/inferred/mixed source modes; "
+                "imagined or remembered content must not be recorded as experienced"
+            )
+        return value
+
+    @field_validator("knowledge_source")
+    @classmethod
+    def _knowledge_source_v1(cls, value: str) -> str:
+        if value not in _KNOWLEDGE_SOURCES_V1:
+            raise ValueError(
+                "knowledge_source is fixed to 'experienced' in this version"
+            )
+        return value
+
+
+class ExperiencedTransitionStore:
+    def __init__(self, db: SocialDB) -> None:
+        self._db = db
+
+    def record(
+        self, transition: ExperiencedTransition
+    ) -> tuple[ExperiencedTransition, bool]:
+        """Insert idempotently; each field is arrived-at exactly once."""
+        existing = self.get_by_next_field(transition.next_field_id)
+        if existing is not None:
+            return existing, False
+        try:
+            with self._db.transaction() as connection:
+                connection.execute(
+                    """
+                    INSERT INTO experienced_transitions(
+                        transition_id, owner_id, previous_field_id, next_field_id,
+                        previous_tick_id, next_tick_id, action_ref, outcome_ref,
+                        intended_trajectory_id, distribution_id, context_signature,
+                        action_kind, outcome_bucket, observed_external_json,
+                        observed_internal_json, observed_social_json,
+                        prediction_errors_json, mean_prediction_error,
+                        valence_before, valence_after, valence_change,
+                        arousal_before, arousal_after, controllability_delta,
+                        agency_confidence, ownership_confidence, success,
+                        latency_ms, expected_latency_ms, source_mode,
+                        knowledge_source, info_content_hash, pose_before_ref,
+                        pose_after_ref, body_delta_json, process_meta_ref,
+                        allostatic_snapshot_json, hor_ref, fork_id, applied_at,
+                        metadata_json, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                              ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                              ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        transition.transition_id,
+                        transition.owner_id,
+                        transition.previous_field_id,
+                        transition.next_field_id,
+                        transition.previous_tick_id,
+                        transition.next_tick_id,
+                        transition.action_ref,
+                        transition.outcome_ref,
+                        transition.intended_trajectory_id,
+                        transition.distribution_id,
+                        transition.context_signature,
+                        transition.action_kind,
+                        transition.outcome_bucket,
+                        json.dumps(transition.observed_external, sort_keys=True),
+                        json.dumps(transition.observed_internal, sort_keys=True),
+                        json.dumps(transition.observed_social, sort_keys=True),
+                        json.dumps(transition.prediction_errors, sort_keys=True),
+                        transition.mean_prediction_error,
+                        transition.valence_before,
+                        transition.valence_after,
+                        transition.valence_change,
+                        transition.arousal_before,
+                        transition.arousal_after,
+                        transition.controllability_delta,
+                        transition.agency_confidence,
+                        transition.ownership_confidence,
+                        None if transition.success is None else int(transition.success),
+                        transition.latency_ms,
+                        transition.expected_latency_ms,
+                        transition.source_mode.value,
+                        transition.knowledge_source,
+                        transition.info_content_hash,
+                        transition.pose_before_ref,
+                        transition.pose_after_ref,
+                        json.dumps(transition.body_delta, sort_keys=True),
+                        transition.process_meta_ref,
+                        json.dumps(transition.allostatic_snapshot, sort_keys=True),
+                        transition.hor_ref,
+                        transition.fork_id,
+                        transition.applied_at,
+                        json.dumps(transition.metadata, sort_keys=True),
+                        transition.created_at,
+                    ),
+                )
+        except sqlite3.IntegrityError:
+            existing = self.get_by_next_field(transition.next_field_id)
+            if existing is not None:
+                return existing, False
+            raise
+        return transition, True
+
+    def _row_to_transition(self, row: Any) -> ExperiencedTransition:
+        return ExperiencedTransition(
+            transition_id=row["transition_id"],
+            owner_id=row["owner_id"],
+            previous_field_id=row["previous_field_id"],
+            next_field_id=row["next_field_id"],
+            previous_tick_id=row["previous_tick_id"],
+            next_tick_id=row["next_tick_id"],
+            action_ref=row["action_ref"],
+            outcome_ref=row["outcome_ref"],
+            intended_trajectory_id=row["intended_trajectory_id"],
+            distribution_id=row["distribution_id"],
+            context_signature=row["context_signature"],
+            action_kind=row["action_kind"],
+            outcome_bucket=row["outcome_bucket"],
+            observed_external=json.loads(row["observed_external_json"]),
+            observed_internal=json.loads(row["observed_internal_json"]),
+            observed_social=json.loads(row["observed_social_json"]),
+            prediction_errors=json.loads(row["prediction_errors_json"]),
+            mean_prediction_error=row["mean_prediction_error"],
+            valence_before=row["valence_before"],
+            valence_after=row["valence_after"],
+            valence_change=row["valence_change"],
+            arousal_before=row["arousal_before"],
+            arousal_after=row["arousal_after"],
+            controllability_delta=row["controllability_delta"],
+            agency_confidence=row["agency_confidence"],
+            ownership_confidence=row["ownership_confidence"],
+            success=None if row["success"] is None else bool(row["success"]),
+            latency_ms=row["latency_ms"],
+            expected_latency_ms=row["expected_latency_ms"],
+            source_mode=SourceMode(row["source_mode"]),
+            knowledge_source=row["knowledge_source"],
+            info_content_hash=row["info_content_hash"],
+            pose_before_ref=row["pose_before_ref"],
+            pose_after_ref=row["pose_after_ref"],
+            body_delta=json.loads(row["body_delta_json"]),
+            process_meta_ref=row["process_meta_ref"],
+            allostatic_snapshot=json.loads(row["allostatic_snapshot_json"]),
+            hor_ref=row["hor_ref"],
+            fork_id=row["fork_id"],
+            applied_at=row["applied_at"],
+            metadata=json.loads(row["metadata_json"]),
+            created_at=row["created_at"],
+        )
+
+    def get(self, transition_id: str) -> ExperiencedTransition | None:
+        row = self._db.fetchone(
+            "SELECT * FROM experienced_transitions WHERE transition_id = ?",
+            (transition_id,),
+        )
+        return None if row is None else self._row_to_transition(row)
+
+    def get_by_next_field(self, next_field_id: str) -> ExperiencedTransition | None:
+        row = self._db.fetchone(
+            "SELECT * FROM experienced_transitions WHERE next_field_id = ?",
+            (next_field_id,),
+        )
+        return None if row is None else self._row_to_transition(row)
+
+    def query(
+        self,
+        *,
+        since: str | None = None,
+        action_kind: str | None = None,
+        context_signature: str | None = None,
+        owner_id: str = "self",
+        limit: int = 50,
+    ) -> list[ExperiencedTransition]:
+        clauses = ["owner_id = ?"]
+        params: list[Any] = [owner_id]
+        if since is not None:
+            clauses.append("created_at >= ?")
+            params.append(since)
+        if action_kind is not None:
+            clauses.append("action_kind = ?")
+            params.append(action_kind)
+        if context_signature is not None:
+            clauses.append("context_signature = ?")
+            params.append(context_signature)
+        params.append(max(1, min(int(limit), 200)))
+        rows = self._db.fetchall(
+            "SELECT * FROM experienced_transitions "
+            f"WHERE {' AND '.join(clauses)} "
+            "ORDER BY created_at DESC, transition_id LIMIT ?",
+            tuple(params),
+        )
+        return [self._row_to_transition(row) for row in rows]
+
+    def link_trajectory(
+        self,
+        transition_id: str,
+        *,
+        intended_trajectory_id: str | None,
+        distribution_id: str | None,
+    ) -> bool:
+        """Complete the prediction linkage exactly once (never rewrites)."""
+        with self._db.transaction() as connection:
+            cursor = connection.execute(
+                "UPDATE experienced_transitions "
+                "SET intended_trajectory_id = ?, distribution_id = ? "
+                "WHERE transition_id = ? AND intended_trajectory_id IS NULL "
+                "AND distribution_id IS NULL",
+                (intended_trajectory_id, distribution_id, transition_id),
+            )
+            return cursor.rowcount > 0

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/generative_model.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/generative_model.py
@@ -1,0 +1,605 @@
+"""Action-conditioned generative model over discretized field context.
+
+`count_v1`: Dirichlet-smoothed categorical outcome statistics per
+(context signature, action kind), with a deterministic hierarchical backoff
+instead of nearest-neighbor retrieval. No RNG anywhere; all learned state
+lives in the shared SQLite database so hook subprocesses see one model.
+
+This records and predicts functional state transitions. It makes no claim
+about phenomenal properties of the modeled process.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import TYPE_CHECKING, Any, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from social_core.db import SocialDB
+from social_core.time import utc_now
+
+from .enacted_field import EnactedField
+from .workspace import SourceMode
+
+if TYPE_CHECKING:
+    from .experienced_transition import ExperiencedTransition
+
+MODEL_VERSION = "count_v1"
+DIRICHLET_ALPHA = 0.5
+MAX_HORIZON = 5
+NO_ACTION = "no_action"
+NOVEL_BUCKET = "novel"
+
+VALENCE_DEADBAND = 0.15
+VALENCE_DELTA_DEADBAND = 0.05
+AROUSAL_LOW = 0.33
+AROUSAL_HIGH = 0.66
+LATENCY_SHORT_MS = 1000
+LATENCY_MID_MS = 10000
+
+DEFAULT_ACTION_PRIOR_BUCKETS = (
+    "ok/short/tool_result/=",
+    "fail/short/tool_result/=",
+)
+DEFAULT_NO_ACTION_PRIOR_BUCKETS = (
+    "na/na/desire/=",
+    "na/na/event/=",
+)
+
+_STATS_FEATURE_COLUMNS = (
+    "focus_kind",
+    "trigger_kind",
+    "dominant_desire",
+    "valence_bucket",
+    "arousal_bucket",
+    "action_kind",
+)
+
+
+def focus_kind_of(content_ref: str | None) -> str:
+    if not content_ref:
+        return "none"
+    if ":" in content_ref:
+        return content_ref.split(":", 1)[0]
+    return content_ref
+
+
+def dominant_desire_of(need_vector: dict[str, float]) -> str:
+    if not need_vector:
+        return ""
+    ranked = sorted(need_vector.items(), key=lambda item: (-item[1], item[0]))
+    return ranked[0][0]
+
+
+def valence_bucket_of(valence: float) -> str:
+    if valence < -VALENCE_DEADBAND:
+        return "neg"
+    if valence > VALENCE_DEADBAND:
+        return "pos"
+    return "neu"
+
+
+def arousal_bucket_of(arousal: float) -> str:
+    if arousal < AROUSAL_LOW:
+        return "low"
+    if arousal > AROUSAL_HIGH:
+        return "high"
+    return "mid"
+
+
+def latency_bucket_of(latency_ms: int | None) -> str:
+    if latency_ms is None:
+        return "na"
+    if latency_ms < LATENCY_SHORT_MS:
+        return "short"
+    if latency_ms < LATENCY_MID_MS:
+        return "mid"
+    return "long"
+
+
+def success_facet_of(success: bool | None) -> str:
+    if success is None:
+        return "na"
+    return "ok" if success else "fail"
+
+
+def valence_delta_facet_of(delta: float) -> str:
+    if delta < -VALENCE_DELTA_DEADBAND:
+        return "-"
+    if delta > VALENCE_DELTA_DEADBAND:
+        return "+"
+    return "="
+
+
+def action_kind_of(tool_name: str | None) -> str:
+    return f"tool:{tool_name}" if tool_name else NO_ACTION
+
+
+def outcome_bucket_of(
+    *,
+    success: bool | None,
+    latency_ms: int | None,
+    next_focus_kind: str,
+    valence_delta: float,
+) -> str:
+    return "/".join(
+        [
+            success_facet_of(success),
+            latency_bucket_of(latency_ms),
+            next_focus_kind,
+            valence_delta_facet_of(valence_delta),
+        ]
+    )
+
+
+def parse_outcome_bucket(bucket: str) -> dict[str, str]:
+    parts = bucket.split("/")
+    if len(parts) != 4:
+        raise ValueError(f"malformed outcome bucket: {bucket!r}")
+    return {
+        "success": parts[0],
+        "latency": parts[1],
+        "next_focus_kind": parts[2],
+        "valence_delta": parts[3],
+    }
+
+
+def _shift_valence_bucket(bucket: str, delta_facet: str) -> str:
+    order = ["neg", "neu", "pos"]
+    index = order.index(bucket) if bucket in order else 1
+    if delta_facet == "+":
+        index = min(len(order) - 1, index + 1)
+    elif delta_facet == "-":
+        index = max(0, index - 1)
+    return order[index]
+
+
+class FieldBelief(BaseModel):
+    """Compact belief-state projection of one enacted field or an imagined one."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    belief_id: str = Field(default_factory=lambda: f"blf_{secrets.token_urlsafe(12)}")
+    field_ref: str | None = None
+    source_mode: SourceMode = SourceMode.INFERRED
+    external: dict[str, Any] = Field(default_factory=dict)
+    internal: dict[str, float] = Field(default_factory=dict)
+    social: dict[str, Any] = Field(default_factory=dict)
+    self_state: dict[str, Any] = Field(default_factory=dict)
+    uncertainty: float = Field(default=0.5, ge=0.0, le=1.0)
+    precision: dict[str, float] = Field(default_factory=dict)
+    ts: str = Field(default_factory=utc_now)
+
+    @classmethod
+    def from_enacted_field(cls, field: EnactedField) -> "FieldBelief":
+        intero = field.interoception
+        need_vector = dict(intero.need_vector or {})
+        return cls(
+            field_ref=field.field_id,
+            source_mode=field.reality_mode,
+            external={
+                "focal_content_ref": field.focal_content_ref,
+                "focus_kind": focus_kind_of(field.focal_content_ref),
+                "reality_score": field.reality_score,
+                "trigger_kind": field.trigger_kind.value,
+            },
+            internal={
+                "valence": intero.valence,
+                "arousal": intero.arousal,
+                "uncertainty": intero.uncertainty,
+                "controllability": intero.controllability,
+                "dominant_need_level": max(need_vector.values(), default=0.0),
+            },
+            social={"person_id": field.person_id},
+            self_state={
+                "ownership_score": field.agency_state.ownership_score,
+                "pending_intention": field.agency_state.pending_intention_ref is not None,
+                "attention_intensity": field.attention_intensity,
+                "self_model_precision": field.precision.self_model,
+            },
+            uncertainty=intero.uncertainty,
+            precision=field.precision.model_dump(),
+        )
+
+
+class ContextSignature(BaseModel):
+    """Discretized (field, action) context; column-aligned with the stats table."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    focus_kind: str
+    trigger_kind: str
+    dominant_desire: str = ""
+    valence_bucket: str
+    arousal_bucket: str
+    action_kind: str
+
+    @classmethod
+    def from_field(cls, field: EnactedField, *, action_kind: str) -> "ContextSignature":
+        intero = field.interoception
+        return cls(
+            focus_kind=focus_kind_of(field.focal_content_ref),
+            trigger_kind=field.trigger_kind.value,
+            dominant_desire=dominant_desire_of(dict(intero.need_vector or {})),
+            valence_bucket=valence_bucket_of(intero.valence),
+            arousal_bucket=arousal_bucket_of(intero.arousal),
+            action_kind=action_kind,
+        )
+
+    @classmethod
+    def from_key(cls, key: str) -> "ContextSignature":
+        parts = key.split("|")
+        if len(parts) != 6:
+            raise ValueError(f"malformed context signature key: {key!r}")
+        return cls(
+            focus_kind=parts[0],
+            trigger_kind=parts[1],
+            dominant_desire=parts[2],
+            valence_bucket=parts[3],
+            arousal_bucket=parts[4],
+            action_kind=parts[5],
+        )
+
+    def key(self) -> str:
+        return "|".join(
+            [
+                self.focus_kind,
+                self.trigger_kind,
+                self.dominant_desire,
+                self.valence_bucket,
+                self.arousal_bucket,
+                self.action_kind,
+            ]
+        )
+
+    def backoff_chain(self) -> list[dict[str, str]]:
+        """Progressively generalized column filters, most specific first."""
+        full = {
+            "focus_kind": self.focus_kind,
+            "trigger_kind": self.trigger_kind,
+            "dominant_desire": self.dominant_desire,
+            "valence_bucket": self.valence_bucket,
+            "arousal_bucket": self.arousal_bucket,
+            "action_kind": self.action_kind,
+        }
+        level_1 = {k: v for k, v in full.items() if k != "dominant_desire"}
+        level_2 = {k: v for k, v in level_1.items() if k != "arousal_bucket"}
+        level_3 = {k: v for k, v in level_2.items() if k != "valence_bucket"}
+        level_4 = {"action_kind": self.action_kind}
+        return [full, level_1, level_2, level_3, level_4]
+
+
+class OutcomePrediction(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    bucket: str
+    probability: float = Field(ge=0.0, le=1.0)
+    uncertainty: float = Field(ge=0.0, le=1.0)
+    support: float = Field(ge=0.0)
+    basis: str
+
+
+class OutcomeForecast(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    predictions: list[OutcomePrediction]
+    novel_probability: float = Field(ge=0.0, le=1.0)
+    basis: str
+    uncertainty: float = Field(ge=0.0, le=1.0)
+    total_observations: float = Field(ge=0.0)
+
+
+class TrajectoryStep(BaseModel):
+    """One imagined step of a rollout; beliefs are always imagined-mode."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    step_index: int = Field(ge=1, le=MAX_HORIZON)
+    predicted_belief: FieldBelief
+    outcome_bucket: str
+    conditional_probability: float = Field(ge=0.0, le=1.0)
+    uncertainty: float = Field(ge=0.0, le=1.0)
+    support_observations: float = Field(ge=0.0)
+    basis: str
+
+    @field_validator("predicted_belief")
+    @classmethod
+    def _belief_must_be_imagined(cls, value: FieldBelief) -> FieldBelief:
+        if value.source_mode is not SourceMode.IMAGINED:
+            raise ValueError("predicted beliefs must carry source_mode=imagined")
+        return value
+
+
+class GenerativeFieldModel(Protocol):
+    def infer(self, field: EnactedField, *, action_kind: str = NO_ACTION) -> ContextSignature: ...
+
+    def rollout(
+        self,
+        field: EnactedField,
+        *,
+        action_kind: str,
+        horizon: int,
+        first_bucket: str | None = None,
+    ) -> list[TrajectoryStep]: ...
+
+    def update(self, transition: "ExperiencedTransition") -> bool: ...
+
+
+class CountBasedGenerativeFieldModel:
+    """Dirichlet-smoothed count model over `generative_transition_stats`."""
+
+    def __init__(
+        self,
+        db: SocialDB,
+        *,
+        owner_id: str = "self",
+        alpha: float = DIRICHLET_ALPHA,
+    ) -> None:
+        self._db = db
+        self.owner_id = owner_id
+        self.alpha = alpha
+
+    def infer(self, field: EnactedField, *, action_kind: str = NO_ACTION) -> ContextSignature:
+        return ContextSignature.from_field(field, action_kind=action_kind)
+
+    def _bucket_counts(self, filters: dict[str, str]) -> dict[str, float]:
+        clauses = ["owner_id = ?"]
+        params: list[Any] = [self.owner_id]
+        for column in _STATS_FEATURE_COLUMNS:
+            if column in filters:
+                clauses.append(f"{column} = ?")
+                params.append(filters[column])
+        rows = self._db.fetchall(
+            "SELECT outcome_bucket, SUM(observation_count) AS n "
+            "FROM generative_transition_stats "
+            f"WHERE {' AND '.join(clauses)} "
+            "GROUP BY outcome_bucket",
+            tuple(params),
+        )
+        return {
+            row["outcome_bucket"]: float(row["n"])
+            for row in rows
+            if row["n"] is not None and float(row["n"]) > 0.0
+        }
+
+    def _prior_buckets(self, action_kind: str) -> tuple[str, ...]:
+        if action_kind == NO_ACTION:
+            return DEFAULT_NO_ACTION_PRIOR_BUCKETS
+        return DEFAULT_ACTION_PRIOR_BUCKETS
+
+    def forecast(self, signature: ContextSignature) -> OutcomeForecast:
+        for level_index, filters in enumerate(signature.backoff_chain()):
+            counts = self._bucket_counts(filters)
+            total = sum(counts.values())
+            if total > 0.0:
+                basis = "count" if level_index == 0 else f"backoff:{level_index}"
+                return self._smoothed_forecast(counts, total, basis)
+        return self._prior_forecast(signature)
+
+    def _smoothed_forecast(
+        self, counts: dict[str, float], total: float, basis: str
+    ) -> OutcomeForecast:
+        k = len(counts) + 1  # +1 novel bucket
+        denominator = total + self.alpha * k
+        uncertainty = min(1.0, (self.alpha * k) / denominator)
+        ranked = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+        predictions = [
+            OutcomePrediction(
+                bucket=bucket,
+                probability=(count + self.alpha) / denominator,
+                uncertainty=uncertainty,
+                support=count,
+                basis=basis,
+            )
+            for bucket, count in ranked
+        ]
+        return OutcomeForecast(
+            predictions=predictions,
+            novel_probability=self.alpha / denominator,
+            basis=basis,
+            uncertainty=uncertainty,
+            total_observations=total,
+        )
+
+    def _prior_forecast(self, signature: ContextSignature) -> OutcomeForecast:
+        buckets = self._prior_buckets(signature.action_kind)
+        k = len(buckets) + 1
+        probability = 1.0 / k
+        predictions = [
+            OutcomePrediction(
+                bucket=bucket,
+                probability=probability,
+                uncertainty=1.0,
+                support=0.0,
+                basis="prior",
+            )
+            for bucket in buckets
+        ]
+        return OutcomeForecast(
+            predictions=predictions,
+            novel_probability=probability,
+            basis="prior",
+            uncertainty=1.0,
+            total_observations=0.0,
+        )
+
+    def probability_of(
+        self, signature: ContextSignature, outcome_bucket: str
+    ) -> tuple[float, str, float]:
+        forecast = self.forecast(signature)
+        for prediction in forecast.predictions:
+            if prediction.bucket == outcome_bucket:
+                return prediction.probability, forecast.basis, forecast.uncertainty
+        return forecast.novel_probability, forecast.basis, forecast.uncertainty
+
+    def _mean_valence_delta(self, signature: ContextSignature, bucket: str) -> float:
+        for filters in signature.backoff_chain():
+            clauses = ["owner_id = ?", "outcome_bucket = ?"]
+            params: list[Any] = [self.owner_id, bucket]
+            for column in _STATS_FEATURE_COLUMNS:
+                if column in filters:
+                    clauses.append(f"{column} = ?")
+                    params.append(filters[column])
+            row = self._db.fetchone(
+                "SELECT SUM(observation_count) AS n, SUM(sum_valence_delta) AS delta "
+                "FROM generative_transition_stats "
+                f"WHERE {' AND '.join(clauses)}",
+                tuple(params),
+            )
+            if row is not None and row["n"] and float(row["n"]) > 0.0:
+                return float(row["delta"] or 0.0) / float(row["n"])
+        facet = parse_outcome_bucket(bucket)["valence_delta"]
+        if facet == "+":
+            return 0.1
+        if facet == "-":
+            return -0.1
+        return 0.0
+
+    def _imagined_next_belief(
+        self,
+        previous: FieldBelief,
+        bucket: str,
+        mean_valence_delta: float,
+        uncertainty: float,
+    ) -> FieldBelief:
+        facets = parse_outcome_bucket(bucket)
+        internal = dict(previous.internal)
+        valence = max(-1.0, min(1.0, internal.get("valence", 0.0) + mean_valence_delta))
+        internal["valence"] = valence
+        external = dict(previous.external)
+        external["focus_kind"] = facets["next_focus_kind"]
+        external["focal_content_ref"] = None
+        return FieldBelief(
+            field_ref=None,
+            source_mode=SourceMode.IMAGINED,
+            external=external,
+            internal=internal,
+            social=dict(previous.social),
+            self_state=dict(previous.self_state),
+            uncertainty=uncertainty,
+            precision=dict(previous.precision),
+        )
+
+    def _chained_signature(
+        self, signature: ContextSignature, bucket: str
+    ) -> ContextSignature:
+        facets = parse_outcome_bucket(bucket)
+        acted = signature.action_kind != NO_ACTION
+        return ContextSignature(
+            focus_kind=facets["next_focus_kind"],
+            trigger_kind="tool_result" if acted else signature.trigger_kind,
+            dominant_desire=signature.dominant_desire,
+            valence_bucket=_shift_valence_bucket(
+                signature.valence_bucket, facets["valence_delta"]
+            ),
+            arousal_bucket=signature.arousal_bucket,
+            action_kind=NO_ACTION,
+        )
+
+    def rollout(
+        self,
+        field: EnactedField,
+        *,
+        action_kind: str,
+        horizon: int,
+        first_bucket: str | None = None,
+    ) -> list[TrajectoryStep]:
+        if not 1 <= horizon <= MAX_HORIZON:
+            raise ValueError(f"horizon must be in 1..{MAX_HORIZON}, got {horizon}")
+        signature = self.infer(field, action_kind=action_kind)
+        belief = FieldBelief.from_enacted_field(field)
+        steps: list[TrajectoryStep] = []
+        for index in range(1, horizon + 1):
+            forecast = self.forecast(signature)
+            chosen: OutcomePrediction | None = None
+            if index == 1 and first_bucket is not None:
+                chosen = next(
+                    (p for p in forecast.predictions if p.bucket == first_bucket),
+                    None,
+                )
+                if chosen is None:
+                    probability, basis, uncertainty = self.probability_of(
+                        signature, first_bucket
+                    )
+                    chosen = OutcomePrediction(
+                        bucket=first_bucket,
+                        probability=probability,
+                        uncertainty=uncertainty,
+                        support=0.0,
+                        basis=basis,
+                    )
+            if chosen is None:
+                chosen = forecast.predictions[0]
+            mean_delta = self._mean_valence_delta(signature, chosen.bucket)
+            belief = self._imagined_next_belief(
+                belief, chosen.bucket, mean_delta, chosen.uncertainty
+            )
+            steps.append(
+                TrajectoryStep(
+                    step_index=index,
+                    predicted_belief=belief,
+                    outcome_bucket=chosen.bucket,
+                    conditional_probability=chosen.probability,
+                    uncertainty=chosen.uncertainty,
+                    support_observations=chosen.support,
+                    basis=chosen.basis,
+                )
+            )
+            signature = self._chained_signature(signature, chosen.bucket)
+        return steps
+
+    def update(self, transition: "ExperiencedTransition") -> bool:
+        """Count one experienced transition into the stats, exactly once.
+
+        Returns False when the transition was already applied (idempotent
+        across processes via the `applied_at` row guard).
+        """
+        signature = ContextSignature.from_key(transition.context_signature)
+        now = utc_now()
+        with self._db.transaction() as connection:
+            cursor = connection.execute(
+                "UPDATE experienced_transitions SET applied_at = ? "
+                "WHERE transition_id = ? AND applied_at IS NULL",
+                (now, transition.transition_id),
+            )
+            if cursor.rowcount == 0:
+                return False
+            connection.execute(
+                """
+                INSERT INTO generative_transition_stats(
+                    owner_id, focus_kind, trigger_kind, dominant_desire,
+                    valence_bucket, arousal_bucket, action_kind, outcome_bucket,
+                    observation_count, sum_valence_delta, sum_latency_ms,
+                    sum_prediction_error, last_transition_id, model_version,
+                    first_observed_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(owner_id, focus_kind, trigger_kind, dominant_desire,
+                            valence_bucket, arousal_bucket, action_kind, outcome_bucket)
+                DO UPDATE SET
+                    observation_count = observation_count + 1,
+                    sum_valence_delta = sum_valence_delta + excluded.sum_valence_delta,
+                    sum_latency_ms = sum_latency_ms + excluded.sum_latency_ms,
+                    sum_prediction_error =
+                        sum_prediction_error + excluded.sum_prediction_error,
+                    last_transition_id = excluded.last_transition_id,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    transition.owner_id,
+                    signature.focus_kind,
+                    signature.trigger_kind,
+                    signature.dominant_desire,
+                    signature.valence_bucket,
+                    signature.arousal_bucket,
+                    signature.action_kind,
+                    transition.outcome_bucket,
+                    transition.valence_change,
+                    float(transition.latency_ms or 0),
+                    transition.mean_prediction_error,
+                    transition.transition_id,
+                    MODEL_VERSION,
+                    now,
+                    now,
+                ),
+            )
+        return True

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/prediction_loop.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/prediction_loop.py
@@ -1,0 +1,363 @@
+"""Coordinator for the generative prediction loop.
+
+The only module the tick runtime imports from the generative layer. It wires
+the count model, trajectory store, and experienced-transition store into four
+moments of the action cycle:
+
+- `imagine_for_intention`: at propose time, persist a ProtentionDistribution
+  (action branch + no-action branch) and mark the modal action trajectory
+  intended.
+- `mark_enacted` / `mark_denied_trajectory`: at gate time, advance or return
+  the linked trajectory. The boundary decision itself never reads this module.
+- `record_transition_and_update`: at commit time, write one
+  ExperiencedTransition (prediction errors are computed against the model
+  BEFORE it learns) and count it into the stats exactly once.
+- `reconcile_trajectories`: after the microtick commit, settle the enacted
+  trajectory into observed / partially_observed / contradicted.
+
+Everything is flag-guarded by `generative_enabled()` (mcpBehavior.toml,
+re-read per call) and returns None / no-ops when disabled.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+from social_core.db import SocialDB
+
+from ._behavior import get_behavior
+from .agency import ActionOutcome, AgencyStore, IntentionRecord
+from .enacted_field import EnactedField
+from .experienced_transition import ExperiencedTransition, ExperiencedTransitionStore
+from .generative_model import (
+    MAX_HORIZON,
+    NO_ACTION,
+    CountBasedGenerativeFieldModel,
+    action_kind_of,
+    focus_kind_of,
+    outcome_bucket_of,
+    parse_outcome_bucket,
+    valence_delta_facet_of,
+)
+from .trajectory import (
+    ImaginedTrajectory,
+    ProtentionDistribution,
+    TrajectoryStatus,
+    TrajectoryStore,
+    normalized_entropy,
+)
+from .workspace import SourceMode
+
+OBSERVED_ERROR_THRESHOLD = 0.35
+PARTIAL_ERROR_THRESHOLD = 0.70
+
+
+def generative_enabled() -> bool:
+    return bool(get_behavior("individual-kernel", "generative_field_model", True))
+
+
+def configured_horizon() -> int:
+    try:
+        value = int(get_behavior("individual-kernel", "generative_rollout_horizon", 2))
+    except (TypeError, ValueError):
+        value = 2
+    return max(1, min(value, MAX_HORIZON))
+
+
+def _combined_uncertainty(step_uncertainties: list[float]) -> float:
+    remaining_confidence = 1.0
+    for value in step_uncertainties:
+        remaining_confidence *= 1.0 - min(1.0, max(0.0, value))
+    return min(1.0, max(0.0, 1.0 - remaining_confidence))
+
+
+class FieldPredictionLoop:
+    def __init__(
+        self,
+        db: SocialDB,
+        *,
+        agency: AgencyStore | None = None,
+        owner_id: str = "self",
+    ) -> None:
+        self._db = db
+        self.owner_id = owner_id
+        self.agency = agency or AgencyStore(db)
+        self.trajectories = TrajectoryStore(db)
+        self.transitions = ExperiencedTransitionStore(db)
+        self.model = CountBasedGenerativeFieldModel(db, owner_id=owner_id)
+
+    def imagine_for_intention(
+        self, field: EnactedField, intention: IntentionRecord
+    ) -> ProtentionDistribution | None:
+        if not generative_enabled():
+            return None
+        horizon = configured_horizon()
+        action_kind = action_kind_of(intention.tool_name)
+        signature = self.model.infer(field, action_kind=action_kind)
+        forecast = self.model.forecast(signature)
+        confidence = min(max(intention.confidence, 0.05), 0.95)
+
+        top = forecast.predictions[:2]
+        top_mass = sum(p.probability for p in top)
+        distribution_id = f"prot_{secrets.token_urlsafe(12)}"
+        trajectories: list[ImaginedTrajectory] = []
+        for prediction in top:
+            steps = self.model.rollout(
+                field,
+                action_kind=action_kind,
+                horizon=horizon,
+                first_bucket=prediction.bucket,
+            )
+            trajectories.append(
+                ImaginedTrajectory(
+                    distribution_id=distribution_id,
+                    owner_id=self.owner_id,
+                    field_id=field.field_id,
+                    tick_id=field.tick_id,
+                    action_ref=intention.action_id,
+                    action_kind=action_kind,
+                    context_signature=signature.key(),
+                    horizon=horizon,
+                    steps=steps,
+                    probability=confidence * (prediction.probability / top_mass),
+                    uncertainty=_combined_uncertainty([s.uncertainty for s in steps]),
+                )
+            )
+
+        no_action_signature = self.model.infer(field, action_kind=NO_ACTION)
+        no_action_steps = self.model.rollout(
+            field, action_kind=NO_ACTION, horizon=horizon
+        )
+        trajectories.append(
+            ImaginedTrajectory(
+                distribution_id=distribution_id,
+                owner_id=self.owner_id,
+                field_id=field.field_id,
+                tick_id=field.tick_id,
+                action_ref=None,
+                action_kind=NO_ACTION,
+                context_signature=no_action_signature.key(),
+                horizon=horizon,
+                steps=no_action_steps,
+                probability=1.0 - confidence,
+                uncertainty=_combined_uncertainty(
+                    [s.uncertainty for s in no_action_steps]
+                ),
+            )
+        )
+
+        distribution = ProtentionDistribution(
+            distribution_id=distribution_id,
+            owner_id=self.owner_id,
+            field_id=field.field_id,
+            tick_id=field.tick_id,
+            action_ref=intention.action_id,
+            trajectories=trajectories,
+            entropy=normalized_entropy([t.probability for t in trajectories]),
+        )
+        self.trajectories.create_distribution(distribution)
+        self.trajectories.transition(
+            trajectories[0].trajectory_id,
+            TrajectoryStatus.INTENDED,
+            reason=f"linked to intention {intention.action_id}",
+        )
+        return distribution
+
+    def mark_enacted(self, action_id: str) -> None:
+        if not generative_enabled():
+            return
+        trajectory = self.trajectories.find_active_for_action(action_id)
+        if trajectory is not None and trajectory.status is TrajectoryStatus.INTENDED:
+            self.trajectories.transition(
+                trajectory.trajectory_id,
+                TrajectoryStatus.ENACTED,
+                reason="tool gate allowed",
+            )
+
+    def mark_denied_trajectory(self, action_id: str) -> None:
+        if not generative_enabled():
+            return
+        trajectory = self.trajectories.find_active_for_action(action_id)
+        if trajectory is not None and trajectory.status is TrajectoryStatus.INTENDED:
+            self.trajectories.transition(
+                trajectory.trajectory_id,
+                TrajectoryStatus.IMAGINED,
+                reason="boundary denied",
+            )
+
+    def record_transition_and_update(
+        self,
+        *,
+        previous: EnactedField | None,
+        committed: EnactedField,
+        action_id: str | None,
+    ) -> ExperiencedTransition | None:
+        if not generative_enabled():
+            return None
+        if previous is None:
+            return None
+
+        intention = self.agency.get(action_id) if action_id else None
+        outcome: ActionOutcome | None = (
+            self.agency.outcome_for_action(action_id) if action_id else None
+        )
+        action_kind = (
+            action_kind_of(intention.tool_name) if intention is not None else NO_ACTION
+        )
+        signature = self.model.infer(previous, action_kind=action_kind)
+
+        valence_before = previous.interoception.valence
+        valence_after = committed.interoception.valence
+        valence_delta = valence_after - valence_before
+        next_focus_kind = focus_kind_of(committed.focal_content_ref)
+        success = outcome.success if outcome is not None else None
+        latency_ms = outcome.latency_ms if outcome is not None else None
+        bucket = outcome_bucket_of(
+            success=success,
+            latency_ms=latency_ms,
+            next_focus_kind=next_focus_kind,
+            valence_delta=valence_delta,
+        )
+        probability_of_observed, _, _ = self.model.probability_of(signature, bucket)
+
+        trajectory = (
+            self.trajectories.find_active_for_action(action_id) if action_id else None
+        )
+        if trajectory is not None and trajectory.status is TrajectoryStatus.INTENDED:
+            # Still INTENDED at commit time means the gate never allowed it
+            # (an allowed action would be ENACTED here), so the imagined
+            # branch was never executed.
+            trajectory = self.trajectories.transition(
+                trajectory.trajectory_id,
+                TrajectoryStatus.IMAGINED,
+                reason="intention expired without execution",
+            )
+
+        errors: dict[str, float] = {}
+        if outcome is not None:
+            for channel, value in outcome.mismatch_vector.items():
+                errors[channel] = min(1.0, max(0.0, float(value)))
+        if trajectory is not None and trajectory.steps:
+            predicted = parse_outcome_bucket(trajectory.steps[0].outcome_bucket)
+            errors["focus_kind_error"] = (
+                0.0 if predicted["next_focus_kind"] == next_focus_kind else 1.0
+            )
+            errors["valence_delta_error"] = (
+                0.0
+                if predicted["valence_delta"] == valence_delta_facet_of(valence_delta)
+                else 1.0
+            )
+        mean_error = (
+            sum(errors.values()) / len(errors)
+            if errors
+            else min(1.0, max(0.0, 1.0 - probability_of_observed))
+        )
+        errors["probability_of_observed"] = probability_of_observed
+
+        if committed.reality_mode is SourceMode.LIVE:
+            source_mode = SourceMode.LIVE
+        elif committed.reality_mode is SourceMode.MIXED:
+            source_mode = SourceMode.MIXED
+        else:
+            source_mode = SourceMode.INFERRED
+
+        transition = ExperiencedTransition(
+            owner_id=committed.owner_id,
+            previous_field_id=previous.field_id,
+            next_field_id=committed.field_id,
+            previous_tick_id=previous.tick_id,
+            next_tick_id=committed.tick_id,
+            action_ref=action_id,
+            outcome_ref=outcome.outcome_id if outcome is not None else None,
+            intended_trajectory_id=(
+                trajectory.trajectory_id
+                if trajectory is not None
+                and trajectory.status
+                in {TrajectoryStatus.INTENDED, TrajectoryStatus.ENACTED}
+                else None
+            ),
+            distribution_id=(
+                trajectory.distribution_id if trajectory is not None else None
+            ),
+            context_signature=signature.key(),
+            action_kind=action_kind,
+            outcome_bucket=bucket,
+            observed_external={
+                "focal_content_ref": committed.focal_content_ref,
+                "focus_kind": next_focus_kind,
+                "trigger_kind": committed.trigger_kind.value,
+                "reality_score": committed.reality_score,
+            },
+            observed_internal={
+                "valence": valence_after,
+                "arousal": committed.interoception.arousal,
+                "uncertainty": committed.interoception.uncertainty,
+                "controllability": committed.interoception.controllability,
+            },
+            observed_social={"person_id": committed.person_id},
+            prediction_errors=errors,
+            mean_prediction_error=min(1.0, max(0.0, mean_error)),
+            valence_before=valence_before,
+            valence_after=valence_after,
+            valence_change=valence_delta,
+            arousal_before=previous.interoception.arousal,
+            arousal_after=committed.interoception.arousal,
+            agency_confidence=(
+                min(
+                    1.0,
+                    max(
+                        0.0,
+                        1.0
+                        - (
+                            sum(outcome.mismatch_vector.values())
+                            / len(outcome.mismatch_vector)
+                        ),
+                    ),
+                )
+                if outcome is not None and outcome.mismatch_vector
+                else 0.5
+            ),
+            ownership_confidence=(
+                outcome.ownership_score
+                if outcome is not None
+                else previous.agency_state.ownership_score
+            ),
+            success=success,
+            latency_ms=latency_ms,
+            expected_latency_ms=(
+                intention.expected_latency_ms if intention is not None else None
+            ),
+            source_mode=source_mode,
+        )
+        stored, created = self.transitions.record(transition)
+        if created:
+            self.model.update(stored)
+        return stored
+
+    def reconcile_trajectories(self, *, action_id: str, next_field_id: str) -> None:
+        if not generative_enabled():
+            return
+        trajectory = self.trajectories.find_active_for_action(action_id)
+        if trajectory is None or trajectory.status is not TrajectoryStatus.ENACTED:
+            return
+        transition = self.transitions.get_by_next_field(next_field_id)
+        if transition is None:
+            return
+        error = transition.mean_prediction_error
+        predicted_success = parse_outcome_bucket(trajectory.steps[0].outcome_bucket)[
+            "success"
+        ]
+        actual_success = parse_outcome_bucket(transition.outcome_bucket)["success"]
+        if actual_success == "fail" and predicted_success != "fail":
+            target = TrajectoryStatus.CONTRADICTED
+        elif error < OBSERVED_ERROR_THRESHOLD:
+            target = TrajectoryStatus.OBSERVED
+        elif error <= PARTIAL_ERROR_THRESHOLD:
+            target = TrajectoryStatus.PARTIALLY_OBSERVED
+        else:
+            target = TrajectoryStatus.CONTRADICTED
+        self.trajectories.transition(
+            trajectory.trajectory_id,
+            target,
+            reason=f"mean prediction error {error:.3f}",
+        )

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/server.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/server.py
@@ -51,6 +51,7 @@ from individual_kernel_mcp.attention_schema import (
     Modality,
 )
 from individual_kernel_mcp.boundary_adapter import BoundaryPolicyAdapter
+from individual_kernel_mcp.calibration import CalibrationScorer
 from individual_kernel_mcp.counterfactual import (
     CounterfactualInput,
     CounterfactualSource,
@@ -65,6 +66,7 @@ from individual_kernel_mcp.frame import (
     ConsciousFrameInput,
     TickFrameStore,
 )
+from individual_kernel_mcp.generative_model import action_kind_of
 from individual_kernel_mcp.hor import (
     AssertedMode,
     HORInput,
@@ -72,6 +74,7 @@ from individual_kernel_mcp.hor import (
     TargetKind,
 )
 from individual_kernel_mcp.introspect import introspect
+from individual_kernel_mcp.prediction_loop import FieldPredictionLoop
 from individual_kernel_mcp.quality_geometry import QualityGeometry
 from individual_kernel_mcp.reflect import reflect_attention_schema
 from individual_kernel_mcp.sleep import SleepConsolidator
@@ -113,6 +116,7 @@ def _stores() -> IndividualKernelStores:
     enacted_fields = EnactedFieldStore(db)
     agency = AgencyStore(db)
     quality = QualityGeometry(db)
+    prediction = FieldPredictionLoop(db, agency=agency)
     tick_producer = TickProducer(
         db,
         workspace=workspace,
@@ -122,6 +126,7 @@ def _stores() -> IndividualKernelStores:
         hors=hor_store,
         agency=agency,
         quality=quality,
+        prediction=prediction,
     )
     field_runtime = FieldRuntime(
         db,
@@ -151,6 +156,91 @@ def reset_store_cache() -> None:
     if _stores.cache_info().currsize:
         _stores().db.close()
         _stores.cache_clear()
+
+
+# -----------------------------------------------------------------------------
+# Generative field model surface
+# -----------------------------------------------------------------------------
+
+
+@mcp.tool()
+def rollout_protention(
+    tool_name: str | None = None,
+    horizon: int = 2,
+    owner_id: str = "self",
+) -> dict[str, Any]:
+    """Roll the count-based transition model forward from the committed field.
+
+    Returns action-conditioned outcome predictions with probabilities and
+    per-step uncertainty. Read-only: nothing is persisted.
+    """
+    stores = _stores()
+    field = stores.enacted_fields.get_current(owner_id)
+    if field is None:
+        return {"error": "no committed field for owner"}
+    action_kind = action_kind_of(tool_name)
+    model = stores.tick_producer.prediction.model
+    signature = model.infer(field, action_kind=action_kind)
+    forecast = model.forecast(signature)
+    steps = model.rollout(field, action_kind=action_kind, horizon=horizon)
+    return {
+        "field_id": field.field_id,
+        "action_kind": action_kind,
+        "context_signature": signature.key(),
+        "forecast": forecast.model_dump(mode="json"),
+        "steps": [step.model_dump(mode="json") for step in steps],
+    }
+
+
+@mcp.tool()
+def query_imagined_trajectories(
+    field_id: str | None = None,
+    action_ref: str | None = None,
+    status: str | None = None,
+    owner_id: str = "self",
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    """List persisted imagined trajectories, newest first."""
+    stores = _stores()
+    rows = stores.tick_producer.prediction.trajectories.query(
+        field_id=field_id,
+        action_ref=action_ref,
+        status=status,
+        owner_id=owner_id,
+        limit=limit,
+    )
+    return [row.model_dump(mode="json") for row in rows]
+
+
+@mcp.tool()
+def query_experienced_transitions(
+    since: str | None = None,
+    action_kind: str | None = None,
+    context_signature: str | None = None,
+    owner_id: str = "self",
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    """List experienced transitions, newest first."""
+    stores = _stores()
+    rows = stores.tick_producer.prediction.transitions.query(
+        since=since,
+        action_kind=action_kind,
+        context_signature=context_signature,
+        owner_id=owner_id,
+        limit=limit,
+    )
+    return [row.model_dump(mode="json") for row in rows]
+
+
+@mcp.tool()
+def get_generative_model_calibration(
+    owner_id: str = "self",
+    window: int = 200,
+) -> dict[str, Any]:
+    """Score stored predictions against observed outcomes (Brier, log loss, ECE)."""
+    stores = _stores()
+    report = CalibrationScorer(stores.db).report(owner_id=owner_id, window=window)
+    return report.model_dump(mode="json")
 
 
 # -----------------------------------------------------------------------------

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/tick.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/tick.py
@@ -44,6 +44,7 @@ from individual_kernel_mcp.enacted_field import (
 )
 from individual_kernel_mcp.frame import ConsciousFrameInput, TickFrameStore
 from individual_kernel_mcp.hor import HORInput, HORRecord, HORStore
+from individual_kernel_mcp.prediction_loop import FieldPredictionLoop, generative_enabled
 from individual_kernel_mcp.quality_geometry import QualityGeometry, QualitySignature
 from individual_kernel_mcp.workspace import (
     CandidateKind,
@@ -120,6 +121,7 @@ class TickProducer:
         hors: HORStore | None = None,
         agency: AgencyStore | None = None,
         quality: QualityGeometry | None = None,
+        prediction: FieldPredictionLoop | None = None,
         interoception_path: str | Path | None = None,
         desires_path: str | Path | None = None,
     ) -> None:
@@ -131,6 +133,7 @@ class TickProducer:
         self.hors = hors or HORStore(db)
         self.agency = agency or AgencyStore(db)
         self.quality = quality or QualityGeometry(db)
+        self.prediction = prediction or FieldPredictionLoop(db, agency=self.agency)
         self.events = EventStore(db=db)
         self.interoception_path = (
             Path(interoception_path)
@@ -539,18 +542,30 @@ class TickProducer:
                 }
             )
             final = self.fields.update(final)
+            transition_action_id = self._transition_action_id(previous)
             self.quality.record_transition(
                 owner_id=final.owner_id,
                 from_field_id=previous.field_id if previous else None,
                 to_field_id=final.field_id,
                 from_content_ref=previous.focal_content_ref if previous else None,
                 to_content_ref=final.focal_content_ref,
-                action_id=self._transition_action_id(previous),
+                action_id=transition_action_id,
                 continuity_score=self._continuity_score(previous, final),
                 prediction_match=self._prediction_match(previous, final),
                 temporal_order=self._next_temporal_order(final.owner_id),
                 metadata={"trigger": final.trigger_kind.value},
             )
+            if generative_enabled():
+                try:
+                    self.prediction.record_transition_and_update(
+                        previous=previous,
+                        committed=final,
+                        action_id=transition_action_id,
+                    )
+                except Exception:
+                    # A prediction-layer fault must never abort a field commit
+                    # (same tolerance as the memory HTTP ingest).
+                    pass
         return TickCommit(
             field=final,
             competition=result,
@@ -1117,6 +1132,17 @@ class FieldRuntime:
         intention = self.agency.propose(proposal, owner_id=owner_id)
         field = self.fields.get(intention.field_id)
         if field is not None:
+            if generative_enabled():
+                try:
+                    distribution = self.producer.prediction.imagine_for_intention(
+                        field, intention
+                    )
+                except Exception:
+                    distribution = None
+                if distribution is not None:
+                    trace = dict(field.epistemic_trace)
+                    trace["protention_distribution_ref"] = distribution.distribution_id
+                    field = field.model_copy(update={"epistemic_trace": trace})
             self.fields.update(field)
         return intention
 
@@ -1189,6 +1215,13 @@ class FieldRuntime:
             )
             if not allowed:
                 self.agency.mark_denied(intention.action_id)
+                if generative_enabled():
+                    try:
+                        self.producer.prediction.mark_denied_trajectory(
+                            intention.action_id
+                        )
+                    except Exception:
+                        pass
                 return ToolGateDecision(
                     allow=False,
                     reason=f"boundary policy denied action: {boundary_reason}",
@@ -1212,6 +1245,11 @@ class FieldRuntime:
                 deferred=True,
             )
         self.agency.mark_allowed(intention.action_id)
+        if generative_enabled():
+            try:
+                self.producer.prediction.mark_enacted(intention.action_id)
+            except Exception:
+                pass
         return ToolGateDecision(
             allow=True,
             reason="field, intention, input hash, boundary, and bottleneck checks passed",
@@ -1292,6 +1330,14 @@ class FieldRuntime:
             source=CandidateSource.TOOL_RESULT,
         )
         commit = self.producer.compete_and_commit(micro.tick_id)
+        if outcome is not None and generative_enabled():
+            try:
+                self.producer.prediction.reconcile_trajectories(
+                    action_id=outcome.action_id,
+                    next_field_id=commit.field.field_id,
+                )
+            except Exception:
+                pass
         return outcome, assessment, commit.field
 
     def close_action(
@@ -1348,6 +1394,14 @@ class FieldRuntime:
             source=CandidateSource.TOOL_RESULT,
         )
         commit = self.producer.compete_and_commit(micro.tick_id)
+        if generative_enabled():
+            try:
+                self.producer.prediction.reconcile_trajectories(
+                    action_id=action_id,
+                    next_field_id=commit.field.field_id,
+                )
+            except Exception:
+                pass
         return outcome, assessment, commit.field
 
 

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/trajectory.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/trajectory.py
@@ -1,0 +1,312 @@
+"""Imagined trajectories and protention distributions.
+
+A trajectory is a persisted rollout of the generative model. Its status
+lifecycle is the only mutable part; probabilities and steps are immutable
+after insert. Imagined records never auto-promote to enacted: every legal
+transition is explicit and audited in `status_history`.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import secrets
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from social_core.db import SocialDB
+from social_core.time import utc_now
+
+from .generative_model import MAX_HORIZON, MODEL_VERSION, TrajectoryStep
+from .workspace import SourceMode
+
+PROBABILITY_TOLERANCE = 1e-6
+
+
+class TrajectoryStatus(StrEnum):
+    IMAGINED = "imagined"
+    INTENDED = "intended"
+    ENACTED = "enacted"
+    OBSERVED = "observed"
+    CONTRADICTED = "contradicted"
+    PARTIALLY_OBSERVED = "partially_observed"
+    EXPIRED = "expired"
+
+
+_LEGAL_TRANSITIONS: dict[TrajectoryStatus, set[TrajectoryStatus]] = {
+    TrajectoryStatus.IMAGINED: {TrajectoryStatus.INTENDED, TrajectoryStatus.EXPIRED},
+    TrajectoryStatus.INTENDED: {TrajectoryStatus.ENACTED, TrajectoryStatus.IMAGINED},
+    TrajectoryStatus.ENACTED: {
+        TrajectoryStatus.OBSERVED,
+        TrajectoryStatus.CONTRADICTED,
+        TrajectoryStatus.PARTIALLY_OBSERVED,
+    },
+    TrajectoryStatus.OBSERVED: set(),
+    TrajectoryStatus.CONTRADICTED: set(),
+    TrajectoryStatus.PARTIALLY_OBSERVED: set(),
+    TrajectoryStatus.EXPIRED: set(),
+}
+
+
+def normalized_entropy(probabilities: list[float]) -> float:
+    """Shannon entropy normalized to [0, 1] over the positive entries."""
+    values = [p for p in probabilities if p > 0.0]
+    if len(values) <= 1:
+        return 0.0
+    entropy = -sum(p * math.log(p) for p in values)
+    return min(1.0, entropy / math.log(len(values)))
+
+
+class ImaginedTrajectory(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    trajectory_id: str = Field(default_factory=lambda: f"traj_{secrets.token_urlsafe(12)}")
+    distribution_id: str
+    owner_id: str = "self"
+    field_id: str
+    tick_id: str
+    action_ref: str | None = None
+    action_kind: str
+    context_signature: str
+    horizon: int = Field(ge=1, le=MAX_HORIZON)
+    steps: list[TrajectoryStep] = Field(min_length=1)
+    probability: float = Field(ge=0.0, le=1.0)
+    uncertainty: float = Field(ge=0.0, le=1.0)
+    source_mode: SourceMode = SourceMode.IMAGINED
+    status: TrajectoryStatus = TrajectoryStatus.IMAGINED
+    status_history: list[dict[str, str]] = Field(default_factory=list)
+    expires_at: str | None = None
+    fork_id: str | None = None
+    created_at: str = Field(default_factory=utc_now)
+    updated_at: str = Field(default_factory=utc_now)
+
+    @field_validator("source_mode")
+    @classmethod
+    def _imagined_only(cls, value: SourceMode) -> SourceMode:
+        if value is not SourceMode.IMAGINED:
+            raise ValueError("trajectories are imagined records; source_mode must be imagined")
+        return value
+
+    @model_validator(mode="after")
+    def _steps_match_horizon(self) -> "ImaginedTrajectory":
+        if len(self.steps) != self.horizon:
+            raise ValueError(
+                f"trajectory has {len(self.steps)} steps but horizon {self.horizon}"
+            )
+        return self
+
+
+class ProtentionDistribution(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    distribution_id: str = Field(default_factory=lambda: f"prot_{secrets.token_urlsafe(12)}")
+    owner_id: str = "self"
+    field_id: str
+    tick_id: str
+    action_ref: str | None = None
+    trajectories: list[ImaginedTrajectory] = Field(min_length=1)
+    entropy: float = Field(ge=0.0, le=1.0)
+    model_version: str = MODEL_VERSION
+    fork_id: str | None = None
+    created_at: str = Field(default_factory=utc_now)
+
+    @model_validator(mode="after")
+    def _probabilities_sum_to_one(self) -> "ProtentionDistribution":
+        total = sum(t.probability for t in self.trajectories)
+        if abs(total - 1.0) > PROBABILITY_TOLERANCE:
+            raise ValueError(f"trajectory probabilities sum to {total}, expected 1.0")
+        return self
+
+
+class TrajectoryStore:
+    """Persistence for distributions and the only legal status mutator."""
+
+    def __init__(self, db: SocialDB) -> None:
+        self._db = db
+
+    def create_distribution(
+        self, distribution: ProtentionDistribution
+    ) -> ProtentionDistribution:
+        with self._db.transaction() as connection:
+            connection.execute(
+                """
+                INSERT INTO protention_distributions(
+                    distribution_id, owner_id, field_id, tick_id, action_ref,
+                    entropy, model_version, trajectory_count, fork_id, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    distribution.distribution_id,
+                    distribution.owner_id,
+                    distribution.field_id,
+                    distribution.tick_id,
+                    distribution.action_ref,
+                    distribution.entropy,
+                    distribution.model_version,
+                    len(distribution.trajectories),
+                    distribution.fork_id,
+                    distribution.created_at,
+                ),
+            )
+            for trajectory in distribution.trajectories:
+                connection.execute(
+                    """
+                    INSERT INTO imagined_trajectories(
+                        trajectory_id, distribution_id, owner_id, field_id, tick_id,
+                        action_ref, action_kind, context_signature, horizon,
+                        steps_json, probability, uncertainty, source_mode, status,
+                        status_history_json, expires_at, fork_id, created_at,
+                        updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        trajectory.trajectory_id,
+                        trajectory.distribution_id,
+                        trajectory.owner_id,
+                        trajectory.field_id,
+                        trajectory.tick_id,
+                        trajectory.action_ref,
+                        trajectory.action_kind,
+                        trajectory.context_signature,
+                        trajectory.horizon,
+                        json.dumps(
+                            [step.model_dump(mode="json") for step in trajectory.steps],
+                            sort_keys=True,
+                        ),
+                        trajectory.probability,
+                        trajectory.uncertainty,
+                        trajectory.source_mode.value,
+                        trajectory.status.value,
+                        json.dumps(trajectory.status_history, sort_keys=True),
+                        trajectory.expires_at,
+                        trajectory.fork_id,
+                        trajectory.created_at,
+                        trajectory.updated_at,
+                    ),
+                )
+        return distribution
+
+    def _row_to_trajectory(self, row: Any) -> ImaginedTrajectory:
+        return ImaginedTrajectory(
+            trajectory_id=row["trajectory_id"],
+            distribution_id=row["distribution_id"],
+            owner_id=row["owner_id"],
+            field_id=row["field_id"],
+            tick_id=row["tick_id"],
+            action_ref=row["action_ref"],
+            action_kind=row["action_kind"],
+            context_signature=row["context_signature"],
+            horizon=row["horizon"],
+            steps=[
+                TrajectoryStep.model_validate(step)
+                for step in json.loads(row["steps_json"])
+            ],
+            probability=row["probability"],
+            uncertainty=row["uncertainty"],
+            source_mode=SourceMode(row["source_mode"]),
+            status=TrajectoryStatus(row["status"]),
+            status_history=json.loads(row["status_history_json"]),
+            expires_at=row["expires_at"],
+            fork_id=row["fork_id"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+    def get_trajectory(self, trajectory_id: str) -> ImaginedTrajectory | None:
+        row = self._db.fetchone(
+            "SELECT * FROM imagined_trajectories WHERE trajectory_id = ?",
+            (trajectory_id,),
+        )
+        return None if row is None else self._row_to_trajectory(row)
+
+    def get_distribution(self, distribution_id: str) -> ProtentionDistribution | None:
+        row = self._db.fetchone(
+            "SELECT * FROM protention_distributions WHERE distribution_id = ?",
+            (distribution_id,),
+        )
+        if row is None:
+            return None
+        trajectory_rows = self._db.fetchall(
+            "SELECT * FROM imagined_trajectories WHERE distribution_id = ? "
+            "ORDER BY probability DESC, trajectory_id",
+            (distribution_id,),
+        )
+        return ProtentionDistribution(
+            distribution_id=row["distribution_id"],
+            owner_id=row["owner_id"],
+            field_id=row["field_id"],
+            tick_id=row["tick_id"],
+            action_ref=row["action_ref"],
+            trajectories=[self._row_to_trajectory(item) for item in trajectory_rows],
+            entropy=row["entropy"],
+            model_version=row["model_version"],
+            fork_id=row["fork_id"],
+            created_at=row["created_at"],
+        )
+
+    def query(
+        self,
+        *,
+        field_id: str | None = None,
+        action_ref: str | None = None,
+        status: TrajectoryStatus | str | None = None,
+        owner_id: str = "self",
+        limit: int = 50,
+    ) -> list[ImaginedTrajectory]:
+        clauses = ["owner_id = ?"]
+        params: list[Any] = [owner_id]
+        if field_id is not None:
+            clauses.append("field_id = ?")
+            params.append(field_id)
+        if action_ref is not None:
+            clauses.append("action_ref = ?")
+            params.append(action_ref)
+        if status is not None:
+            clauses.append("status = ?")
+            params.append(TrajectoryStatus(status).value)
+        params.append(max(1, min(int(limit), 200)))
+        rows = self._db.fetchall(
+            "SELECT * FROM imagined_trajectories "
+            f"WHERE {' AND '.join(clauses)} "
+            "ORDER BY created_at DESC, trajectory_id LIMIT ?",
+            tuple(params),
+        )
+        return [self._row_to_trajectory(row) for row in rows]
+
+    def find_active_for_action(self, action_ref: str) -> ImaginedTrajectory | None:
+        row = self._db.fetchone(
+            "SELECT * FROM imagined_trajectories "
+            "WHERE action_ref = ? AND status IN ('intended', 'enacted') "
+            "ORDER BY created_at DESC LIMIT 1",
+            (action_ref,),
+        )
+        return None if row is None else self._row_to_trajectory(row)
+
+    def transition(
+        self,
+        trajectory_id: str,
+        new_status: TrajectoryStatus,
+        *,
+        reason: str,
+    ) -> ImaginedTrajectory:
+        current = self.get_trajectory(trajectory_id)
+        if current is None:
+            raise ValueError(f"unknown trajectory {trajectory_id!r}")
+        target = TrajectoryStatus(new_status)
+        if target not in _LEGAL_TRANSITIONS[current.status]:
+            raise ValueError(
+                f"illegal trajectory transition {current.status.value!r} -> "
+                f"{target.value!r}"
+            )
+        now = utc_now()
+        history = [*current.status_history, {"status": target.value, "ts": now, "reason": reason}]
+        self._db.execute(
+            "UPDATE imagined_trajectories "
+            "SET status = ?, status_history_json = ?, updated_at = ? "
+            "WHERE trajectory_id = ?",
+            (target.value, json.dumps(history, sort_keys=True), now, trajectory_id),
+        )
+        refreshed = self.get_trajectory(trajectory_id)
+        assert refreshed is not None
+        return refreshed

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_agency_tokens_cjk.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_agency_tokens_cjk.py
@@ -1,0 +1,34 @@
+"""Mismatch tokenization handles non-ASCII summaries via character bigrams."""
+
+from __future__ import annotations
+
+from individual_kernel_mcp.agency import _tokens
+
+
+class TestTokenizerCjk:
+    def test_ascii_behavior_unchanged(self) -> None:
+        assert _tokens("Camera moved left as predicted") == {
+            "camera",
+            "moved",
+            "left",
+            "predicted",
+        }
+
+    def test_japanese_identical_summaries_fully_overlap(self) -> None:
+        expected = _tokens("カメラが左に動いた")
+        actual = _tokens("カメラが左に動いた")
+        assert expected
+        assert len(expected & actual) / len(expected) == 1.0
+
+    def test_japanese_related_summaries_share_tokens(self) -> None:
+        expected = _tokens("カメラが左に動いた")
+        actual = _tokens(
+            "カメラが左に動いて視界が変わった"
+        )
+        overlap = len(expected & actual) / len(expected)
+        assert overlap > 0.5
+
+    def test_mixed_text_keeps_both_kinds_of_tokens(self) -> None:
+        tokens = _tokens("cameraを左へ")
+        assert "camera" in tokens
+        assert "を左" in tokens

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_benchmark_reports.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_benchmark_reports.py
@@ -1,0 +1,80 @@
+"""Benchmark emits both mandated reports with disciplined vocabulary."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from individual_kernel_mcp.benchmark import run_candidate_benchmark
+from individual_kernel_mcp.calibration import (
+    brier_score,
+    expected_calibration_error,
+    log_loss,
+)
+
+_FORBIDDEN_PHRASES = (
+    "consciousness probability",
+    "is conscious",
+    "sentience score",
+)
+
+
+@pytest.fixture(autouse=True)
+def _generative_flag_on(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    toml = tmp_path / "behavior-on.toml"
+    toml.write_text(
+        "[individual-kernel]\n"
+        "generative_field_model = true\n"
+        "generative_rollout_horizon = 2\n"
+    )
+    monkeypatch.setenv("MCP_BEHAVIOR_TOML", str(toml))
+
+
+class TestPureMetrics:
+    def test_brier_hand_computed(self) -> None:
+        assert brier_score([(0.8, True), (0.4, False)]) == pytest.approx(
+            ((0.8 - 1.0) ** 2 + 0.4**2) / 2
+        )
+
+    def test_log_loss_clips_extremes(self) -> None:
+        value = log_loss([(0.0, True)])
+        assert value > 0.0
+        assert value < 10.0
+
+    def test_ece_perfect_calibration_is_zero(self) -> None:
+        pairs = [(0.5, True), (0.5, False)]
+        ece, bins = expected_calibration_error(pairs)
+        assert ece == pytest.approx(0.0)
+        assert bins[0]["count"] == 2.0
+
+
+class TestBenchmarkReports:
+    def test_benchmark_writes_both_reports(self, tmp_path: Path) -> None:
+        output = tmp_path / "out"
+        result = run_candidate_benchmark(
+            output_dir=output, db_path=tmp_path / "field.db"
+        )
+        indicator = (output / "indicator-profile.md").read_text(encoding="utf-8")
+        calibration = (output / "prediction-calibration.md").read_text(
+            encoding="utf-8"
+        )
+        combined = (indicator + calibration).lower()
+        for phrase in _FORBIDDEN_PHRASES:
+            assert phrase not in combined
+        assert "not proof of phenomenology" in indicator
+        assert "not proof of phenomenology" in calibration
+        assert "n_resolved" in calibration
+        assert result["calibration"]["n_resolved"] >= 1
+        assert result["calibration"]["reliable"] is False
+        assert any(
+            "Provisional" in note
+            for note in result["calibration"]["uncertainty_notes"]
+        )
+        detail = result["profile"]["prediction_calibration_detail"]
+        assert detail["source"] in {"legacy_binary", "generative"}
+        payload = json.loads(
+            (output / "prediction-calibration.json").read_text(encoding="utf-8")
+        )
+        assert payload["baseline_uniform_brier"] >= 0.0

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_experienced_transition.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_experienced_transition.py
@@ -1,0 +1,218 @@
+"""Experienced transitions: idempotent recording and exactly-once learning."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+from social_core.db import SocialDB
+
+from individual_kernel_mcp.enacted_field import TriggerKind
+from individual_kernel_mcp.experienced_transition import (
+    ExperiencedTransition,
+    ExperiencedTransitionStore,
+)
+from individual_kernel_mcp.generative_model import CountBasedGenerativeFieldModel
+from individual_kernel_mcp.tick import TickProducer
+from individual_kernel_mcp.workspace import (
+    CandidateKind,
+    CandidateSource,
+    SourceMode,
+    WorkspaceCandidate,
+)
+
+_SIGNATURE = "desire|user_prompt|identity_coherence|neu|mid|no_action"
+
+
+def _producer(social_db: SocialDB, tmp_path: Path) -> TickProducer:
+    interoception = tmp_path / "interoception.json"
+    interoception.write_text(json.dumps({"now": {"arousal": 50.0}}))
+    desires = tmp_path / "desires.json"
+    desires.write_text(
+        json.dumps(
+            {
+                "desires": {"identity_coherence": 0.9},
+                "discomforts": {"identity_coherence": 0.5},
+                "dominant": "identity_coherence",
+            }
+        )
+    )
+    return TickProducer(
+        social_db,
+        interoception_path=interoception,
+        desires_path=desires,
+    )
+
+
+def _commit(producer: TickProducer, focus_ref: str = "desire:identity_coherence"):
+    opened = producer.begin_tick(TriggerKind.USER_PROMPT)
+    producer.workspace.add_candidate(
+        WorkspaceCandidate(
+            tick_id=opened.tick_id,
+            kind=CandidateKind.GOAL,
+            content_ref=focus_ref,
+            content_summary=f"focus {focus_ref}",
+            source=CandidateSource.EXPLICIT,
+            source_mode=SourceMode.INFERRED,
+            precision=1.0,
+            prediction_error=1.0,
+            need_relevance=1.0,
+            goal_relevance=1.0,
+            expected_information_gain=1.0,
+            continuity_with_previous=1.0,
+            controllability=1.0,
+            social_relevance=1.0,
+        )
+    )
+    return producer.compete_and_commit(opened.tick_id).field
+
+
+def _transition(previous_field, next_field, **overrides) -> ExperiencedTransition:
+    data: dict = {
+        "owner_id": "self",
+        "previous_field_id": previous_field.field_id if previous_field else None,
+        "next_field_id": next_field.field_id,
+        "previous_tick_id": previous_field.tick_id if previous_field else None,
+        "next_tick_id": next_field.tick_id,
+        "context_signature": _SIGNATURE,
+        "action_kind": "no_action",
+        "outcome_bucket": "na/na/desire/=",
+        "prediction_errors": {"probability_of_observed": 0.5},
+        "mean_prediction_error": 0.5,
+        "valence_before": -0.1,
+        "valence_after": -0.1,
+        "valence_change": 0.0,
+        "arousal_before": 0.5,
+        "arousal_after": 0.5,
+        "agency_confidence": 0.5,
+        "ownership_confidence": 0.5,
+        "source_mode": SourceMode.INFERRED,
+    }
+    data.update(overrides)
+    return ExperiencedTransition(**data)
+
+
+class TestSourceDiscipline:
+    def test_imagined_and_remembered_sources_are_rejected(
+        self, social_db, tmp_path
+    ) -> None:
+        producer = _producer(social_db, tmp_path)
+        field = _commit(producer)
+        for mode in (SourceMode.IMAGINED, SourceMode.REMEMBERED):
+            with pytest.raises(ValidationError):
+                _transition(None, field, source_mode=mode)
+
+    def test_knowledge_source_is_experienced_only_in_v1(
+        self, social_db, tmp_path
+    ) -> None:
+        producer = _producer(social_db, tmp_path)
+        field = _commit(producer)
+        for value in ("told", "imagined", "replayed"):
+            with pytest.raises(ValidationError):
+                _transition(None, field, knowledge_source=value)
+
+
+class TestIdempotentRecording:
+    def test_round_trip(self, social_db, tmp_path) -> None:
+        producer = _producer(social_db, tmp_path)
+        previous = _commit(producer)
+        following = _commit(producer)
+        store = ExperiencedTransitionStore(social_db)
+        transition, created = store.record(_transition(previous, following))
+        assert created is True
+        loaded = store.get(transition.transition_id)
+        assert loaded == transition
+
+    def test_double_record_for_same_next_field_returns_existing(
+        self, social_db, tmp_path
+    ) -> None:
+        producer = _producer(social_db, tmp_path)
+        previous = _commit(producer)
+        following = _commit(producer)
+        store = ExperiencedTransitionStore(social_db)
+        first, created_first = store.record(_transition(previous, following))
+        second, created_second = store.record(_transition(previous, following))
+        assert created_first is True
+        assert created_second is False
+        assert second.transition_id == first.transition_id
+        count = social_db.fetchone(
+            "SELECT COUNT(*) AS n FROM experienced_transitions WHERE next_field_id = ?",
+            (following.field_id,),
+        )
+        assert count["n"] == 1
+
+    def test_trajectory_link_is_set_once(self, social_db, tmp_path) -> None:
+        producer = _producer(social_db, tmp_path)
+        previous = _commit(producer)
+        following = _commit(producer)
+        store = ExperiencedTransitionStore(social_db)
+        transition, _ = store.record(_transition(previous, following))
+        assert (
+            store.link_trajectory(
+                transition.transition_id,
+                intended_trajectory_id=None,
+                distribution_id="prot_a",
+            )
+            is True
+        )
+        assert (
+            store.link_trajectory(
+                transition.transition_id,
+                intended_trajectory_id=None,
+                distribution_id="prot_b",
+            )
+            is False
+        )
+        loaded = store.get(transition.transition_id)
+        assert loaded is not None
+        assert loaded.distribution_id == "prot_a"
+
+
+class TestExactlyOnceLearning:
+    def test_update_applies_once_within_one_connection(
+        self, social_db, tmp_path
+    ) -> None:
+        producer = _producer(social_db, tmp_path)
+        previous = _commit(producer)
+        following = _commit(producer)
+        store = ExperiencedTransitionStore(social_db)
+        transition, _ = store.record(_transition(previous, following))
+        model = CountBasedGenerativeFieldModel(social_db)
+        assert model.update(transition) is True
+        assert model.update(transition) is False
+        row = social_db.fetchone(
+            "SELECT observation_count FROM generative_transition_stats "
+            "WHERE action_kind = 'no_action' AND outcome_bucket = 'na/na/desire/='",
+        )
+        assert row is not None
+        assert row["observation_count"] == pytest.approx(1.0)
+
+    def test_update_applies_once_across_connections(
+        self, temp_db_path: Path, tmp_path: Path
+    ) -> None:
+        first = SocialDB(temp_db_path)
+        first.connect()
+        producer = _producer(first, tmp_path)
+        previous = _commit(producer)
+        following = _commit(producer)
+        store = ExperiencedTransitionStore(first)
+        transition, _ = store.record(_transition(previous, following))
+        assert CountBasedGenerativeFieldModel(first).update(transition) is True
+        first.close()
+
+        second = SocialDB(temp_db_path)
+        second.connect()
+        try:
+            loaded = ExperiencedTransitionStore(second).get(transition.transition_id)
+            assert loaded is not None
+            assert CountBasedGenerativeFieldModel(second).update(loaded) is False
+            row = second.fetchone(
+                "SELECT observation_count FROM generative_transition_stats "
+                "WHERE action_kind = 'no_action' AND outcome_bucket = 'na/na/desire/='",
+            )
+            assert row is not None
+            assert row["observation_count"] == pytest.approx(1.0)
+        finally:
+            second.close()

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_experienced_transition.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_experienced_transition.py
@@ -26,6 +26,14 @@ from individual_kernel_mcp.workspace import (
 _SIGNATURE = "desire|user_prompt|identity_coherence|neu|mid|no_action"
 
 
+@pytest.fixture(autouse=True)
+def _generative_flag_off(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate store/model unit tests from the automatic commit-time loop."""
+    toml = tmp_path / "behavior-off.toml"
+    toml.write_text("[individual-kernel]\ngenerative_field_model = false\n")
+    monkeypatch.setenv("MCP_BEHAVIOR_TOML", str(toml))
+
+
 def _producer(social_db: SocialDB, tmp_path: Path) -> TickProducer:
     interoception = tmp_path / "interoception.json"
     interoception.write_text(json.dumps({"now": {"arousal": 50.0}}))

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_generative_model.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_generative_model.py
@@ -1,0 +1,298 @@
+"""Count-based generative field model: signatures, smoothing, backoff, rollout."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from social_core.db import SocialDB
+
+from individual_kernel_mcp.enacted_field import TriggerKind
+from individual_kernel_mcp.generative_model import (
+    DIRICHLET_ALPHA,
+    NO_ACTION,
+    ContextSignature,
+    CountBasedGenerativeFieldModel,
+    arousal_bucket_of,
+    dominant_desire_of,
+    focus_kind_of,
+    latency_bucket_of,
+    valence_bucket_of,
+    valence_delta_facet_of,
+)
+from individual_kernel_mcp.tick import TickProducer
+from individual_kernel_mcp.workspace import (
+    CandidateKind,
+    CandidateSource,
+    SourceMode,
+    WorkspaceCandidate,
+)
+
+
+def _producer(social_db: SocialDB, tmp_path: Path) -> TickProducer:
+    interoception = tmp_path / "interoception.json"
+    interoception.write_text(json.dumps({"now": {"arousal": 50.0}}))
+    desires = tmp_path / "desires.json"
+    desires.write_text(
+        json.dumps(
+            {
+                "desires": {"identity_coherence": 0.9},
+                "discomforts": {"identity_coherence": 0.5},
+                "dominant": "identity_coherence",
+            }
+        )
+    )
+    return TickProducer(
+        social_db,
+        interoception_path=interoception,
+        desires_path=desires,
+    )
+
+
+def _commit(producer: TickProducer, focus_ref: str = "desire:identity_coherence"):
+    opened = producer.begin_tick(TriggerKind.USER_PROMPT)
+    producer.workspace.add_candidate(
+        WorkspaceCandidate(
+            tick_id=opened.tick_id,
+            kind=CandidateKind.GOAL,
+            content_ref=focus_ref,
+            content_summary=f"focus {focus_ref}",
+            source=CandidateSource.EXPLICIT,
+            source_mode=SourceMode.INFERRED,
+            precision=1.0,
+            prediction_error=1.0,
+            need_relevance=1.0,
+            goal_relevance=1.0,
+            expected_information_gain=1.0,
+            continuity_with_previous=1.0,
+            controllability=1.0,
+            social_relevance=1.0,
+        )
+    )
+    return producer.compete_and_commit(opened.tick_id).field
+
+
+def _seed_stats(
+    db: SocialDB,
+    *,
+    signature: ContextSignature,
+    bucket: str,
+    count: float,
+    sum_valence_delta: float = 0.0,
+) -> None:
+    db.execute(
+        """
+        INSERT INTO generative_transition_stats(
+            owner_id, focus_kind, trigger_kind, dominant_desire, valence_bucket,
+            arousal_bucket, action_kind, outcome_bucket, observation_count,
+            sum_valence_delta, sum_latency_ms, sum_prediction_error,
+            last_transition_id, model_version, first_observed_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0.0, 0.0, NULL, 'count_v1',
+                  '2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00')
+        """,
+        (
+            "self",
+            signature.focus_kind,
+            signature.trigger_kind,
+            signature.dominant_desire,
+            signature.valence_bucket,
+            signature.arousal_bucket,
+            signature.action_kind,
+            bucket,
+            count,
+            sum_valence_delta,
+        ),
+    )
+
+
+_SIG = ContextSignature(
+    focus_kind="desire",
+    trigger_kind="user_prompt",
+    dominant_desire="identity_coherence",
+    valence_bucket="neu",
+    arousal_bucket="mid",
+    action_kind="tool:Bash",
+)
+
+
+class TestBucketBoundaries:
+    def test_valence_deadband_edges(self) -> None:
+        assert valence_bucket_of(-0.150) == "neu"
+        assert valence_bucket_of(-0.151) == "neg"
+        assert valence_bucket_of(0.150) == "neu"
+        assert valence_bucket_of(0.151) == "pos"
+
+    def test_arousal_edges(self) -> None:
+        assert arousal_bucket_of(0.329) == "low"
+        assert arousal_bucket_of(0.33) == "mid"
+        assert arousal_bucket_of(0.66) == "mid"
+        assert arousal_bucket_of(0.661) == "high"
+
+    def test_latency_edges(self) -> None:
+        assert latency_bucket_of(None) == "na"
+        assert latency_bucket_of(999) == "short"
+        assert latency_bucket_of(1000) == "mid"
+        assert latency_bucket_of(9999) == "mid"
+        assert latency_bucket_of(10000) == "long"
+
+    def test_valence_delta_facets(self) -> None:
+        assert valence_delta_facet_of(-0.051) == "-"
+        assert valence_delta_facet_of(0.0) == "="
+        assert valence_delta_facet_of(0.051) == "+"
+
+    def test_focus_kind_prefix(self) -> None:
+        assert focus_kind_of("desire:identity_coherence") == "desire"
+        assert focus_kind_of(None) == "none"
+
+    def test_dominant_desire_lexical_tiebreak(self) -> None:
+        assert dominant_desire_of({"b": 0.5, "a": 0.5}) == "a"
+        assert dominant_desire_of({}) == ""
+
+
+class TestContextSignature:
+    def test_from_committed_field_is_deterministic(self, social_db, tmp_path) -> None:
+        producer = _producer(social_db, tmp_path)
+        field = _commit(producer)
+        model = CountBasedGenerativeFieldModel(social_db)
+        first = model.infer(field, action_kind="tool:Bash")
+        second = model.infer(field, action_kind="tool:Bash")
+        assert first == second
+        assert first.focus_kind == "desire"
+        assert first.trigger_kind == "user_prompt"
+        assert first.dominant_desire == "identity_coherence"
+        assert first.valence_bucket == "neu"
+        assert first.arousal_bucket == "mid"
+
+    def test_key_round_trips(self) -> None:
+        assert ContextSignature.from_key(_SIG.key()) == _SIG
+
+
+class TestDirichletSmoothing:
+    def test_hand_computed_probabilities(self, social_db) -> None:
+        _seed_stats(social_db, signature=_SIG, bucket="ok/short/tool_result/=", count=3)
+        _seed_stats(social_db, signature=_SIG, bucket="fail/short/tool_result/=", count=1)
+        model = CountBasedGenerativeFieldModel(social_db)
+        forecast = model.forecast(_SIG)
+        # K = 2 observed + 1 novel = 3; N = 4; alpha = 0.5
+        assert forecast.basis == "count"
+        assert forecast.predictions[0].bucket == "ok/short/tool_result/="
+        assert forecast.predictions[0].probability == pytest.approx(3.5 / 5.5)
+        assert forecast.predictions[1].probability == pytest.approx(1.5 / 5.5)
+        assert forecast.novel_probability == pytest.approx(0.5 / 5.5)
+        assert forecast.uncertainty == pytest.approx(1.5 / 5.5)
+
+    def test_probability_mass_sums_to_one(self, social_db) -> None:
+        _seed_stats(social_db, signature=_SIG, bucket="ok/short/tool_result/=", count=3)
+        _seed_stats(social_db, signature=_SIG, bucket="fail/short/tool_result/=", count=1)
+        _seed_stats(social_db, signature=_SIG, bucket="ok/mid/tool_result/+", count=2)
+        model = CountBasedGenerativeFieldModel(social_db)
+        forecast = model.forecast(_SIG)
+        total = sum(p.probability for p in forecast.predictions) + forecast.novel_probability
+        assert total == pytest.approx(1.0)
+
+    def test_probability_of_unseen_bucket_equals_novel_mass(self, social_db) -> None:
+        _seed_stats(social_db, signature=_SIG, bucket="ok/short/tool_result/=", count=3)
+        model = CountBasedGenerativeFieldModel(social_db)
+        probability, basis, uncertainty = model.probability_of(_SIG, "fail/long/none/-")
+        # K = 1 observed + 1 novel = 2; N = 3
+        assert probability == pytest.approx(0.5 / 4.0)
+        assert basis == "count"
+        assert uncertainty == pytest.approx(1.0 / 4.0)
+
+    def test_uncertainty_decreases_with_observations(self, social_db) -> None:
+        model = CountBasedGenerativeFieldModel(social_db)
+        empty = model.forecast(_SIG)
+        assert empty.uncertainty == 1.0
+        _seed_stats(social_db, signature=_SIG, bucket="ok/short/tool_result/=", count=1)
+        one = model.forecast(_SIG)
+        _seed_stats(social_db, signature=_SIG, bucket="ok/mid/tool_result/=", count=9)
+        many = model.forecast(_SIG)
+        assert 0.0 < many.uncertainty < one.uncertainty < 1.0
+
+
+class TestBackoffChain:
+    def test_backoff_levels_in_declared_order(self, social_db) -> None:
+        seeded = _SIG.model_copy(update={"dominant_desire": "browse_curiosity"})
+        _seed_stats(social_db, signature=seeded, bucket="ok/short/tool_result/=", count=2)
+        model = CountBasedGenerativeFieldModel(social_db)
+        exact_missing = model.forecast(_SIG)
+        assert exact_missing.basis == "backoff:1"
+
+        far = _SIG.model_copy(
+            update={"dominant_desire": "x", "arousal_bucket": "high", "valence_bucket": "neg"}
+        )
+        assert model.forecast(far).basis == "backoff:3"
+
+        other_action = _SIG.model_copy(update={"action_kind": "tool:Write"})
+        assert model.forecast(other_action).basis == "prior"
+
+    def test_action_only_backoff_level(self, social_db) -> None:
+        seeded = _SIG.model_copy(
+            update={
+                "focus_kind": "event",
+                "trigger_kind": "tool_result",
+                "dominant_desire": "x",
+                "valence_bucket": "neg",
+                "arousal_bucket": "high",
+            }
+        )
+        _seed_stats(social_db, signature=seeded, bucket="ok/short/tool_result/=", count=2)
+        model = CountBasedGenerativeFieldModel(social_db)
+        assert model.forecast(_SIG).basis == "backoff:4"
+
+
+class TestRollout:
+    def test_rejects_out_of_range_horizon(self, social_db, tmp_path) -> None:
+        producer = _producer(social_db, tmp_path)
+        field = _commit(producer)
+        model = CountBasedGenerativeFieldModel(social_db)
+        with pytest.raises(ValueError):
+            model.rollout(field, action_kind="tool:Bash", horizon=0)
+        with pytest.raises(ValueError):
+            model.rollout(field, action_kind="tool:Bash", horizon=6)
+
+    def test_horizon_chain_produces_imagined_steps(self, social_db, tmp_path) -> None:
+        producer = _producer(social_db, tmp_path)
+        field = _commit(producer)
+        model = CountBasedGenerativeFieldModel(social_db)
+        steps = model.rollout(field, action_kind="tool:Bash", horizon=3)
+        assert [step.step_index for step in steps] == [1, 2, 3]
+        for step in steps:
+            assert step.predicted_belief.source_mode is SourceMode.IMAGINED
+            assert 0.0 <= step.conditional_probability <= 1.0
+            assert 0.0 <= step.uncertainty <= 1.0
+
+    def test_first_bucket_override_selects_branch(self, social_db, tmp_path) -> None:
+        producer = _producer(social_db, tmp_path)
+        field = _commit(producer)
+        model = CountBasedGenerativeFieldModel(social_db)
+        signature = model.infer(field, action_kind="tool:Bash")
+        _seed_stats(social_db, signature=signature, bucket="ok/short/tool_result/=", count=3)
+        _seed_stats(social_db, signature=signature, bucket="fail/short/tool_result/-", count=1)
+        steps = model.rollout(
+            field,
+            action_kind="tool:Bash",
+            horizon=1,
+            first_bucket="fail/short/tool_result/-",
+        )
+        assert steps[0].outcome_bucket == "fail/short/tool_result/-"
+
+    def test_predictions_persist_across_reconnect(self, temp_db_path: Path) -> None:
+        first = SocialDB(temp_db_path)
+        first.connect()
+        _seed_stats(first, signature=_SIG, bucket="ok/short/tool_result/=", count=3)
+        before = CountBasedGenerativeFieldModel(first).forecast(_SIG)
+        first.close()
+
+        second = SocialDB(temp_db_path)
+        second.connect()
+        try:
+            after = CountBasedGenerativeFieldModel(second).forecast(_SIG)
+            assert after == before
+        finally:
+            second.close()
+
+    def test_no_action_constant_exported(self) -> None:
+        assert NO_ACTION == "no_action"
+        assert DIRICHLET_ALPHA == 0.5

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_prediction_loop.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_prediction_loop.py
@@ -1,0 +1,355 @@
+"""Acceptance fixture: field -> rollout -> intention -> action -> error -> update."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from social_core.db import SocialDB
+
+from individual_kernel_mcp.agency import ActionProposal, PredictedEffects
+from individual_kernel_mcp.enacted_field import TriggerKind
+from individual_kernel_mcp.experienced_transition import ExperiencedTransitionStore
+from individual_kernel_mcp.generative_model import CountBasedGenerativeFieldModel
+from individual_kernel_mcp.tick import FieldRuntime, TickProducer
+from individual_kernel_mcp.trajectory import TrajectoryStatus, TrajectoryStore
+from individual_kernel_mcp.workspace import (
+    CandidateKind,
+    CandidateSource,
+    SourceMode,
+    WorkspaceCandidate,
+)
+
+_NEW_TABLES = (
+    "protention_distributions",
+    "imagined_trajectories",
+    "experienced_transitions",
+    "generative_transition_stats",
+)
+
+
+@pytest.fixture
+def flag_on(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    toml = tmp_path / "behavior-on.toml"
+    toml.write_text(
+        "[individual-kernel]\n"
+        "generative_field_model = true\n"
+        "generative_rollout_horizon = 2\n"
+    )
+    monkeypatch.setenv("MCP_BEHAVIOR_TOML", str(toml))
+    return toml
+
+
+def _flag_off(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    toml = tmp_path / "behavior-off.toml"
+    toml.write_text("[individual-kernel]\ngenerative_field_model = false\n")
+    monkeypatch.setenv("MCP_BEHAVIOR_TOML", str(toml))
+
+
+def _producer(social_db: SocialDB, state_dir: Path) -> TickProducer:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    interoception = state_dir / "interoception.json"
+    interoception.write_text(json.dumps({"now": {"arousal": 50.0}}))
+    desires = state_dir / "desires.json"
+    desires.write_text(
+        json.dumps(
+            {
+                "desires": {"identity_coherence": 0.9},
+                "discomforts": {"identity_coherence": 0.5},
+                "dominant": "identity_coherence",
+            }
+        )
+    )
+    return TickProducer(
+        social_db,
+        interoception_path=interoception,
+        desires_path=desires,
+    )
+
+
+def _commit(producer: TickProducer, focus_ref: str = "desire:identity_coherence"):
+    opened = producer.begin_tick(TriggerKind.USER_PROMPT)
+    producer.workspace.add_candidate(
+        WorkspaceCandidate(
+            tick_id=opened.tick_id,
+            kind=CandidateKind.GOAL,
+            content_ref=focus_ref,
+            content_summary=f"focus {focus_ref}",
+            source=CandidateSource.EXPLICIT,
+            source_mode=SourceMode.INFERRED,
+            precision=1.0,
+            prediction_error=1.0,
+            need_relevance=1.0,
+            goal_relevance=1.0,
+            expected_information_gain=1.0,
+            continuity_with_previous=1.0,
+            controllability=1.0,
+            social_relevance=1.0,
+        )
+    )
+    return producer.compete_and_commit(opened.tick_id).field
+
+
+_TOOL_INPUT = {"file_path": "/tmp/prediction-loop-fixture.txt", "content": "x"}
+
+
+def _proposal(field, confidence: float = 0.6) -> ActionProposal:
+    return ActionProposal(
+        field_id=field.field_id,
+        tool_name="Write",
+        tool_input=dict(_TOOL_INPUT),
+        predicted_effects=PredictedEffects(),
+        goal="write the fixture file",
+        confidence=confidence,
+    )
+
+
+class TestImagineAtProposeTime:
+    def test_distribution_shape_and_modal_intended(
+        self, social_db, tmp_path, flag_on
+    ) -> None:
+        producer = _producer(social_db, tmp_path / "state")
+        runtime = FieldRuntime(social_db, producer=producer)
+        field = _commit(producer)
+        intention = runtime.propose_action(_proposal(field))
+
+        refreshed = producer.fields.get(field.field_id)
+        assert refreshed is not None
+        ref = refreshed.epistemic_trace.get("protention_distribution_ref")
+        assert ref
+        store = TrajectoryStore(social_db)
+        distribution = store.get_distribution(ref)
+        assert distribution is not None
+        assert len(distribution.trajectories) >= 2
+        no_action = [t for t in distribution.trajectories if t.action_kind == "no_action"]
+        assert len(no_action) == 1
+        assert sum(t.probability for t in distribution.trajectories) == pytest.approx(1.0)
+
+        linked = store.find_active_for_action(intention.action_id)
+        assert linked is not None
+        assert linked.status is TrajectoryStatus.INTENDED
+        others = [
+            t
+            for t in distribution.trajectories
+            if t.trajectory_id != linked.trajectory_id
+        ]
+        assert all(
+            store.get_trajectory(t.trajectory_id).status is TrajectoryStatus.IMAGINED
+            for t in others
+        )
+
+
+class TestActRecordLearnCycle:
+    def test_full_cycle_records_transition_and_improves_prediction(
+        self, social_db, tmp_path, flag_on
+    ) -> None:
+        producer = _producer(social_db, tmp_path / "state")
+        runtime = FieldRuntime(social_db, producer=producer)
+        field = _commit(producer)
+        intention = runtime.propose_action(_proposal(field))
+
+        decision = runtime.gate_tool(tool_name="Write", tool_input=dict(_TOOL_INPUT))
+        assert decision.allow is True
+        store = TrajectoryStore(social_db)
+        assert (
+            store.find_active_for_action(intention.action_id).status
+            is TrajectoryStatus.ENACTED
+        )
+
+        outcome, assessment, committed = runtime.close_tool(
+            tool_name="Write",
+            tool_input=dict(_TOOL_INPUT),
+            actual_result_summary="fixture file written successfully",
+            success=True,
+            latency_ms=50,
+        )
+        assert outcome is not None
+        assert committed is not None
+
+        transitions = ExperiencedTransitionStore(social_db)
+        transition = transitions.get_by_next_field(committed.field_id)
+        assert transition is not None
+        assert transition.action_ref == intention.action_id
+        assert transition.action_kind == "tool:Write"
+        assert transition.intended_trajectory_id is not None
+        assert transition.applied_at is not None
+        for key in (
+            "exteroceptive",
+            "interoceptive",
+            "social",
+            "mnemonic",
+            "latency",
+            "focus_kind_error",
+            "valence_delta_error",
+            "probability_of_observed",
+        ):
+            assert key in transition.prediction_errors
+
+        settled = store.get_trajectory(transition.intended_trajectory_id)
+        assert settled is not None
+        assert settled.status in {
+            TrajectoryStatus.OBSERVED,
+            TrajectoryStatus.PARTIALLY_OBSERVED,
+        }
+
+        model = CountBasedGenerativeFieldModel(social_db)
+        signature = model.infer(field, action_kind="tool:Write")
+        before = transition.prediction_errors["probability_of_observed"]
+        after, basis, uncertainty = model.probability_of(
+            signature, transition.outcome_bucket
+        )
+        assert after > before
+        assert uncertainty < 1.0
+        assert basis == "count"
+
+    def test_failed_action_contradicts_trajectory(
+        self, social_db, tmp_path, flag_on
+    ) -> None:
+        producer = _producer(social_db, tmp_path / "state")
+        runtime = FieldRuntime(social_db, producer=producer)
+        field = _commit(producer)
+        intention = runtime.propose_action(_proposal(field, confidence=0.9))
+        assert runtime.gate_tool(
+            tool_name="Write", tool_input=dict(_TOOL_INPUT)
+        ).allow
+        runtime.close_tool(
+            tool_name="Write",
+            tool_input=dict(_TOOL_INPUT),
+            actual_result_summary="permission denied while writing fixture",
+            success=False,
+            latency_ms=20,
+        )
+        store = TrajectoryStore(social_db)
+        assert (
+            store.find_active_for_action(intention.action_id) is None
+            or store.find_active_for_action(intention.action_id).status
+            is not TrajectoryStatus.ENACTED
+        )
+        settled = TrajectoryStore(social_db).get_trajectory(
+            ExperiencedTransitionStore(social_db)
+            .query(action_kind="tool:Write")[0]
+            .intended_trajectory_id
+        )
+        assert settled.status is TrajectoryStatus.CONTRADICTED
+
+
+class TestNoActionAndExpiry:
+    def test_plain_commits_record_no_action_transition_once(
+        self, social_db, tmp_path, flag_on
+    ) -> None:
+        producer = _producer(social_db, tmp_path / "state")
+        first = _commit(producer)
+        second = _commit(producer)
+        transitions = ExperiencedTransitionStore(social_db)
+        transition = transitions.get_by_next_field(second.field_id)
+        assert transition is not None
+        assert transition.action_ref is None
+        assert transition.action_kind == "no_action"
+        assert transition.previous_field_id == first.field_id
+        row = social_db.fetchone(
+            "SELECT COUNT(*) AS n FROM experienced_transitions WHERE next_field_id = ?",
+            (second.field_id,),
+        )
+        assert row["n"] == 1
+
+    def test_unexecuted_intention_returns_trajectory_to_imagined(
+        self, social_db, tmp_path, flag_on
+    ) -> None:
+        producer = _producer(social_db, tmp_path / "state")
+        runtime = FieldRuntime(social_db, producer=producer)
+        field = _commit(producer)
+        intention = runtime.propose_action(_proposal(field))
+        _commit(producer)  # recovers the dangling intention, no execution
+        store = TrajectoryStore(social_db)
+        rows = store.query(action_ref=intention.action_id)
+        assert rows
+        assert all(t.status is TrajectoryStatus.IMAGINED for t in rows)
+        assert any(
+            entry["reason"] == "intention expired without execution"
+            for t in rows
+            for entry in t.status_history
+        )
+
+
+class TestBoundaryIndependenceAndFlag:
+    def test_gate_decision_identical_with_flag_on_and_off(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        def run(db_name: str, state: str) -> tuple:
+            db = SocialDB(tmp_path / db_name)
+            db.connect()
+            try:
+                producer = _producer(db, tmp_path / state)
+                runtime = FieldRuntime(db, producer=producer)
+                field = _commit(producer)
+                runtime.propose_action(_proposal(field))
+                decision = runtime.gate_tool(
+                    tool_name="Write", tool_input=dict(_TOOL_INPUT)
+                )
+                return (
+                    decision.allow,
+                    decision.reason,
+                    decision.external,
+                    decision.deferred,
+                )
+            finally:
+                db.close()
+
+        toml_on = tmp_path / "on.toml"
+        toml_on.write_text("[individual-kernel]\ngenerative_field_model = true\n")
+        monkeypatch.setenv("MCP_BEHAVIOR_TOML", str(toml_on))
+        with_flag = run("a.db", "state-a")
+
+        _flag_off(tmp_path, monkeypatch)
+        without_flag = run("b.db", "state-b")
+
+        assert with_flag == without_flag
+
+    def test_flag_off_writes_nothing(self, tmp_path, monkeypatch) -> None:
+        _flag_off(tmp_path, monkeypatch)
+        db = SocialDB(tmp_path / "off.db")
+        db.connect()
+        try:
+            producer = _producer(db, tmp_path / "state-off")
+            runtime = FieldRuntime(db, producer=producer)
+            field = _commit(producer)
+            runtime.propose_action(_proposal(field))
+            assert runtime.gate_tool(
+                tool_name="Write", tool_input=dict(_TOOL_INPUT)
+            ).allow
+            runtime.close_tool(
+                tool_name="Write",
+                tool_input=dict(_TOOL_INPUT),
+                actual_result_summary="fixture file written successfully",
+                success=True,
+                latency_ms=50,
+            )
+            for table in _NEW_TABLES:
+                row = db.fetchone(f"SELECT COUNT(*) AS n FROM {table}")
+                assert row["n"] == 0, table
+        finally:
+            db.close()
+
+    def test_boundary_denial_returns_trajectory(
+        self, social_db, tmp_path, flag_on
+    ) -> None:
+        producer = _producer(social_db, tmp_path / "state")
+        runtime = FieldRuntime(
+            social_db,
+            producer=producer,
+            boundary_evaluator=lambda name, tool_input, field: (False, "fixture deny"),
+        )
+        field = _commit(producer)
+        intention = runtime.propose_action(_proposal(field))
+        decision = runtime.gate_tool(tool_name="Write", tool_input=dict(_TOOL_INPUT))
+        assert decision.allow is False
+        store = TrajectoryStore(social_db)
+        rows = store.query(action_ref=intention.action_id)
+        assert rows
+        assert all(t.status is TrajectoryStatus.IMAGINED for t in rows)
+        assert any(
+            entry["reason"] == "boundary denied"
+            for t in rows
+            for entry in t.status_history
+        )

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_server_generative.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_server_generative.py
@@ -1,0 +1,80 @@
+"""Generative MCP tool surface: rollout, queries, calibration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from individual_kernel_mcp import server
+from individual_kernel_mcp.enacted_field import TriggerKind
+from individual_kernel_mcp.workspace import (
+    CandidateKind,
+    CandidateSource,
+    SourceMode,
+    WorkspaceCandidate,
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SOCIAL_DB_PATH", str(tmp_path / "social.db"))
+    toml = tmp_path / "behavior-on.toml"
+    toml.write_text(
+        "[individual-kernel]\n"
+        "generative_field_model = true\n"
+        "generative_rollout_horizon = 2\n"
+    )
+    monkeypatch.setenv("MCP_BEHAVIOR_TOML", str(toml))
+    server.reset_store_cache()
+    yield
+    server.reset_store_cache()
+
+
+def _commit_field() -> str:
+    stores = server._stores()
+    opened = stores.tick_producer.begin_tick(TriggerKind.USER_PROMPT)
+    stores.workspace.add_candidate(
+        WorkspaceCandidate(
+            tick_id=opened.tick_id,
+            kind=CandidateKind.GOAL,
+            content_ref="desire:identity_coherence",
+            content_summary="focus desire",
+            source=CandidateSource.EXPLICIT,
+            source_mode=SourceMode.INFERRED,
+            precision=1.0,
+            prediction_error=1.0,
+            need_relevance=1.0,
+            goal_relevance=1.0,
+            expected_information_gain=1.0,
+            continuity_with_previous=1.0,
+            controllability=1.0,
+            social_relevance=1.0,
+        )
+    )
+    return stores.tick_producer.compete_and_commit(opened.tick_id).field.field_id
+
+
+class TestGenerativeTools:
+    def test_rollout_without_field_reports_error(self) -> None:
+        result = server.rollout_protention()
+        assert result == {"error": "no committed field for owner"}
+
+    def test_rollout_returns_forecast_and_steps(self) -> None:
+        field_id = _commit_field()
+        result = server.rollout_protention(tool_name="Write", horizon=2)
+        assert result["field_id"] == field_id
+        assert result["action_kind"] == "tool:Write"
+        assert len(result["steps"]) == 2
+        assert result["forecast"]["predictions"]
+
+    def test_query_tools_return_lists(self) -> None:
+        _commit_field()
+        assert isinstance(server.query_imagined_trajectories(), list)
+        assert isinstance(server.query_experienced_transitions(), list)
+
+    def test_calibration_report_shape(self) -> None:
+        report = server.get_generative_model_calibration()
+        assert report["n_resolved"] == 0
+        assert report["reliable"] is False
+        assert "brier" in report

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_trajectory_lifecycle.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_trajectory_lifecycle.py
@@ -1,0 +1,246 @@
+"""Imagined trajectories: status lifecycle, immutability, distribution invariants."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+from social_core.db import SocialDB
+
+from individual_kernel_mcp.enacted_field import TriggerKind
+from individual_kernel_mcp.generative_model import FieldBelief, TrajectoryStep
+from individual_kernel_mcp.tick import TickProducer
+from individual_kernel_mcp.trajectory import (
+    ImaginedTrajectory,
+    ProtentionDistribution,
+    TrajectoryStatus,
+    TrajectoryStore,
+    normalized_entropy,
+)
+from individual_kernel_mcp.workspace import (
+    CandidateKind,
+    CandidateSource,
+    SourceMode,
+    WorkspaceCandidate,
+)
+
+
+def _producer(social_db: SocialDB, tmp_path: Path) -> TickProducer:
+    interoception = tmp_path / "interoception.json"
+    interoception.write_text(json.dumps({"now": {"arousal": 50.0}}))
+    desires = tmp_path / "desires.json"
+    desires.write_text(
+        json.dumps(
+            {
+                "desires": {"identity_coherence": 0.9},
+                "discomforts": {"identity_coherence": 0.5},
+                "dominant": "identity_coherence",
+            }
+        )
+    )
+    return TickProducer(
+        social_db,
+        interoception_path=interoception,
+        desires_path=desires,
+    )
+
+
+def _commit(producer: TickProducer, focus_ref: str = "desire:identity_coherence"):
+    opened = producer.begin_tick(TriggerKind.USER_PROMPT)
+    producer.workspace.add_candidate(
+        WorkspaceCandidate(
+            tick_id=opened.tick_id,
+            kind=CandidateKind.GOAL,
+            content_ref=focus_ref,
+            content_summary=f"focus {focus_ref}",
+            source=CandidateSource.EXPLICIT,
+            source_mode=SourceMode.INFERRED,
+            precision=1.0,
+            prediction_error=1.0,
+            need_relevance=1.0,
+            goal_relevance=1.0,
+            expected_information_gain=1.0,
+            continuity_with_previous=1.0,
+            controllability=1.0,
+            social_relevance=1.0,
+        )
+    )
+    return producer.compete_and_commit(opened.tick_id).field
+
+
+def _step(index: int = 1) -> TrajectoryStep:
+    return TrajectoryStep(
+        step_index=index,
+        predicted_belief=FieldBelief(source_mode=SourceMode.IMAGINED),
+        outcome_bucket="ok/short/tool_result/=",
+        conditional_probability=0.5,
+        uncertainty=0.5,
+        support_observations=0.0,
+        basis="prior",
+    )
+
+
+def _trajectory(
+    field,
+    distribution_id: str,
+    *,
+    probability: float,
+    action_kind: str = "tool:Bash",
+) -> ImaginedTrajectory:
+    return ImaginedTrajectory(
+        distribution_id=distribution_id,
+        field_id=field.field_id,
+        tick_id=field.tick_id,
+        action_kind=action_kind,
+        context_signature="desire|user_prompt|identity_coherence|neu|mid|" + action_kind,
+        horizon=1,
+        steps=[_step()],
+        probability=probability,
+        uncertainty=0.5,
+    )
+
+
+def _distribution(field) -> ProtentionDistribution:
+    distribution_id = "prot_test_000000"
+    trajectories = [
+        _trajectory(field, distribution_id, probability=0.6),
+        _trajectory(field, distribution_id, probability=0.4, action_kind="no_action"),
+    ]
+    return ProtentionDistribution(
+        distribution_id=distribution_id,
+        field_id=field.field_id,
+        tick_id=field.tick_id,
+        trajectories=trajectories,
+        entropy=normalized_entropy([0.6, 0.4]),
+    )
+
+
+class TestDistributionInvariants:
+    def test_probabilities_must_sum_to_one(self, social_db, tmp_path) -> None:
+        producer = _producer(social_db, tmp_path)
+        field = _commit(producer)
+        with pytest.raises(ValidationError):
+            ProtentionDistribution(
+                field_id=field.field_id,
+                tick_id=field.tick_id,
+                trajectories=[
+                    _trajectory(field, "prot_x", probability=0.6),
+                    _trajectory(field, "prot_x", probability=0.6),
+                ],
+                entropy=0.5,
+            )
+
+    def test_trajectory_source_mode_must_be_imagined(self, social_db, tmp_path) -> None:
+        producer = _producer(social_db, tmp_path)
+        field = _commit(producer)
+        with pytest.raises(ValidationError):
+            ImaginedTrajectory(
+                distribution_id="prot_x",
+                field_id=field.field_id,
+                tick_id=field.tick_id,
+                action_kind="no_action",
+                context_signature="a|b|c|d|e|no_action",
+                horizon=1,
+                steps=[_step()],
+                probability=1.0,
+                uncertainty=0.5,
+                source_mode=SourceMode.LIVE,
+            )
+
+    def test_steps_must_match_horizon(self, social_db, tmp_path) -> None:
+        producer = _producer(social_db, tmp_path)
+        field = _commit(producer)
+        with pytest.raises(ValidationError):
+            ImaginedTrajectory(
+                distribution_id="prot_x",
+                field_id=field.field_id,
+                tick_id=field.tick_id,
+                action_kind="no_action",
+                context_signature="a|b|c|d|e|no_action",
+                horizon=2,
+                steps=[_step()],
+                probability=1.0,
+                uncertainty=0.5,
+            )
+
+    def test_entropy_of_uniform_pair_is_one(self) -> None:
+        assert normalized_entropy([0.5, 0.5]) == pytest.approx(1.0)
+        assert normalized_entropy([1.0]) == 0.0
+
+
+class TestStoreRoundTrip:
+    def test_distribution_round_trips(self, social_db, tmp_path) -> None:
+        producer = _producer(social_db, tmp_path)
+        field = _commit(producer)
+        store = TrajectoryStore(social_db)
+        created = store.create_distribution(_distribution(field))
+        loaded = store.get_distribution(created.distribution_id)
+        assert loaded is not None
+        key = lambda t: t.trajectory_id  # noqa: E731
+        assert sorted(loaded.trajectories, key=key) == sorted(created.trajectories, key=key)
+
+
+class TestStatusLifecycle:
+    def _stored_trajectory(self, social_db, tmp_path):
+        producer = _producer(social_db, tmp_path)
+        field = _commit(producer)
+        store = TrajectoryStore(social_db)
+        distribution = store.create_distribution(_distribution(field))
+        return store, distribution.trajectories[0].trajectory_id
+
+    def test_full_legal_chain(self, social_db, tmp_path) -> None:
+        store, trajectory_id = self._stored_trajectory(social_db, tmp_path)
+        store.transition(trajectory_id, TrajectoryStatus.INTENDED, reason="linked")
+        store.transition(trajectory_id, TrajectoryStatus.ENACTED, reason="gate allowed")
+        final = store.transition(
+            trajectory_id, TrajectoryStatus.OBSERVED, reason="low prediction error"
+        )
+        assert final.status is TrajectoryStatus.OBSERVED
+        assert [entry["status"] for entry in final.status_history] == [
+            "intended",
+            "enacted",
+            "observed",
+        ]
+
+    def test_boundary_denial_returns_to_imagined(self, social_db, tmp_path) -> None:
+        store, trajectory_id = self._stored_trajectory(social_db, tmp_path)
+        store.transition(trajectory_id, TrajectoryStatus.INTENDED, reason="linked")
+        back = store.transition(
+            trajectory_id, TrajectoryStatus.IMAGINED, reason="boundary denied"
+        )
+        assert back.status is TrajectoryStatus.IMAGINED
+
+    def test_enacted_can_contradict_or_partially_observe(self, social_db, tmp_path) -> None:
+        store, first = self._stored_trajectory(social_db, tmp_path)
+        store.transition(first, TrajectoryStatus.INTENDED, reason="linked")
+        store.transition(first, TrajectoryStatus.ENACTED, reason="gate allowed")
+        assert (
+            store.transition(first, TrajectoryStatus.CONTRADICTED, reason="mismatch").status
+            is TrajectoryStatus.CONTRADICTED
+        )
+
+    def test_imagined_never_auto_promotes_to_enacted(self, social_db, tmp_path) -> None:
+        store, trajectory_id = self._stored_trajectory(social_db, tmp_path)
+        with pytest.raises(ValueError):
+            store.transition(trajectory_id, TrajectoryStatus.ENACTED, reason="skip")
+
+    def test_terminal_states_reject_transitions(self, social_db, tmp_path) -> None:
+        store, trajectory_id = self._stored_trajectory(social_db, tmp_path)
+        store.transition(trajectory_id, TrajectoryStatus.INTENDED, reason="linked")
+        store.transition(trajectory_id, TrajectoryStatus.ENACTED, reason="gate allowed")
+        store.transition(trajectory_id, TrajectoryStatus.OBSERVED, reason="done")
+        for target in (
+            TrajectoryStatus.INTENDED,
+            TrajectoryStatus.ENACTED,
+            TrajectoryStatus.IMAGINED,
+            TrajectoryStatus.CONTRADICTED,
+        ):
+            with pytest.raises(ValueError):
+                store.transition(trajectory_id, target, reason="illegal")
+
+    def test_unknown_trajectory_raises(self, social_db) -> None:
+        store = TrajectoryStore(social_db)
+        with pytest.raises(ValueError):
+            store.transition("traj_missing", TrajectoryStatus.INTENDED, reason="x")

--- a/docs/generative-field-model-design.md
+++ b/docs/generative-field-model-design.md
@@ -1,0 +1,154 @@
+# GenerativeFieldModel Design (count_v1)
+
+Status: first vertical slice shipped 2026-07-26 on the
+`feat/generative-field-model` branch. Scope: prediction and learning only.
+Action selection, workspace competition, the `<current_field>` surface, and
+the boundary gate are byte-identical with the flag on or off.
+
+Claim policy: this layer records and predicts functional state transitions.
+Nothing in it is a phenomenal claim.
+
+## Goal
+
+Upgrade the EFPF from a state snapshot to a dynamical-system state:
+
+```
+committed field -> imagine >=2 action-conditioned trajectories (incl. no-action)
+-> one is linked to the registered intention -> the action executes
+-> the result is observed -> component prediction errors are computed
+-> one ExperiencedTransition is recorded -> the model updates exactly once
+-> the next rollout for the same (context, action) is measurably different
+```
+
+## Data model (migration `009_generative_field_model`)
+
+- `protention_distributions` - one row per propose-time rollout set
+  (entropy, model version, trajectory count).
+- `imagined_trajectories` - persisted rollouts. Status lifecycle is the only
+  mutable part: `imagined -> intended -> enacted -> observed | contradicted |
+  partially_observed`, plus `intended -> imagined` when the boundary denies or
+  the intention expires unexecuted, and a reserved `expired` state for the
+  future protention-expiry daemon. Probabilities and steps are immutable after
+  insert; every transition is appended to `status_history`. Imagined records
+  never auto-promote.
+- `experienced_transitions` - one row per arrived-at field, action-attributed
+  or `no_action`. Carries observed external/internal/social snapshots,
+  per-component prediction errors, valence/arousal before/after, agency and
+  ownership confidence, `source_mode` restricted to live/inferred/mixed, and
+  `knowledge_source` fixed to `experienced` in v1 (told/imagined/replayed are
+  reserved for the fork experiments, together with `info_content_hash`,
+  `fork_id`, pose refs, `body_delta_json`, `process_meta_ref`, and
+  `allostatic_snapshot_json`, which exist now so later phases need no
+  re-migration). `next_field_id` is UNIQUE: recording is idempotent.
+- `generative_transition_stats` - Dirichlet count table keyed by the six
+  context features plus the outcome bucket. `observation_count` is REAL so the
+  future organism daemon can decay counts fractionally.
+- `prediction_resolutions` - one row per scored (trajectory, step); unique per
+  pair, so calibration passes are idempotent. v1 resolves step 1; deeper steps
+  reuse the same table later.
+
+Learning is exactly-once: `model.update` first claims the transition via
+`UPDATE ... SET applied_at = ? WHERE applied_at IS NULL` and only counts it
+when the claim succeeds, which is safe across hook subprocesses.
+
+## Context and outcome discretization
+
+The count model deliberately predicts at kind level, not exact refs (the
+dormant `QualityGeometry.predict_transition` shows exact refs never repeat).
+
+- `ContextSignature`: `focus_kind | trigger_kind | dominant_desire |
+  valence_bucket(neg/neu/pos, +-0.15 deadband) | arousal_bucket(low/mid/high)
+  | action_kind(tool:<name> or no_action)`.
+- Outcome bucket: `{ok|fail|na}/{short|mid|long|na}/{next_focus_kind}/{-|=|+}`
+  (latency <1s/<10s; valence delta +-0.05 deadband).
+- Inference: Dirichlet smoothing `P=(n+a)/(N+aK)` with `a=0.5` and
+  `K = observed buckets + 1` (a novel bucket); step uncertainty `aK/(N+aK)`.
+- Nearest-neighbor fallback is a deterministic backoff chain (drop
+  dominant_desire, then arousal, then valence, then everything but
+  action_kind, then a fixed uniform prior). The level used is recorded in
+  `TrajectoryStep.basis`. No RNG anywhere.
+- Rollout supports horizon 1..5: step 1 conditions on the action, later steps
+  on `no_action`, chaining the imagined context. Sparse data pushes deep steps
+  onto backoff/prior levels so their uncertainty honestly approaches 1.
+
+Implementation note: `TrajectoryStep` lives in `generative_model.py` (it is a
+prediction product) and `trajectory.py` imports it; this keeps the module
+graph acyclic.
+
+## Runtime integration (flag-guarded, exception-tolerant)
+
+```mermaid
+flowchart TD
+    F[committed EnactedField] --> PR[propose_field_action]
+    PR --> IM[imagine_for_intention:\naction branch top-2 + no-action branch\nprobabilities sum to 1]
+    IM --> IN[modal trajectory -> intended]
+    IN --> GT[gate_tool: hash, boundary, bottleneck\nreads nothing from this layer]
+    GT -->|allow| EN[trajectory -> enacted]
+    GT -->|boundary deny| BK[trajectory -> imagined]
+    EN --> X[external tool executes]
+    X --> CL[close outcome: mismatch vector]
+    CL --> MT[microtick compete_and_commit]
+    MT --> ET[record ExperiencedTransition\nerrors vs pre-update model]
+    ET --> UP[model.update exactly once]
+    MT --> RC[reconcile: observed /\npartially_observed / contradicted]
+    UP --> F2[next rollout differs for the\nsame context and action]
+```
+
+Integration points: `TickProducer.compete_and_commit` (single learning choke
+point, inside the commit transaction, wrapped so a prediction fault can never
+abort a commit), `FieldRuntime.propose_action` (rollout + trace ref),
+`gate_tool` (status advance/return after the unchanged gate decision), and
+`close_tool`/`close_action` (reconciliation after the microtick). Action
+branch weight is `intention.confidence`; the no-action branch gets the
+remainder, so the distribution honestly models "the proposed action may not
+execute". Hooks and `.claude/settings.json` are unchanged; all learned state
+lives in SQLite because each hook is a fresh subprocess.
+
+## Configuration
+
+`mcpBehavior.toml` (re-read on every call, so live toggling works):
+
+```toml
+[individual-kernel]
+generative_field_model = true      # default on; writes are additive-only
+generative_rollout_horizon = 2     # 1..5
+```
+
+## Measurement
+
+`calibration.py` scores step-1 predictions against observed transitions:
+Brier, log loss, ECE (10 bins), top-1, per-component MAE, always next to
+persistence and uniform baselines, with a 20-sample reliability floor.
+`IndicatorProfile.prediction_calibration` becomes `1 - Brier` once enough
+resolutions exist and falls back to the legacy binary `prediction_match`
+otherwise (`prediction_calibration_detail` records which source produced the
+headline number). The benchmark writes `prediction-calibration.{json,md}`
+next to the indicator profile, and `run.py --check` fails if either mandated
+report is missing.
+
+MCP inspection surface: `rollout_protention`, `query_imagined_trajectories`,
+`query_experienced_transitions`, `get_generative_model_calibration`.
+
+## How later phases extend this layer
+
+- Allostatic valence: replace the desire-file EMA with
+  `AllostaticVariable`-based valence; `allostatic_snapshot_json` and the
+  arousal columns on transitions are already in place, and
+  `sum_valence_delta` in the stats feeds expected-improvement estimates.
+- Valence coupling: per-tick competition weights recorded in the epistemic
+  trace; the model's learning rate can be modulated per update.
+- BodyContingency: `pose_before_ref`/`pose_after_ref`/`body_delta_json` on
+  transitions take measured actuator deltas (e.g. the camera's ONVIF pose
+  readback) and replace the success-flag `exclusive_causal_fit` stub with a
+  reafference comparison.
+- Process-level HOR: `process_meta_ref` links transitions to
+  ProcessMetaRepresentation records; calibration errors feed precision
+  adjustments.
+- Experienced/told/imagined forks: forks are separate SQLite copies (several
+  kernel read paths are not owner-filtered, so owner namespacing would leak
+  evidence); `knowledge_source`, `info_content_hash`, and `fork_id` already
+  exist, and the `ExperiencedTransition` validator is the single place that
+  widens from `experienced`-only.
+- Organism daemon: fractional decay of `observation_count`, protention expiry
+  via `expires_at`/`expired`, and batch resolution of deeper steps, all
+  without an LLM in the loop.

--- a/docs/phenomenal-architecture-current-state.md
+++ b/docs/phenomenal-architecture-current-state.md
@@ -1,0 +1,107 @@
+# Phenomenal-Candidate Architecture: Current State Survey
+
+Status: survey completed 2026-07-26, at the start of the generative-field-model
+work. This document records what the EFPF (Enacted First-Person Field) runtime
+already implemented, what was partial, and the known hazards, so later phases
+can be reviewed against a fixed baseline.
+
+Claim policy: everything here describes implemented causal organization. It is
+not evidence of phenomenology and none of the indicators are a consciousness
+score.
+
+## Classification against the program specification
+
+### Implemented before this work
+
+- One committed self-world field per owner (`enacted_fields` with a partial
+  unique index enforcing the unity invariant), produced by workspace
+  competition over typed candidates (desire, event, interoception, memory,
+  previous field, scene, social, attention-schema/HOR self-model).
+- Explicit intention/outcome loop: `propose_field_action` with typed predicted
+  effects, exact tool-input hash gating in `PreToolUse`, outcome closure with a
+  five-channel mismatch vector and ownership scoring.
+- Counterfactual ledger, HOR records, attention schemas, quality signatures,
+  reversible field ablations, and a deterministic fail-closed boundary gate
+  that reads nothing from any predictive model.
+- Source modes live/inferred/remembered/imagined/mixed enforced at the DB
+  level for fields.
+
+### Partial before this work
+
+- `field_transitions` recorded state-to-state edges but carried no component
+  errors, no affect deltas, and only a binary `prediction_match`.
+- `QualityGeometry.predict_transition` already computed an action-conditioned
+  empirical transition distribution every commit, but keyed on exact content
+  refs (which embed ids/timestamps), so counts never accumulated, and nothing
+  read the result back. It remains untouched and is superseded by the
+  discretized count model.
+- `Protention` was a single next-candidate heuristic (the competition
+  runner-up), not action-conditioned; `Protention.action_ref` was declared but
+  never populated.
+- `agent_experiences` (sociality) stored rich experience rows but had no field
+  or tick foreign keys.
+- `TriggerKind.HEARTBEAT` was only half wired (cron prompt path) and
+  `TriggerKind.AUTONOMOUS` had no producer.
+
+### Not implemented before this work
+
+GenerativeFieldModel, FieldBelief, ImaginedTrajectory, ExperiencedTransition,
+ProtentionDistribution, action-conditioned rollout, online model update,
+Brier/log-loss/ECE calibration, allostatic valence, BodyContingency,
+process-level HOR, experienced/told/imagined separation experiments, and a
+non-LLM organism daemon.
+
+## Current tick lifecycle (before the generative layer)
+
+```mermaid
+flowchart TD
+    H[Claude Code hooks / efpf-hook CLI] --> B[begin_tick]
+    B --> C[gather workspace candidates:\ndesire, event, interoception,\nmemory HTTP, previous field, scene, social, self-model]
+    C --> W[WorkspaceEngine.compete]
+    W --> P[build single-candidate protention\n= competition runner-up]
+    P --> F[commit EnactedField\nunity invariant]
+    F --> A[attention schema + HOR + quality signature]
+    A --> T[record field_transition\nbinary prediction_match]
+    F --> G[gate_tool: intention hash, boundary, bottleneck]
+    G --> X[external tool executes]
+    X --> O[close outcome: mismatch vector, ownership]
+    O --> B
+```
+
+## Known hazards recorded at survey time
+
+- `predicted_next_focus` is written twice per commit from two different
+  predictors (protention at tick.py commit, then the attention schema).
+  Unchanged in this work; canonicalization is scheduled with the fork
+  experiments.
+- Workspace candidate scores are frozen at insert time, so learned weight
+  changes can only affect future ticks.
+- Valence was causally inert on the live path: computed only from the desire
+  file as an EMA of `-0.6 * max(discomforts)` (structurally never positive),
+  absent from competition weights and memory recall. The live
+  `~/.claude/desires.json` had been stale since 2026-05-18 with the
+  `desire-updater` cron not installed, pinning live valence at -0.30. The
+  allostatic rework owns the durable fix.
+- `InteroceptionState.controllability` was derived from discomfort and not
+  wired to the measured `ownership_score`.
+- `SleepConsolidator` was constructed without a quiet-hours predicate, so its
+  gate is always true in production wiring.
+- The mismatch-vector token overlap is ASCII-word based and degrades on
+  Japanese summaries (addressed in this change set by non-ASCII character
+  bigrams; embedding-based comparison is scheduled with the body-contingency
+  work).
+- `_bash_is_read_only` misclassifies quoted pipes (e.g. a `grep` pattern
+  containing `|`) and `git -C <dir> <subcommand>` as outward actions.
+  Documented here; fixing the gate classifier is intentionally out of scope
+  for the generative layer.
+- Heartbeat ticks pass no `user_text`, so they receive no memory candidates
+  from the HTTP recall path.
+
+## What the generative-field-model change set adds
+
+See `docs/generative-field-model-design.md` for the design that turns this
+baseline into a predict-act-observe-update loop: migration 009, the count
+model, imagined trajectories with a strict status lifecycle, experienced
+transitions with exactly-once learning, calibration metrics, and four MCP
+inspection tools, all behind the `[individual-kernel]` behavior flag with no
+change to action selection or the boundary gate.

--- a/mcpBehavior.toml
+++ b/mcpBehavior.toml
@@ -46,3 +46,7 @@ language = "ja"
 
 [ip-webcam]
 port = 8080
+
+[individual-kernel]
+generative_field_model = true      # 予測・学習ループ（追加テーブルへの書き込みのみ、行為選択は不変）
+generative_rollout_horizon = 2     # propose 時の rollout 深さ (1-5)

--- a/sociality-mcp/packages/social-core/src/social_core/migrations.py
+++ b/sociality-mcp/packages/social-core/src/social_core/migrations.py
@@ -406,6 +406,150 @@ CREATE INDEX IF NOT EXISTS idx_field_transitions_action
     ON field_transitions(action_id, created_at DESC);
 """
 
+_MIGRATION_009_SQL = """
+CREATE TABLE IF NOT EXISTS protention_distributions (
+    distribution_id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    field_id TEXT NOT NULL REFERENCES enacted_fields(field_id) ON DELETE CASCADE,
+    tick_id TEXT NOT NULL REFERENCES tick_frames(tick_id) ON DELETE CASCADE,
+    action_ref TEXT REFERENCES field_intentions(action_id) ON DELETE SET NULL,
+    entropy REAL NOT NULL,
+    model_version TEXT NOT NULL,
+    trajectory_count INTEGER NOT NULL,
+    fork_id TEXT,
+    created_at TEXT NOT NULL,
+    CHECK(entropy >= 0.0 AND entropy <= 1.0)
+);
+CREATE INDEX IF NOT EXISTS idx_protention_distributions_field
+    ON protention_distributions(field_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_protention_distributions_action
+    ON protention_distributions(action_ref);
+
+CREATE TABLE IF NOT EXISTS imagined_trajectories (
+    trajectory_id TEXT PRIMARY KEY,
+    distribution_id TEXT NOT NULL
+        REFERENCES protention_distributions(distribution_id) ON DELETE CASCADE,
+    owner_id TEXT NOT NULL,
+    field_id TEXT NOT NULL REFERENCES enacted_fields(field_id) ON DELETE CASCADE,
+    tick_id TEXT NOT NULL REFERENCES tick_frames(tick_id) ON DELETE CASCADE,
+    action_ref TEXT REFERENCES field_intentions(action_id) ON DELETE SET NULL,
+    action_kind TEXT NOT NULL,
+    context_signature TEXT NOT NULL,
+    horizon INTEGER NOT NULL,
+    steps_json TEXT NOT NULL,
+    probability REAL NOT NULL,
+    uncertainty REAL NOT NULL,
+    source_mode TEXT NOT NULL,
+    status TEXT NOT NULL,
+    status_history_json TEXT NOT NULL DEFAULT '[]',
+    expires_at TEXT,
+    fork_id TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    CHECK(status IN ('imagined','intended','enacted','observed',
+                     'contradicted','partially_observed','expired')),
+    CHECK(source_mode IN ('imagined')),
+    CHECK(probability >= 0.0 AND probability <= 1.0),
+    CHECK(horizon >= 1 AND horizon <= 5)
+);
+CREATE INDEX IF NOT EXISTS idx_imagined_trajectories_distribution
+    ON imagined_trajectories(distribution_id);
+CREATE INDEX IF NOT EXISTS idx_imagined_trajectories_action
+    ON imagined_trajectories(action_ref, status);
+CREATE INDEX IF NOT EXISTS idx_imagined_trajectories_field
+    ON imagined_trajectories(field_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS experienced_transitions (
+    transition_id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    previous_field_id TEXT REFERENCES enacted_fields(field_id) ON DELETE SET NULL,
+    next_field_id TEXT NOT NULL UNIQUE REFERENCES enacted_fields(field_id) ON DELETE CASCADE,
+    previous_tick_id TEXT,
+    next_tick_id TEXT NOT NULL,
+    action_ref TEXT REFERENCES field_intentions(action_id) ON DELETE SET NULL,
+    outcome_ref TEXT,
+    intended_trajectory_id TEXT
+        REFERENCES imagined_trajectories(trajectory_id) ON DELETE SET NULL,
+    distribution_id TEXT,
+    context_signature TEXT NOT NULL,
+    action_kind TEXT NOT NULL,
+    outcome_bucket TEXT NOT NULL,
+    observed_external_json TEXT NOT NULL DEFAULT '{}',
+    observed_internal_json TEXT NOT NULL DEFAULT '{}',
+    observed_social_json TEXT NOT NULL DEFAULT '{}',
+    prediction_errors_json TEXT NOT NULL DEFAULT '{}',
+    mean_prediction_error REAL NOT NULL,
+    valence_before REAL NOT NULL,
+    valence_after REAL NOT NULL,
+    valence_change REAL NOT NULL,
+    arousal_before REAL NOT NULL,
+    arousal_after REAL NOT NULL,
+    controllability_delta REAL NOT NULL DEFAULT 0.0,
+    agency_confidence REAL NOT NULL,
+    ownership_confidence REAL NOT NULL,
+    success INTEGER,
+    latency_ms INTEGER,
+    expected_latency_ms INTEGER,
+    source_mode TEXT NOT NULL,
+    knowledge_source TEXT NOT NULL DEFAULT 'experienced',
+    info_content_hash TEXT,
+    pose_before_ref TEXT,
+    pose_after_ref TEXT,
+    body_delta_json TEXT NOT NULL DEFAULT '{}',
+    process_meta_ref TEXT,
+    allostatic_snapshot_json TEXT NOT NULL DEFAULT '{}',
+    hor_ref TEXT,
+    fork_id TEXT,
+    applied_at TEXT,
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    CHECK(source_mode IN ('live','inferred','mixed')),
+    CHECK(knowledge_source IN ('experienced','told','imagined','replayed'))
+);
+CREATE INDEX IF NOT EXISTS idx_experienced_transitions_owner
+    ON experienced_transitions(owner_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_experienced_transitions_context
+    ON experienced_transitions(context_signature, action_kind);
+CREATE INDEX IF NOT EXISTS idx_experienced_transitions_action
+    ON experienced_transitions(action_ref);
+
+CREATE TABLE IF NOT EXISTS generative_transition_stats (
+    owner_id TEXT NOT NULL,
+    focus_kind TEXT NOT NULL,
+    trigger_kind TEXT NOT NULL,
+    dominant_desire TEXT NOT NULL DEFAULT '',
+    valence_bucket TEXT NOT NULL,
+    arousal_bucket TEXT NOT NULL,
+    action_kind TEXT NOT NULL,
+    outcome_bucket TEXT NOT NULL,
+    observation_count REAL NOT NULL DEFAULT 0,
+    sum_valence_delta REAL NOT NULL DEFAULT 0.0,
+    sum_latency_ms REAL NOT NULL DEFAULT 0.0,
+    sum_prediction_error REAL NOT NULL DEFAULT 0.0,
+    last_transition_id TEXT,
+    model_version TEXT NOT NULL DEFAULT 'count_v1',
+    first_observed_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (owner_id, focus_kind, trigger_kind, dominant_desire,
+                 valence_bucket, arousal_bucket, action_kind, outcome_bucket)
+);
+CREATE INDEX IF NOT EXISTS idx_generative_stats_action
+    ON generative_transition_stats(owner_id, action_kind, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS prediction_resolutions (
+    resolution_id TEXT PRIMARY KEY,
+    trajectory_id TEXT NOT NULL
+        REFERENCES imagined_trajectories(trajectory_id) ON DELETE CASCADE,
+    step_index INTEGER NOT NULL,
+    transition_id TEXT NOT NULL
+        REFERENCES experienced_transitions(transition_id) ON DELETE CASCADE,
+    hit INTEGER NOT NULL,
+    component_errors_json TEXT NOT NULL DEFAULT '{}',
+    resolved_at TEXT NOT NULL,
+    UNIQUE(trajectory_id, step_index)
+);
+"""
+
 
 MIGRATIONS = [
     Migration(
@@ -629,6 +773,10 @@ MIGRATIONS = [
     Migration(
         name="008_enacted_field_indexes",
         sql=_MIGRATION_008_SQL,
+    ),
+    Migration(
+        name="009_generative_field_model",
+        sql=_MIGRATION_009_SQL,
     ),
 ]
 

--- a/sociality-mcp/packages/social-core/tests/test_generative_field_model_migration.py
+++ b/sociality-mcp/packages/social-core/tests/test_generative_field_model_migration.py
@@ -1,0 +1,65 @@
+"""Migration 009 creates the generative-field-model tables."""
+
+from pathlib import Path
+
+from social_core.db import SocialDB
+
+EXPECTED_TABLES = {
+    "protention_distributions",
+    "imagined_trajectories",
+    "experienced_transitions",
+    "generative_transition_stats",
+    "prediction_resolutions",
+}
+
+
+def _table_names(db: SocialDB) -> set[str]:
+    rows = db.fetchall("SELECT name FROM sqlite_master WHERE type = 'table'")
+    return {row["name"] for row in rows}
+
+
+class TestGenerativeFieldModelMigration:
+    def test_migration_009_creates_all_tables(self, social_db: SocialDB) -> None:
+        assert EXPECTED_TABLES <= _table_names(social_db)
+
+    def test_migration_009_is_recorded(self, social_db: SocialDB) -> None:
+        row = social_db.fetchone(
+            "SELECT name FROM schema_migrations WHERE name = ?",
+            ("009_generative_field_model",),
+        )
+        assert row is not None
+
+    def test_migration_is_idempotent_across_reconnect(self, temp_db_path: Path) -> None:
+        first = SocialDB(temp_db_path)
+        first.connect()
+        first.close()
+        second = SocialDB(temp_db_path)
+        second.connect()
+        try:
+            assert EXPECTED_TABLES <= _table_names(second)
+        finally:
+            second.close()
+
+    def test_experienced_transitions_next_field_id_is_unique(
+        self, social_db: SocialDB
+    ) -> None:
+        indexes = social_db.fetchall("PRAGMA index_list('experienced_transitions')")
+        assert any(row["unique"] == 1 for row in indexes)
+
+    def test_imagined_trajectories_status_check_rejects_unknown_status(
+        self, social_db: SocialDB
+    ) -> None:
+        import sqlite3
+
+        import pytest
+
+        with pytest.raises(sqlite3.IntegrityError):
+            social_db.execute(
+                """
+                INSERT INTO protention_distributions(
+                    distribution_id, owner_id, field_id, tick_id, entropy,
+                    model_version, trajectory_count, created_at
+                ) VALUES ('prot_x', 'self', 'field_missing', 'tick_missing',
+                          0.5, 'count_v1', 1, '2026-01-01T00:00:00+00:00')
+                """
+            )


### PR DESCRIPTION
## Summary

Upgrades the EFPF from a state snapshot toward a dynamical-system state: each committed field now feeds a predict-act-observe-update loop.

- Registering an intention persists a ProtentionDistribution: >=2 action-conditioned imagined trajectories (top-2 outcome branches) plus exactly one no-action branch, probabilities summing to 1 (action weight = intention confidence).
- Every arrived-at field records one ExperiencedTransition with component prediction errors (mismatch 5ch + focus-kind + valence-delta + pre-update probability of the observed bucket) and affect deltas.
- A count-based Dirichlet model (`count_v1`) learns from each transition exactly once (`applied_at` claim + UNIQUE `next_field_id`, safe across hook subprocesses); the next rollout for the same (context, action) is measurably different.
- Trajectories follow a strict status lifecycle: imagined -> intended -> enacted -> observed | partially_observed | contradicted, with intended -> imagined on boundary denial or expiry; imagined records never auto-promote.
- Calibration: Brier / log loss / ECE / top-1 / per-component MAE with persistence and uniform baselines and a 20-sample reliability floor; `IndicatorProfile.prediction_calibration` upgrades to 1-Brier when reliable. The benchmark writes `prediction-calibration.{json,md}` and `run.py` gains `--check`.
- MCP inspection tools: `rollout_protention`, `query_imagined_trajectories`, `query_experienced_transitions`, `get_generative_model_calibration`.
- social-core migration `009_generative_field_model` (5 tables, with columns for later phases so they need no re-migration).
- Severable fix: the mismatch tokenizer compares non-ASCII runs as character bigrams, so Japanese summaries no longer inflate prediction error.

Additive-only and flag-guarded (`[individual-kernel]` in mcpBehavior.toml). Action selection, workspace competition, the `<current_field>` surface, boundary gate decisions, and hook config are unchanged; with the flag off the new tables stay empty and gate/commit outputs are identical (asserted in tests).

Design and baseline survey: `docs/generative-field-model-design.md`, `docs/phenomenal-architecture-current-state.md`.

Claim policy: this layer records and predicts functional state transitions; nothing here is a phenomenal claim.

## Acceptance (this slice)

- propose -> distribution with >=2 trajectories (exactly one no-action), probabilities sum to 1, modal branch -> intended
- gate allow -> enacted; boundary denial -> back to imagined; ToolGateDecision identical with flag on/off
- close -> ExperiencedTransition with full component-error keys -> trajectory reconciled (observed / partially_observed / contradicted)
- learning: re-rollout for the same (context, action) strictly increases P(observed bucket) and strictly decreases uncertainty; deterministic across fresh DBs; double-apply leaves counts unchanged (including across separate connections)
- flag off: zero rows in all new tables, unchanged gate/commit behavior

## Tests

- 257 passed (individual-kernel), 55 passed (social-core incl. migration 009); sociality suite 179 passed with 1 pre-existing time-of-day-dependent failure unrelated to this branch (`test_autonomous_with_dominant_desire_is_bounded` expects `act_autonomously`, but quiet-hours planning returns `write_private_reflection` when the suite runs in the JST night window; the orchestrator package has zero diff on this branch)
- `uv lock --check` clean; ruff clean on tracked packages
- `run.py --output-dir <dir> --check` writes `indicator-profile.{json,md}` and `prediction-calibration.{json,md}`

## Roadmap (PR-2 .. PR-7)

- PR-2: allostatic valence (AllostaticVariable, controllability wired to measured ownership, desire clock without cron)
- PR-3: valence causal propagation (competition weights, recall/encoding, learning rate) plus an intervention report
- PR-4: BodyContingency (migration 010, reafference test replacing the success-flag stub, embedding-based mismatch)
- PR-5: process-level HOR, precision feedback, report-independence measurement
- PR-6: experienced/told/imagined fork experiments (DB-copy forks, `knowledge_source` widening, `prediction_match` retirement)
- PR-7: organism daemon (desire drift, count decay, protention expiry, first `TriggerKind.AUTONOMOUS` producer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
