### PR TITLE
feat(individual-kernel): compose the body state as an allostatic variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to embodied-claude are documented here.
 
 ### Added
 
+- individual-kernel: allostatic body state, behind `allostatic_valence` in
+  `[individual-kernel]` (default off). Desire levels are re-derived from the
+  recorded snapshot plus elapsed time, so the kernel owns the clock and an
+  external writer that stops running costs accuracy rather than motion.
+  Valence becomes an appetitive term (expected improvement from the count
+  model, scaled by measured control) minus an aversive one (unmet needs,
+  uncertainty, unresolved prediction error), and can now be positive; the
+  previous rule was bounded above by zero. `controllability` follows the
+  measured `ownership_score` instead of restating discomfort. No migration is
+  needed: every input already existed. With the flag off the legacy arithmetic
+  is reproduced exactly.
+- individual-kernel: `CountBasedGenerativeFieldModel.expected_valence_delta`,
+  the bucket-probability-weighted estimate of how affect will move in a
+  context.
+- docs: `allostatic-valence-design.md`.
 - individual-kernel: generative field model (count_v1). Registering an
   intention now persists a ProtentionDistribution (action branch plus a
   no-action branch, probabilities summing to 1); every arrived-at field
@@ -34,6 +49,11 @@ All notable changes to embodied-claude are documented here.
 
 ### Fixed
 
+- docs: `phenomenal-architecture-current-state.md` said the `desire-updater`
+  cron was not installed. It was installed, and had been failing silently
+  since 2026-05-13: first because `uv` was missing from cron's PATH, then
+  because the repository moved out of the working directory the crontab entry
+  changes into.
 - individual-kernel: the mismatch-vector tokenizer now compares non-ASCII
   runs as character bigrams, so Japanese result summaries no longer inflate
   prediction error and deflate ownership scores. ASCII behavior is unchanged.

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/allostasis.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/allostasis.py
@@ -1,0 +1,243 @@
+"""Allostatic body state: desire projection and valence composition.
+
+Two problems in the previous body state are addressed here.
+
+The desire file is written by an external updater on a timer. When that timer
+stops, every level freezes at whatever was last written. `project_desires`
+re-derives current levels from the recorded snapshot plus elapsed time, so the
+writer only supplies corrections and the kernel owns the clock.
+
+Valence was `-0.6 * max_discomfort`, whose upper bound is zero: no outcome could
+produce a positive state. `compose_valence` builds it from an appetitive term
+(expected improvement, weighted by how much control we actually measured) minus
+an aversive term (unmet needs, uncertainty, unresolved prediction error).
+
+Everything here is a pure function of its arguments, including `now`, so the
+caller supplies the clock and tests stay deterministic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+JST = timezone(timedelta(hours=9))
+
+# Weights for the two valence terms. Chosen so that a fully good context reaches
+# +1 and a fully bad one reaches -1; see tests/test_valence_composition.py.
+APPETITIVE_GAIN = 1.0
+DISCOMFORT_WEIGHT = 0.55
+UNCERTAINTY_WEIGHT = 0.25
+UNRESOLVED_ERROR_WEIGHT = 0.20
+
+
+@dataclass(frozen=True)
+class DesireSpec:
+    """How one need grows over time and where it is comfortable."""
+
+    satisfaction_hours: float
+    set_point: float
+
+
+# Mirrors desire-system/desire_updater.py. That package has its own virtualenv
+# and is not part of this workspace, so the constants are duplicated rather than
+# imported; mcpBehavior.toml can override them without touching code.
+DEFAULT_DESIRE_SPECS: dict[str, DesireSpec] = {
+    "look_outside": DesireSpec(satisfaction_hours=1.0, set_point=0.3),
+    "browse_curiosity": DesireSpec(satisfaction_hours=2.0, set_point=0.3),
+    "miss_companion": DesireSpec(satisfaction_hours=3.0, set_point=0.3),
+    "miss_kouta": DesireSpec(satisfaction_hours=3.0, set_point=0.3),
+    "observe_room": DesireSpec(satisfaction_hours=0.167, set_point=0.2),
+    "identity_coherence": DesireSpec(satisfaction_hours=1.0, set_point=0.9),
+    "cognitive_load": DesireSpec(satisfaction_hours=1.5, set_point=0.3),
+}
+
+FALLBACK_SPEC = DesireSpec(satisfaction_hours=2.0, set_point=0.3)
+
+
+@dataclass(frozen=True)
+class DesireProjection:
+    """Desire levels re-derived for a specific instant."""
+
+    desires: dict[str, float]
+    discomforts: dict[str, float]
+    dominant: str | None
+    stale_seconds: float
+
+    @property
+    def mean_discomfort(self) -> float:
+        if not self.discomforts:
+            return 0.0
+        return sum(self.discomforts.values()) / len(self.discomforts)
+
+
+@dataclass(frozen=True)
+class AllostaticVariable:
+    """The composed body state, with its terms kept separable for inspection."""
+
+    appetitive: float
+    aversive: float
+    controllability: float
+    uncertainty: float
+    unresolved_error: float
+    expected_valence_delta: float
+
+    @property
+    def valence(self) -> float:
+        return _clamp(self.appetitive - self.aversive, -1.0, 1.0)
+
+    def as_snapshot(self) -> dict[str, float]:
+        return {
+            "valence": self.valence,
+            "appetitive": self.appetitive,
+            "aversive": self.aversive,
+            "controllability": self.controllability,
+            "uncertainty": self.uncertainty,
+            "unresolved_error": self.unresolved_error,
+            "expected_valence_delta": self.expected_valence_delta,
+        }
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
+
+
+def _clamp01(value: float) -> float:
+    return _clamp(value, 0.0, 1.0)
+
+
+def extrapolate_desire_level(
+    recorded_level: float,
+    recorded_at: datetime,
+    satisfaction_hours: float,
+    now: datetime,
+) -> float:
+    """Advance a recorded level to ``now``.
+
+    Levels grow linearly as ``elapsed / satisfaction_hours``, so the recorded
+    level implies when the need was last met and the same ramp can be evaluated
+    at any later instant. A level already at 1.0 carries no such implication and
+    stays saturated. Time running backwards (clock skew, a snapshot written by a
+    machine slightly ahead) never lowers the level below what was recorded.
+    """
+
+    level = _clamp01(recorded_level)
+    if satisfaction_hours <= 0.0 or level >= 1.0:
+        return 1.0
+    elapsed_hours = (now - recorded_at).total_seconds() / 3600.0
+    if elapsed_hours <= 0.0:
+        return level
+    return _clamp01(level + elapsed_hours / satisfaction_hours)
+
+
+def allostatic_set_point(name: str, spec: DesireSpec, now: datetime) -> float:
+    """Adjust a set point for the time of day.
+
+    Being alone at 3am is not the same as being alone at noon, so the social and
+    outward-looking needs settle overnight. Identity coherence does not: it is
+    wanted equally at every hour.
+    """
+
+    if name == "identity_coherence":
+        return spec.set_point
+    hour = now.astimezone(JST).hour
+    if 0 <= hour < 5:
+        if name in ("miss_companion", "miss_kouta"):
+            return max(0.0, spec.set_point - 0.15)
+        if name in ("look_outside", "observe_room"):
+            return max(0.0, spec.set_point - 0.1)
+    if 5 <= hour < 7 and name in ("miss_companion", "miss_kouta"):
+        return max(0.0, spec.set_point - 0.05)
+    return spec.set_point
+
+
+def _parse_timestamp(raw: Any) -> datetime | None:
+    if not isinstance(raw, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def project_desires(
+    snapshot: dict[str, Any],
+    now: datetime,
+    specs: dict[str, DesireSpec] | None = None,
+) -> DesireProjection:
+    """Re-derive desire levels and discomforts for ``now``.
+
+    An unreadable or absent timestamp is treated as "just written": the recorded
+    levels are used as-is rather than extrapolated from a guessed instant.
+    """
+
+    specs = specs or DEFAULT_DESIRE_SPECS
+    recorded = snapshot.get("desires") or {}
+    if not isinstance(recorded, dict) or not recorded:
+        return DesireProjection({}, {}, None, 0.0)
+
+    recorded_at = _parse_timestamp(snapshot.get("updated_at"))
+    stale_seconds = (
+        max(0.0, (now - recorded_at).total_seconds()) if recorded_at else 0.0
+    )
+
+    desires: dict[str, float] = {}
+    discomforts: dict[str, float] = {}
+    for name, raw_level in recorded.items():
+        try:
+            level = float(raw_level)
+        except (TypeError, ValueError):
+            continue
+        spec = specs.get(str(name), FALLBACK_SPEC)
+        projected = (
+            extrapolate_desire_level(level, recorded_at, spec.satisfaction_hours, now)
+            if recorded_at
+            else _clamp01(level)
+        )
+        desires[str(name)] = projected
+        discomforts[str(name)] = abs(
+            projected - allostatic_set_point(str(name), spec, now)
+        )
+
+    dominant = (
+        max(sorted(discomforts), key=lambda name: discomforts[name])
+        if discomforts
+        else None
+    )
+    return DesireProjection(desires, discomforts, dominant, stale_seconds)
+
+
+def compose_valence(
+    expected_valence_delta: float,
+    mean_discomfort: float,
+    controllability: float,
+    uncertainty: float,
+    unresolved_error: float,
+) -> AllostaticVariable:
+    """Combine an appetitive and an aversive term into a body state.
+
+    Expected improvement only counts to the extent it is actually reachable, so
+    it is scaled by measured controllability; an expected gain nobody can bring
+    about is not good news. Expected worsening is aversive on its own terms and
+    is not discounted that way.
+    """
+
+    delta = _clamp(expected_valence_delta, -1.0, 1.0)
+    control = _clamp01(controllability)
+    appetitive = APPETITIVE_GAIN * max(0.0, delta) * control
+    aversive = (
+        max(0.0, -delta)
+        + DISCOMFORT_WEIGHT * _clamp01(mean_discomfort)
+        + UNCERTAINTY_WEIGHT * _clamp01(uncertainty)
+        + UNRESOLVED_ERROR_WEIGHT * _clamp01(unresolved_error)
+    )
+    return AllostaticVariable(
+        appetitive=appetitive,
+        aversive=aversive,
+        controllability=control,
+        uncertainty=_clamp01(uncertainty),
+        unresolved_error=_clamp01(unresolved_error),
+        expected_valence_delta=delta,
+    )

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/generative_model.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/generative_model.py
@@ -432,6 +432,24 @@ class CountBasedGenerativeFieldModel:
                 return prediction.probability, forecast.basis, forecast.uncertainty
         return forecast.novel_probability, forecast.basis, forecast.uncertainty
 
+    def expected_valence_delta(self, signature: ContextSignature) -> float:
+        """How much affect this context is expected to move, in [-1, 1].
+
+        Each reachable outcome bucket contributes its learned mean valence
+        change, weighted by how likely that bucket is. With no history the
+        forecast falls back to the uniform prior, whose buckets carry small
+        symmetric deltas, so the estimate sits near zero rather than inventing
+        an expectation.
+        """
+
+        forecast = self.forecast(signature)
+        expected = sum(
+            prediction.probability
+            * self._mean_valence_delta(signature, prediction.bucket)
+            for prediction in forecast.predictions
+        )
+        return max(-1.0, min(1.0, expected))
+
     def _mean_valence_delta(self, signature: ContextSignature, bucket: str) -> float:
         for filters in signature.backoff_chain():
             clauses = ["owner_id = ?", "outcome_bucket = ?"]

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/tick.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/tick.py
@@ -10,7 +10,7 @@ import tempfile
 import urllib.parse
 import urllib.request
 from collections.abc import Callable, Iterable
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +20,7 @@ from social_core.events import EventStore
 from social_core.models import SocialEventCreate
 from social_core.time import utc_now
 
+from individual_kernel_mcp._behavior import get_behavior
 from individual_kernel_mcp.agency import (
     ActionOutcome,
     ActionProposal,
@@ -28,6 +29,7 @@ from individual_kernel_mcp.agency import (
     IntentionRecord,
     is_external_tool,
 )
+from individual_kernel_mcp.allostasis import compose_valence, project_desires
 from individual_kernel_mcp.attention_schema import AttentionSchema, AttentionSchemaTracker
 from individual_kernel_mcp.bottleneck import ActionBottleneck
 from individual_kernel_mcp.counterfactual import CounterfactualStore
@@ -43,6 +45,7 @@ from individual_kernel_mcp.enacted_field import (
     TriggerKind,
 )
 from individual_kernel_mcp.frame import ConsciousFrameInput, TickFrameStore
+from individual_kernel_mcp.generative_model import NO_ACTION, ContextSignature
 from individual_kernel_mcp.hor import HORInput, HORRecord, HORStore
 from individual_kernel_mcp.prediction_loop import FieldPredictionLoop, generative_enabled
 from individual_kernel_mcp.quality_geometry import QualityGeometry, QualitySignature
@@ -97,6 +100,15 @@ class TemporalSequenceMetrics(BaseModel):
 
 
 BoundaryEvaluator = Callable[[str, dict[str, Any], EnactedField], tuple[bool, str]]
+
+# Control and surprise both default to the midpoint when nothing has been
+# measured yet, so an unmeasured body state is neither confident nor alarmed.
+UNMEASURED_CONTROLLABILITY = 0.5
+UNRESOLVED_ERROR_WHEN_UNKNOWN = 0.5
+
+
+def allostatic_enabled() -> bool:
+    return bool(get_behavior("individual-kernel", "allostatic_valence", False))
 
 
 def default_interoception_path() -> Path:
@@ -872,6 +884,87 @@ class TickProducer:
             )
 
     def _read_interoception(
+        self,
+        previous: EnactedField | None,
+    ) -> InteroceptionState:
+        if allostatic_enabled():
+            try:
+                return self._allostatic_interoception(previous)
+            except Exception:
+                # The body state must always be producible; fall back rather
+                # than block a tick on a prediction or storage fault.
+                pass
+        return self._legacy_interoception(previous)
+
+    def _measured_controllability(self, previous: EnactedField | None) -> float:
+        """Control as actually measured, not as inferred from discomfort.
+
+        Ownership is only meaningful once an intention has been registered and
+        closed; before that there is nothing measured to report, so the neutral
+        midpoint stands in.
+        """
+
+        if previous is None:
+            return UNMEASURED_CONTROLLABILITY
+        agency = previous.agency_state
+        if agency is None or not agency.registered_intention:
+            return UNMEASURED_CONTROLLABILITY
+        return _clamp01(agency.ownership_score)
+
+    def _expected_valence_delta(self, previous: EnactedField | None) -> float:
+        if previous is None:
+            return 0.0
+        signature = ContextSignature.from_field(previous, action_kind=NO_ACTION)
+        return self.prediction.model.expected_valence_delta(signature)
+
+    def _unresolved_prediction_error(self) -> float:
+        recent = self.prediction.transitions.query(limit=1)
+        if not recent:
+            return UNRESOLVED_ERROR_WHEN_UNKNOWN
+        return _clamp01(recent[0].mean_prediction_error)
+
+    def _allostatic_interoception(
+        self,
+        previous: EnactedField | None,
+    ) -> InteroceptionState:
+        """Body state composed from projected needs and the learned model."""
+
+        raw = self._read_json(self.interoception_path)
+        now_readings = raw.get("now") or {}
+        # utc_now() yields an ISO string for storage; the projection needs a
+        # real instant to subtract from.
+        projection = project_desires(
+            self._read_json(self.desires_path), now=datetime.now(timezone.utc)
+        )
+        control = self._measured_controllability(previous)
+        uncertainty = 0.35 if raw else 0.6
+        state = compose_valence(
+            expected_valence_delta=self._expected_valence_delta(previous),
+            mean_discomfort=projection.mean_discomfort,
+            controllability=control,
+            uncertainty=uncertainty,
+            unresolved_error=self._unresolved_prediction_error(),
+        )
+        valence = state.valence
+        arousal = _clamp01(float(now_readings.get("arousal", 0.0)) / 100.0)
+        exposure = 0.0
+        if previous and valence < -0.2:
+            exposure = min(
+                86400.0,
+                previous.interoception.negative_exposure_seconds
+                + max(0.0, _seconds_between(previous.updated_at, utc_now())),
+            )
+        return InteroceptionState(
+            valence=valence,
+            arousal=arousal,
+            uncertainty=uncertainty,
+            controllability=control,
+            need_vector=projection.discomforts or projection.desires,
+            resource_refs=([str(self.interoception_path)] if raw else []),
+            negative_exposure_seconds=exposure,
+        )
+
+    def _legacy_interoception(
         self,
         previous: EnactedField | None,
     ) -> InteroceptionState:

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_allostasis.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_allostasis.py
@@ -1,0 +1,106 @@
+"""Desire projection under a stalled writer, and valence composition.
+
+The desire file is produced by an external updater that can stop running. These
+tests pin the contract that the kernel re-derives current levels from the
+recorded snapshot plus elapsed time, so a stalled writer degrades gracefully
+instead of freezing the body state.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from individual_kernel_mcp.allostasis import (
+    DEFAULT_DESIRE_SPECS,
+    allostatic_set_point,
+    extrapolate_desire_level,
+    project_desires,
+)
+
+UTC = timezone.utc
+T0 = datetime(2026, 7, 27, 3, 0, tzinfo=UTC)
+
+
+class TestExtrapolateDesireLevel:
+    def test_level_grows_with_elapsed_time(self) -> None:
+        level = extrapolate_desire_level(0.25, T0, 4.0, T0 + timedelta(hours=2))
+        assert level == pytest.approx(0.75)
+
+    def test_saturated_level_stays_saturated(self) -> None:
+        level = extrapolate_desire_level(1.0, T0, 2.0, T0 + timedelta(days=30))
+        assert level == 1.0
+
+    def test_long_stall_saturates_instead_of_overflowing(self) -> None:
+        level = extrapolate_desire_level(0.4, T0, 1.0, T0 + timedelta(days=70))
+        assert level == 1.0
+
+    def test_clock_skew_backwards_does_not_reduce_below_recorded(self) -> None:
+        level = extrapolate_desire_level(0.4, T0, 1.0, T0 - timedelta(hours=5))
+        assert level == pytest.approx(0.4)
+
+    def test_zero_cycle_is_treated_as_saturated(self) -> None:
+        assert extrapolate_desire_level(0.4, T0, 0.0, T0) == 1.0
+
+
+class TestAllostaticSetPoint:
+    def test_identity_coherence_is_time_invariant(self) -> None:
+        spec = DEFAULT_DESIRE_SPECS["identity_coherence"]
+        night = datetime(2026, 7, 27, 17, 0, tzinfo=UTC)  # 02:00 JST
+        noon = datetime(2026, 7, 27, 3, 0, tzinfo=UTC)  # 12:00 JST
+        assert allostatic_set_point("identity_coherence", spec, night) == spec.set_point
+        assert allostatic_set_point("identity_coherence", spec, noon) == spec.set_point
+
+    def test_companion_set_point_drops_at_night(self) -> None:
+        spec = DEFAULT_DESIRE_SPECS["miss_companion"]
+        night = datetime(2026, 7, 27, 17, 0, tzinfo=UTC)  # 02:00 JST
+        noon = datetime(2026, 7, 27, 3, 0, tzinfo=UTC)  # 12:00 JST
+        assert allostatic_set_point("miss_companion", spec, night) < allostatic_set_point(
+            "miss_companion", spec, noon
+        )
+
+    def test_unknown_desire_falls_back_to_its_own_set_point(self) -> None:
+        spec = DEFAULT_DESIRE_SPECS["browse_curiosity"]
+        assert allostatic_set_point("not_a_real_desire", spec, T0) == spec.set_point
+
+
+class TestProjectDesires:
+    def test_stalled_snapshot_still_moves(self) -> None:
+        """The live failure mode: the writer stopped months ago."""
+        snapshot = {
+            "updated_at": "2026-05-18T02:04:32+00:00",
+            "desires": {"browse_curiosity": 0.2, "identity_coherence": 0.4},
+            "discomforts": {"identity_coherence": 0.5},
+        }
+        projected = project_desires(snapshot, now=T0)
+        assert projected.desires["browse_curiosity"] > 0.2
+        assert projected.stale_seconds > 30 * 24 * 3600
+
+    def test_dominant_is_the_largest_discomfort(self) -> None:
+        snapshot = {
+            "updated_at": T0.isoformat(),
+            "desires": {"browse_curiosity": 0.3, "identity_coherence": 0.1},
+        }
+        projected = project_desires(snapshot, now=T0)
+        # identity_coherence sits far below its 0.9 set point, so it dominates.
+        assert projected.dominant == "identity_coherence"
+
+    def test_discomfort_is_distance_from_set_point(self) -> None:
+        snapshot = {
+            "updated_at": T0.isoformat(),
+            "desires": {"identity_coherence": 0.9},
+        }
+        projected = project_desires(snapshot, now=T0)
+        assert projected.discomforts["identity_coherence"] == pytest.approx(0.0)
+
+    def test_missing_file_yields_empty_projection(self) -> None:
+        projected = project_desires({}, now=T0)
+        assert projected.desires == {}
+        assert projected.dominant is None
+
+    def test_unparsable_timestamp_is_treated_as_no_elapsed_time(self) -> None:
+        snapshot = {"updated_at": "not-a-date", "desires": {"browse_curiosity": 0.2}}
+        projected = project_desires(snapshot, now=T0)
+        assert projected.desires["browse_curiosity"] == pytest.approx(0.2)
+        assert projected.stale_seconds == 0.0

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_allostatic_integration.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_allostatic_integration.py
@@ -1,0 +1,160 @@
+"""The tick runtime's body state on either side of the allostatic switch.
+
+With the flag off the legacy arithmetic must be reproduced exactly; with it on
+the body state must stop being pinned by a desire file that nobody is updating.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from social_core.db import SocialDB
+
+from individual_kernel_mcp.enacted_field import EnactedField, TriggerKind
+from individual_kernel_mcp.tick import TickProducer
+from individual_kernel_mcp.workspace import (
+    CandidateKind,
+    CandidateSource,
+    SourceMode,
+    WorkspaceCandidate,
+)
+
+# The live desire file has not been rewritten since this instant.
+STALE = "2026-05-18T02:04:32+00:00"
+
+
+@pytest.fixture
+def behavior(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    def _configure(*, allostatic: bool) -> None:
+        path = tmp_path / "mcpBehavior.toml"
+        path.write_text(
+            "[individual-kernel]\n"
+            f"allostatic_valence = {'true' if allostatic else 'false'}\n"
+            "generative_field_model = false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("MCP_BEHAVIOR_TOML", str(path))
+
+    return _configure
+
+
+def _producer(social_db: SocialDB, tmp_path: Path) -> TickProducer:
+    interoception = tmp_path / "interoception.json"
+    interoception.write_text(json.dumps({"now": {"arousal": 20.0}}), encoding="utf-8")
+    desires = tmp_path / "desires.json"
+    desires.write_text(
+        json.dumps(
+            {
+                "updated_at": STALE,
+                "desires": {"identity_coherence": 0.4},
+                "discomforts": {"identity_coherence": 0.5},
+                "dominant": "identity_coherence",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return TickProducer(
+        social_db, interoception_path=interoception, desires_path=desires
+    )
+
+
+def _commit(producer: TickProducer) -> EnactedField:
+    opened = producer.begin_tick(TriggerKind.USER_PROMPT)
+    producer.workspace.add_candidate(
+        WorkspaceCandidate(
+            tick_id=opened.tick_id,
+            kind=CandidateKind.GOAL,
+            content_ref="desire:identity_coherence",
+            content_summary="need identity_coherence",
+            source=CandidateSource.DESIRE,
+            source_mode=SourceMode.INFERRED,
+            modality="internal",
+            precision=1.0,
+            need_relevance=1.0,
+            goal_relevance=1.0,
+            continuity_with_previous=1.0,
+            controllability=1.0,
+        )
+    )
+    return producer.compete_and_commit(opened.tick_id).field
+
+
+class TestFlagOff:
+    def test_legacy_valence_is_reproduced_exactly(
+        self, social_db: SocialDB, tmp_path: Path, behavior
+    ) -> None:
+        behavior(allostatic=False)
+        field = _commit(_producer(social_db, tmp_path))
+        # 0.65 * 0.0 + 0.35 * (-0.6 * 0.5)
+        assert field.interoception.valence == pytest.approx(-0.105)
+
+    def test_legacy_controllability_is_reproduced_exactly(
+        self, social_db: SocialDB, tmp_path: Path, behavior
+    ) -> None:
+        behavior(allostatic=False)
+        field = _commit(_producer(social_db, tmp_path))
+        # 0.45 + 0.25 * (1 - 0.5)
+        assert field.interoception.controllability == pytest.approx(0.575)
+
+    def test_legacy_need_vector_is_the_recorded_discomforts(
+        self, social_db: SocialDB, tmp_path: Path, behavior
+    ) -> None:
+        behavior(allostatic=False)
+        field = _commit(_producer(social_db, tmp_path))
+        assert field.interoception.need_vector == {"identity_coherence": 0.5}
+
+
+class TestFlagOn:
+    def test_stale_desire_file_no_longer_pins_the_need(
+        self, social_db: SocialDB, tmp_path: Path, behavior
+    ) -> None:
+        """The recorded discomfort was 0.5 and the file has not moved since May."""
+        behavior(allostatic=True)
+        field = _commit(_producer(social_db, tmp_path))
+        need = field.interoception.need_vector["identity_coherence"]
+        assert need != pytest.approx(0.5)
+
+    def test_valence_stays_in_range(
+        self, social_db: SocialDB, tmp_path: Path, behavior
+    ) -> None:
+        behavior(allostatic=True)
+        field = _commit(_producer(social_db, tmp_path))
+        assert -1.0 <= field.interoception.valence <= 1.0
+
+    def test_controllability_is_no_longer_derived_from_discomfort(
+        self, social_db: SocialDB, tmp_path: Path, behavior
+    ) -> None:
+        behavior(allostatic=True)
+        field = _commit(_producer(social_db, tmp_path))
+        assert field.interoception.controllability != pytest.approx(0.575)
+
+    def test_controllability_follows_a_measured_ownership_score(
+        self, social_db: SocialDB, tmp_path: Path, behavior
+    ) -> None:
+        """Once an action has actually been owned, control reflects that score."""
+        behavior(allostatic=True)
+        producer = _producer(social_db, tmp_path)
+        first = _commit(producer)
+        producer.fields.update(
+            first.model_copy(
+                update={
+                    "agency_state": first.agency_state.model_copy(
+                        update={
+                            "registered_intention": True,
+                            "ownership_score": 0.82,
+                        }
+                    )
+                }
+            )
+        )
+        second = _commit(producer)
+        assert second.interoception.controllability == pytest.approx(0.82)
+
+    def test_body_state_is_not_the_legacy_value(
+        self, social_db: SocialDB, tmp_path: Path, behavior
+    ) -> None:
+        behavior(allostatic=True)
+        field = _commit(_producer(social_db, tmp_path))
+        assert field.interoception.valence != pytest.approx(-0.105)

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_expected_valence_delta.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_expected_valence_delta.py
@@ -1,0 +1,86 @@
+"""The model's bucket-weighted estimate of how affect will move.
+
+This is what turns learned transition counts into an appetitive signal: given a
+context, how much is valence expected to change, averaging over the outcomes
+that context actually produced.
+"""
+
+from __future__ import annotations
+
+import pytest
+from social_core.db import SocialDB
+
+from individual_kernel_mcp.generative_model import (
+    ContextSignature,
+    CountBasedGenerativeFieldModel,
+)
+
+SIGNATURE = ContextSignature(
+    focus_kind="desire",
+    trigger_kind="tool_result",
+    dominant_desire="identity_coherence",
+    valence_bucket="neg",
+    arousal_bucket="low",
+    action_kind="tool:Write",
+)
+
+
+def _seed(
+    db: SocialDB,
+    bucket: str,
+    observations: float,
+    sum_valence_delta: float,
+) -> None:
+    db.execute(
+        "INSERT INTO generative_transition_stats ("
+        "owner_id, focus_kind, trigger_kind, dominant_desire, valence_bucket, "
+        "arousal_bucket, action_kind, outcome_bucket, observation_count, "
+        "sum_valence_delta, sum_latency_ms, sum_prediction_error, "
+        "model_version, first_observed_at, updated_at"
+        ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 'count_v1', ?, ?)",
+        (
+            "self",
+            SIGNATURE.focus_kind,
+            SIGNATURE.trigger_kind,
+            SIGNATURE.dominant_desire,
+            SIGNATURE.valence_bucket,
+            SIGNATURE.arousal_bucket,
+            SIGNATURE.action_kind,
+            bucket,
+            observations,
+            sum_valence_delta,
+            "2026-07-27T00:00:00+00:00",
+            "2026-07-27T00:00:00+00:00",
+        ),
+    )
+
+
+def _model(db: SocialDB) -> CountBasedGenerativeFieldModel:
+    return CountBasedGenerativeFieldModel(db)
+
+
+class TestExpectedValenceDelta:
+    def test_no_history_is_neutral(self, social_db: SocialDB) -> None:
+        assert _model(social_db).expected_valence_delta(SIGNATURE) == pytest.approx(
+            0.0, abs=0.15
+        )
+
+    def test_improving_context_is_positive(self, social_db: SocialDB) -> None:
+        _seed(social_db, "ok/short/desire/+", observations=20.0, sum_valence_delta=4.0)
+        assert _model(social_db).expected_valence_delta(SIGNATURE) > 0.0
+
+    def test_worsening_context_is_negative(self, social_db: SocialDB) -> None:
+        _seed(social_db, "ok/short/desire/-", observations=20.0, sum_valence_delta=-4.0)
+        assert _model(social_db).expected_valence_delta(SIGNATURE) < 0.0
+
+    def test_mixed_history_is_weighted_by_outcome_probability(
+        self, social_db: SocialDB
+    ) -> None:
+        # Improvement is rare, worsening is common: the estimate leans negative.
+        _seed(social_db, "ok/short/desire/+", observations=1.0, sum_valence_delta=0.5)
+        _seed(social_db, "ok/short/desire/-", observations=19.0, sum_valence_delta=-3.8)
+        assert _model(social_db).expected_valence_delta(SIGNATURE) < 0.0
+
+    def test_estimate_stays_within_unit_range(self, social_db: SocialDB) -> None:
+        _seed(social_db, "ok/short/desire/+", observations=2.0, sum_valence_delta=99.0)
+        assert _model(social_db).expected_valence_delta(SIGNATURE) <= 1.0

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_valence_composition.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_valence_composition.py
@@ -1,0 +1,100 @@
+"""Valence is composed from appetitive and aversive terms.
+
+The legacy rule was `-0.6 * max_discomfort`, whose upper bound is zero: no
+outcome could ever produce a positive body state. These tests pin the replacement
+contract, above all that a well-predicted, controllable, improving context does
+produce positive valence.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from individual_kernel_mcp.allostasis import AllostaticVariable, compose_valence
+
+
+def _compose(**overrides: float) -> AllostaticVariable:
+    base: dict[str, float] = {
+        "expected_valence_delta": 0.0,
+        "mean_discomfort": 0.0,
+        "controllability": 0.5,
+        "uncertainty": 0.5,
+        "unresolved_error": 0.5,
+    }
+    base.update(overrides)
+    return compose_valence(**base)
+
+
+class TestValenceRange:
+    def test_valence_stays_within_bounds(self) -> None:
+        best = _compose(
+            expected_valence_delta=1.0,
+            mean_discomfort=0.0,
+            controllability=1.0,
+            uncertainty=0.0,
+            unresolved_error=0.0,
+        )
+        worst = _compose(
+            expected_valence_delta=-1.0,
+            mean_discomfort=1.0,
+            controllability=0.0,
+            uncertainty=1.0,
+            unresolved_error=1.0,
+        )
+        assert -1.0 <= worst.valence <= best.valence <= 1.0
+
+    def test_good_context_produces_positive_valence(self) -> None:
+        """The property the legacy formula could not express."""
+        state = _compose(
+            expected_valence_delta=0.5,
+            mean_discomfort=0.05,
+            controllability=0.9,
+            uncertainty=0.1,
+            unresolved_error=0.1,
+        )
+        assert state.valence > 0.0
+
+    def test_bad_context_produces_negative_valence(self) -> None:
+        state = _compose(
+            expected_valence_delta=-0.3,
+            mean_discomfort=0.8,
+            controllability=0.1,
+            uncertainty=0.9,
+            unresolved_error=0.9,
+        )
+        assert state.valence < 0.0
+
+
+class TestMonotonicity:
+    def test_more_expected_improvement_raises_valence(self) -> None:
+        low = _compose(expected_valence_delta=0.0)
+        high = _compose(expected_valence_delta=0.6)
+        assert high.valence > low.valence
+
+    def test_more_discomfort_lowers_valence(self) -> None:
+        low = _compose(mean_discomfort=0.1)
+        high = _compose(mean_discomfort=0.9)
+        assert high.valence < low.valence
+
+    def test_control_raises_valence_when_improvement_is_expected(self) -> None:
+        weak = _compose(expected_valence_delta=0.5, controllability=0.1)
+        strong = _compose(expected_valence_delta=0.5, controllability=0.9)
+        assert strong.valence > weak.valence
+
+    def test_unresolved_error_lowers_valence(self) -> None:
+        settled = _compose(unresolved_error=0.0)
+        surprised = _compose(unresolved_error=1.0)
+        assert surprised.valence < settled.valence
+
+
+class TestComponentsAreInspectable:
+    def test_terms_are_reported_separately(self) -> None:
+        state = _compose(expected_valence_delta=0.4, mean_discomfort=0.2)
+        assert state.appetitive >= 0.0
+        assert state.aversive >= 0.0
+        assert state.valence == pytest.approx(state.appetitive - state.aversive, abs=1e-9)
+
+    def test_snapshot_round_trips_as_plain_json_types(self) -> None:
+        snapshot = _compose(expected_valence_delta=0.4).as_snapshot()
+        assert set(snapshot) >= {"valence", "appetitive", "aversive", "controllability"}
+        assert all(isinstance(value, float) for value in snapshot.values())

--- a/docs/allostatic-valence-design.md
+++ b/docs/allostatic-valence-design.md
@@ -1,0 +1,120 @@
+# Allostatic Valence Design
+
+Status: shipped 2026-07-27 on the `feat/allostatic-valence` branch, behind
+`[individual-kernel] allostatic_valence`, which defaults to **off**. Scope: the
+body state only. Action selection, workspace competition, the `<current_field>`
+surface, and the boundary gate are unchanged.
+
+Claim policy: this layer computes a functional affect variable. Nothing in it is
+a phenomenal claim.
+
+## Two defects in the previous body state
+
+**Valence could not be positive.** It was an EMA whose target was
+`-0.6 * max(discomfort)`, so the upper bound was exactly zero. A run of
+well-predicted, successful actions moved it toward 0 and no further; nothing
+could register as going well.
+
+**The needs had stopped moving.** Desire levels came from a file written by an
+external updater on a 5-minute timer. That timer had been dead since
+2026-05-13, so every level was frozen at its last written value, which in turn
+pinned valence at -0.30 for two months. The failure was invisible: the crontab
+entry existed, and both of its failure stages (a missing `uv` on cron's PATH,
+then a working directory that no longer existed after the repository moved)
+produced either logs nobody read or no logs at all.
+
+A third, smaller defect: `controllability` was `0.45 + 0.25 * (1 - discomfort)`,
+a restatement of discomfort rather than a measure of whether actions were
+actually landing.
+
+## Desire projection: the kernel owns the clock
+
+Levels grow linearly, `level = elapsed / satisfaction_hours`, so a recorded
+level implies when the need was last met, and the same ramp can be evaluated at
+any later instant. `project_desires` re-derives every level for *now* from the
+recorded snapshot plus elapsed time.
+
+The external writer is therefore demoted from clock to corrector: when it runs,
+it supplies a fresh, memory-grounded reading; when it does not, the kernel keeps
+moving on its own. A stalled writer costs accuracy, not motion.
+
+Edge cases pinned by tests: a level already at 1.0 stays saturated (it implies
+no last-satisfied instant); a 70-day stall saturates instead of overflowing;
+backwards clock skew never lowers a level below what was recorded; an
+unparsable timestamp is treated as "just written" rather than extrapolated from
+a guess.
+
+Set points are adjusted for the time of day: social and outward-looking needs
+settle overnight, and `identity_coherence` does not, because it is wanted
+equally at every hour. Its set point is 0.9 while the others sit at 0.2-0.3,
+so it is a need to *stay* coherent rather than one that accumulates by neglect.
+
+## Valence composition
+
+```
+appetitive = max(0, expected_valence_delta) * measured_controllability
+aversive   = max(0, -expected_valence_delta)
+           + 0.55 * mean_discomfort
+           + 0.25 * uncertainty
+           + 0.20 * unresolved_prediction_error
+valence    = clamp(appetitive - aversive, -1, 1)
+```
+
+Expected improvement is scaled by measured control: an improvement nobody can
+bring about is not good news. Expected worsening is *not* discounted that way,
+since harm one cannot avert is still aversive.
+
+`expected_valence_delta` comes from the count model shipped in PR #108:
+
+```
+E[dvalence | context] = sum over outcome buckets of
+                        P(bucket | context) * mean valence change in that bucket
+```
+
+This is the point where the previous phase pays off. The transitions the model
+learned from experience become the estimate of whether the current situation is
+going anywhere good. With no history the forecast falls back to the uniform
+prior, whose buckets carry small symmetric deltas, so the estimate sits near
+zero rather than inventing an expectation.
+
+`controllability` is now the measured `ownership_score` of the previous field,
+used only once an intention has actually been registered and closed; before
+that there is nothing measured, and the neutral midpoint stands in.
+
+## Integration
+
+`TickProducer._read_interoception` branches on the flag. The legacy arithmetic
+is preserved verbatim as `_legacy_interoception` and is reproduced bit-for-bit
+when the flag is off (asserted against the exact constants -0.105, 0.575, and
+the recorded discomfort map).
+
+The allostatic branch is wrapped so a prediction or storage fault falls back to
+the legacy path instead of blocking a tick: a body state must always be
+producible. This tolerance has a cost that showed up during development, and is
+worth recording. A `TypeError` inside the new branch (`utc_now()` returns an ISO
+string, not a `datetime`) was swallowed silently, and the flag simply appeared
+not to work. The fallback is right for production and blinding during
+development; when this branch misbehaves, remove the `except` before theorising.
+
+No migration is required. Every input already existed:
+`generative_transition_stats` for expected improvement, `agency_state` for
+measured control, `experienced_transitions` for unresolved error, and the desire
+file for needs.
+
+## Why the flag defaults to off
+
+The generative layer in PR #108 shipped enabled because it only *added* rows.
+This change rewrites a value the whole runtime reads, including workspace
+salience and the negative-exposure counter. It ships off so the live smoke can
+be run deliberately: enable it, take a few ticks, compare the reported body
+state against the same period under the legacy rule, then decide.
+
+## What later phases take from here
+
+- PR-3 (valence coupling) reads `AllostaticVariable`'s separated appetitive and
+  aversive terms rather than the scalar, so competition weights and recall can
+  be modulated by *why* affect is where it is.
+- `as_snapshot()` is shaped for `experienced_transitions.allostatic_snapshot_json`,
+  which already exists from migration 009.
+- The organism daemon (PR-7) can retire the external desire writer entirely; the
+  projection already covers the interval between writes.

--- a/docs/phenomenal-architecture-current-state.md
+++ b/docs/phenomenal-architecture-current-state.md
@@ -79,9 +79,18 @@ flowchart TD
 - Valence was causally inert on the live path: computed only from the desire
   file as an EMA of `-0.6 * max(discomforts)` (structurally never positive),
   absent from competition weights and memory recall. The live
-  `~/.claude/desires.json` had been stale since 2026-05-18 with the
-  `desire-updater` cron not installed, pinning live valence at -0.30. The
-  allostatic rework owns the durable fix.
+  `~/.claude/desires.json` had been stale since 2026-05-18, pinning live
+  valence at -0.30.
+
+  Correction (2026-07-27, found while starting the allostatic rework): an
+  earlier revision of this document said the `desire-updater` cron was not
+  installed. It was installed, and had failed silently in two stages: `uv`
+  was not on cron's PATH (18k log lines, last written 2026-05-13), and later
+  the repository moved out of `~/repo/`, so the `cd` in the crontab entry
+  began failing before anything could be logged at all. A timer that is
+  present but dead is the worse failure, because nothing reports its absence.
+  The durable fix moves the clock into the kernel, so a stalled writer costs
+  corrections rather than motion.
 - `InteroceptionState.controllability` was derived from discomfort and not
   wired to the measured `ownership_score`.
 - `SleepConsolidator` was constructed without a quiet-hours predicate, so its

--- a/mcpBehavior.toml
+++ b/mcpBehavior.toml
@@ -50,3 +50,6 @@ port = 8080
 [individual-kernel]
 generative_field_model = true      # 予測・学習ループ（追加テーブルへの書き込みのみ、行為選択は不変）
 generative_rollout_horizon = 2     # propose 時の rollout 深さ (1-5)
+allostatic_valence = false         # valence/needs/controllability の再定義。既定 off:
+                                   # 既存の body state を書き換えるため、ライブで一度
+                                   # 確認してから on にする（docs/allostatic-valence-design.md）


### PR DESCRIPTION
## Summary

PR-2 of the roadmap: the body state stops being a frozen, structurally negative
number and becomes an allostatic variable the kernel computes for itself.

Two defects are addressed. **Valence could not be positive** — it was an EMA
toward `-0.6 * max(discomfort)`, bounded above by exactly zero, so no run of
well-predicted successful actions could register as going well. **The needs had
stopped moving** — desire levels came from a file whose external writer had been
dead since 2026-05-13, pinning live valence at -0.30 for two months.

- `project_desires` re-derives every desire level for *now* from the recorded
  snapshot plus elapsed time. Levels grow as `elapsed / satisfaction_hours`, so
  a recorded level implies when the need was last met and the ramp can be
  evaluated at any later instant. The external writer is demoted from clock to
  corrector: when it stops, accuracy degrades but motion does not.
- `compose_valence` builds affect from an appetitive term (expected improvement,
  scaled by measured control) minus an aversive one (unmet needs, uncertainty,
  unresolved prediction error). Expected *worsening* is not discounted by
  control, since harm one cannot avert is still aversive.
- `CountBasedGenerativeFieldModel.expected_valence_delta` supplies the
  appetitive input as `sum P(bucket | context) * mean valence change in bucket`.
  The transitions learned in #108 become the estimate of whether the current
  situation is going anywhere good.
- `controllability` follows the measured `ownership_score` of the previous
  field, used only once an intention has actually been registered and closed;
  before that the neutral midpoint stands in.

**No migration.** Every input already existed: `generative_transition_stats`,
`agency_state`, `experienced_transitions`, and the desire file.

Design: `docs/allostatic-valence-design.md`.

Claim policy: this computes a functional affect variable; nothing here is a
phenomenal claim.

## The flag defaults to off

#108 shipped enabled because it only added rows. This rewrites a value the whole
runtime reads, including workspace salience and the negative-exposure counter,
so it ships off. The intended smoke: enable it, take a few ticks, compare the
reported body state against the same period under the legacy rule, then decide.

With the flag off the legacy arithmetic is reproduced bit-for-bit, asserted
against the exact constants (valence -0.105, controllability 0.575, and the
recorded discomfort map).

## Tests

292 passed in the kernel suite (257 existing + 35 new), 55 in social-core.
`uv lock --check` clean, ruff clean, benchmark `--check` writes both mandated
reports.

Properties pinned by the new tests: a stalled snapshot still moves; a saturated
level stays saturated; a 70-day stall saturates instead of overflowing;
backwards clock skew never lowers a level; an unparsable timestamp is treated as
"just written" rather than extrapolated from a guess; a well-predicted,
controllable, improving context produces **positive** valence; control no longer
restates discomfort and follows a measured ownership score.

## Two development notes worth keeping

The allostatic branch is wrapped so a fault falls back to the legacy path — a
body state must always be producible. That tolerance blinded me during
development: a `TypeError` (`utc_now()` returns an ISO string, not a `datetime`)
was swallowed silently and the flag simply appeared not to work. Right for
production, wrong for debugging; the design doc says to remove the `except`
before theorising.

Separately, writing the new branch before its imports took the tick runtime
down mid-session, and since editing files is gated on having a committed field,
recovery required driving `begin_subjective_tick` / `commit_subjective_field` by
hand to buy one edit at a time. The gate behaved correctly; it is simply worth
knowing that kernel edits can lock out the editor.

## Roadmap

PR-3 (valence coupling) reads the separated appetitive and aversive terms rather
than the scalar, so competition weights and recall can be modulated by *why*
affect is where it is. `as_snapshot()` is already shaped for
`experienced_transitions.allostatic_snapshot_json` from migration 009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
