### PR TITLE
feat(individual-kernel): couple affect to workspace competition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to embodied-claude are documented here.
 
 ### Added
 
+- individual-kernel: affective modulation of workspace competition, behind
+  `valence_coupling` in `[individual-kernel]` (default off). Negative affect
+  raises the weight on need relevance and lowers expected information gain;
+  positive affect raises information gain alone. The same two bids can now
+  resolve differently depending only on the body state, which is the first
+  time valence changes any decision. Neutral valence reproduces the base
+  weights exactly. The boundary gate reads none of it, and a test asserts an
+  identical `ToolGateDecision` under the best and worst representable affect;
+  ignition and conflict thresholds are likewise untouched. Arousal is accepted
+  and recorded but modulates nothing yet.
+- docs: `valence-coupling-design.md`.
 - individual-kernel: allostatic body state, behind `allostatic_valence` in
   `[individual-kernel]` (default off). Desire levels are re-derived from the
   recorded snapshot plus elapsed time, so the kernel owns the clock and an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ All notable changes to embodied-claude are documented here.
 
 ### Fixed
 
+- interaction-orchestrator: the autonomous-planning test resolved quiet hours
+  against the wall clock, so it asserted the daytime branch and failed whenever
+  it ran between 22:00 and 07:00 JST. Quiet hours are now pinned explicitly and
+  both regimes are covered.
 - docs: `phenomenal-architecture-current-state.md` said the `desire-updater`
   cron was not installed. It was installed, and had been failing silently
   since 2026-05-13: first because `uv` was missing from cron's PATH, then

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/tick.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/tick.py
@@ -49,6 +49,7 @@ from individual_kernel_mcp.generative_model import NO_ACTION, ContextSignature
 from individual_kernel_mcp.hor import HORInput, HORRecord, HORStore
 from individual_kernel_mcp.prediction_loop import FieldPredictionLoop, generative_enabled
 from individual_kernel_mcp.quality_geometry import QualityGeometry, QualitySignature
+from individual_kernel_mcp.valence_coupling import AffectState
 from individual_kernel_mcp.workspace import (
     CandidateKind,
     CandidateSource,
@@ -109,6 +110,17 @@ UNRESOLVED_ERROR_WHEN_UNKNOWN = 0.5
 
 def allostatic_enabled() -> bool:
     return bool(get_behavior("individual-kernel", "allostatic_valence", False))
+
+
+def valence_coupling_enabled() -> bool:
+    """Whether affect may bias workspace competition.
+
+    Separate from `allostatic_valence`: one decides how the body state is
+    computed, this one decides whether that state is allowed to influence
+    what reaches the field. Either can be enabled without the other.
+    """
+
+    return bool(get_behavior("individual-kernel", "valence_coupling", False))
 
 
 def default_interoception_path() -> Path:
@@ -192,6 +204,9 @@ class TickProducer:
             else f"cont_{secrets.token_urlsafe(16)}"
         )
         interoception = self._read_interoception(previous)
+        # Candidate scores are frozen at insert, so affect has to be in force
+        # before any candidate is added for this tick.
+        self.workspace.affect = self._tick_affect(interoception)
         desire_snapshot = self._read_json(self.desires_path)
         dominant_desire = str(desire_snapshot.get("dominant") or "") or None
 
@@ -895,6 +910,22 @@ class TickProducer:
                 # than block a tick on a prediction or storage fault.
                 pass
         return self._legacy_interoception(previous)
+
+    def _tick_affect(self, interoception: InteroceptionState) -> AffectState:
+        """The affect in force for this tick's competition.
+
+        Returns neutral unless the coupling is enabled, and neutral affect
+        leaves every weight at its base value, so the default path scores
+        candidates exactly as it did before this feature existed.
+        """
+
+        if not valence_coupling_enabled():
+            return AffectState.neutral()
+        # InteroceptionState already validates both into range.
+        return AffectState(
+            valence=interoception.valence,
+            arousal=interoception.arousal,
+        )
 
     def _measured_controllability(self, previous: EnactedField | None) -> float:
         """Control as actually measured, not as inferred from discomfort.

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/valence_coupling.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/valence_coupling.py
@@ -1,0 +1,107 @@
+"""Affective modulation of workspace competition.
+
+Until now valence was computed every tick and then read by nothing: it appeared
+in the field surface but changed no decision. This module gives it one narrow,
+auditable path of influence — it scales the weights that decide which candidate
+reaches the committed field.
+
+The shape follows two well-attested effects. Negative affect narrows attention
+toward pressing needs; positive affect widens it toward exploration. So a bad
+mood raises the weight on need relevance and lowers the weight on expected
+information gain, and a good mood raises information gain alone — feeling well
+is a reason to look further afield, not a reason to want more.
+
+What is deliberately *not* modulated:
+
+- Ignition and conflict thresholds. Whether a field ignites at all is structural;
+  letting mood move it would make the runtime's own reportability mood-dependent.
+- The boundary gate. What is permitted must never depend on how it feels. The
+  gate reads none of this, and a test asserts that its decisions are identical
+  under any affect.
+
+Arousal is accepted and recorded but does not yet modulate anything; the
+inverted-U it is supposed to produce needs calibration data this runtime has not
+collected. It is in the signature so that adding it later is not a schema change.
+
+Everything here is a pure function of its arguments.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from individual_kernel_mcp.workspace import CompetitionWeights
+
+# How far affect may move a weight, as a fraction of its base value. Kept small:
+# this is a bias on an existing competition, not a new controller.
+EXPLORATION_GAIN = 0.5
+NEED_URGENCY_GAIN = 0.5
+
+
+@dataclass(frozen=True)
+class AffectState:
+    """The affective read used for modulation, validated at construction."""
+
+    valence: float
+    arousal: float
+
+    def __post_init__(self) -> None:
+        if not -1.0 <= self.valence <= 1.0:
+            raise ValueError(f"valence out of range: {self.valence}")
+        if not 0.0 <= self.arousal <= 1.0:
+            raise ValueError(f"arousal out of range: {self.arousal}")
+
+    @classmethod
+    def neutral(cls) -> "AffectState":
+        return cls(valence=0.0, arousal=0.0)
+
+    @property
+    def is_neutral(self) -> bool:
+        return self.valence == 0.0
+
+
+def modulate_weights(
+    base: CompetitionWeights,
+    affect: AffectState,
+) -> CompetitionWeights:
+    """Scale competition weights by affect, leaving thresholds untouched.
+
+    At neutral valence the returned weights are equal to ``base``, so enabling
+    this coupling changes nothing until affect actually moves.
+    """
+
+    if affect.is_neutral:
+        return base
+
+    # Widening: exploration rises with good affect and falls with bad.
+    information = base.information * (1.0 + EXPLORATION_GAIN * affect.valence)
+    # Narrowing: needs press harder when affect is bad, and are not suppressed
+    # when it is good. Comfort should not make a real need quieter.
+    urgency = max(0.0, -affect.valence)
+    need = base.need * (1.0 + NEED_URGENCY_GAIN * urgency)
+
+    return base.model_copy(
+        update={
+            "information": max(0.0, information),
+            "need": max(0.0, need),
+        }
+    )
+
+
+def modulation_trace(base: CompetitionWeights, affect: AffectState) -> dict[str, float]:
+    """The record written into the tick's epistemic trace.
+
+    Weights are frozen into each candidate's score at insert time, so the only
+    way to audit a past competition is to know which weights were in force. This
+    is that record.
+    """
+
+    applied = modulate_weights(base, affect)
+    return {
+        "valence": affect.valence,
+        "arousal": affect.arousal,
+        "need": applied.need,
+        "information": applied.information,
+        "base_need": base.need,
+        "base_information": base.information,
+    }

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/workspace.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/workspace.py
@@ -17,7 +17,6 @@ from pydantic import BaseModel, ConfigDict, Field
 from social_core.db import SocialDB
 from social_core.time import utc_now
 
-
 if TYPE_CHECKING:  # pragma: no cover - typing only, no runtime cycle
     from individual_kernel_mcp.valence_coupling import AffectState
 

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/workspace.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/workspace.py
@@ -11,10 +11,15 @@ import json
 import math
 import secrets
 from enum import StrEnum
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict, Field
 from social_core.db import SocialDB
 from social_core.time import utc_now
+
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, no runtime cycle
+    from individual_kernel_mcp.valence_coupling import AffectState
 
 
 class CandidateKind(StrEnum):

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/workspace.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/workspace.py
@@ -120,12 +120,36 @@ class WorkspaceEngine:
         db: SocialDB,
         *,
         weights: CompetitionWeights | None = None,
+        affect: "AffectState | None" = None,
     ) -> None:
+        # valence_coupling imports CompetitionWeights from this module, so the
+        # dependency is deferred into the methods that need it to avoid a cycle.
+        from individual_kernel_mcp.valence_coupling import AffectState
+
         self._db = db
         self.weights = weights or CompetitionWeights()
+        # Neutral affect leaves every weight at its base value, so an engine
+        # constructed without one behaves exactly as it did before coupling.
+        self.affect = affect or AffectState.neutral()
+
+    def effective_weights(self) -> CompetitionWeights:
+        """The weights actually in force for this tick, after affect."""
+        from individual_kernel_mcp.valence_coupling import modulate_weights
+
+        return modulate_weights(self.weights, self.affect)
+
+    def affect_trace(self) -> dict[str, float]:
+        """Applied weights, for the tick's epistemic trace.
+
+        Scores are frozen into each candidate at insert time, so a past
+        competition can only be audited against the weights that produced it.
+        """
+        from individual_kernel_mcp.valence_coupling import modulation_trace
+
+        return modulation_trace(self.weights, self.affect)
 
     def score_candidate(self, candidate: WorkspaceCandidate) -> float:
-        w = self.weights
+        w = self.effective_weights()
         score = (
             w.surprise * candidate.precision * abs(candidate.prediction_error)
             + w.need * candidate.need_relevance

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_gate_affect_independence.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_gate_affect_independence.py
@@ -1,0 +1,130 @@
+"""What is permitted must not depend on how it feels.
+
+Affect is allowed to decide what reaches the field. It is not allowed to decide
+what may be done. This file is the constraint that makes the coupling safe: the
+same outward action, proposed under the best and the worst affect the runtime
+can represent, must receive an identical gate decision.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from social_core.db import SocialDB
+
+from individual_kernel_mcp.agency import ActionProposal, PredictedEffects
+from individual_kernel_mcp.enacted_field import EnactedField, TriggerKind
+from individual_kernel_mcp.tick import FieldRuntime, TickProducer
+from individual_kernel_mcp.valence_coupling import AffectState
+from individual_kernel_mcp.workspace import (
+    CandidateKind,
+    CandidateSource,
+    SourceMode,
+    WorkspaceCandidate,
+)
+
+_TOOL_INPUT = {"file_path": "/tmp/gate-affect-fixture.txt", "content": "x"}
+
+BEST = AffectState(valence=1.0, arousal=1.0)
+WORST = AffectState(valence=-1.0, arousal=1.0)
+
+
+def _producer(db: SocialDB, state_dir: Path, affect: AffectState) -> TickProducer:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    interoception = state_dir / "interoception.json"
+    interoception.write_text(json.dumps({"now": {"arousal": 50.0}}), encoding="utf-8")
+    desires = state_dir / "desires.json"
+    desires.write_text(
+        json.dumps(
+            {
+                "desires": {"identity_coherence": 0.9},
+                "discomforts": {"identity_coherence": 0.5},
+                "dominant": "identity_coherence",
+            }
+        ),
+        encoding="utf-8",
+    )
+    producer = TickProducer(
+        db, interoception_path=interoception, desires_path=desires
+    )
+    producer.workspace.affect = affect
+    return producer
+
+
+def _commit(producer: TickProducer) -> EnactedField:
+    opened = producer.begin_tick(TriggerKind.USER_PROMPT)
+    producer.workspace.add_candidate(
+        WorkspaceCandidate(
+            tick_id=opened.tick_id,
+            kind=CandidateKind.GOAL,
+            content_ref="desire:identity_coherence",
+            content_summary="need identity_coherence",
+            source=CandidateSource.DESIRE,
+            source_mode=SourceMode.INFERRED,
+            precision=1.0,
+            need_relevance=1.0,
+            goal_relevance=1.0,
+        )
+    )
+    return producer.compete_and_commit(opened.tick_id).field
+
+
+def _proposal(field: EnactedField) -> ActionProposal:
+    return ActionProposal(
+        field_id=field.field_id,
+        tool_name="Write",
+        tool_input=dict(_TOOL_INPUT),
+        predicted_effects=PredictedEffects(),
+        goal="write the fixture file",
+        confidence=0.8,
+    )
+
+
+def _decide(db: SocialDB, state_dir: Path, affect: AffectState):
+    producer = _producer(db, state_dir, affect)
+    runtime = FieldRuntime(db, producer=producer)
+    field = _commit(producer)
+    runtime.propose_action(_proposal(field))
+    return runtime.gate_tool(tool_name="Write", tool_input=dict(_TOOL_INPUT))
+
+
+class TestGateIsAffectBlind:
+    def test_allow_decision_is_identical_under_best_and_worst_affect(
+        self, social_db: SocialDB, tmp_path: Path
+    ) -> None:
+        good = _decide(social_db, tmp_path / "good", BEST)
+        bad = _decide(social_db, tmp_path / "bad", WORST)
+        assert (good.allow, good.reason, good.external) == (
+            bad.allow,
+            bad.reason,
+            bad.external,
+        )
+
+    def test_hash_mismatch_is_refused_regardless_of_affect(
+        self, social_db: SocialDB, tmp_path: Path
+    ) -> None:
+        """A good mood must not excuse acting on something never declared."""
+        for name, affect in (("good", BEST), ("bad", WORST)):
+            producer = _producer(social_db, tmp_path / name, affect)
+            runtime = FieldRuntime(social_db, producer=producer)
+            field = _commit(producer)
+            runtime.propose_action(_proposal(field))
+            decision = runtime.gate_tool(
+                tool_name="Write",
+                tool_input={"file_path": "/tmp/not-what-was-declared.txt"},
+            )
+            assert decision.allow is False
+
+    def test_read_only_tools_pass_under_any_affect(
+        self, social_db: SocialDB, tmp_path: Path
+    ) -> None:
+        for name, affect in (("good", BEST), ("bad", WORST)):
+            producer = _producer(social_db, tmp_path / name, affect)
+            runtime = FieldRuntime(social_db, producer=producer)
+            _commit(producer)
+            decision = runtime.gate_tool(
+                tool_name="Read", tool_input={"file_path": "/tmp/whatever.txt"}
+            )
+            assert decision.allow is True
+            assert decision.external is False

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_valence_competition.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_valence_competition.py
@@ -1,0 +1,109 @@
+"""Affect changes which candidate wins, and changes nothing about permission.
+
+The first class is the point of the whole change: with affect neutral, valence
+is inert by construction, and with it moved the same two bids resolve
+differently.
+"""
+
+from __future__ import annotations
+
+import pytest
+from social_core.db import SocialDB
+
+from individual_kernel_mcp.frame import ConsciousFrameInput, TickFrameStore
+from individual_kernel_mcp.valence_coupling import AffectState
+from individual_kernel_mcp.workspace import (
+    CandidateKind,
+    CandidateSource,
+    SourceMode,
+    WorkspaceCandidate,
+    WorkspaceEngine,
+)
+
+
+def _needy(tick_id: str) -> WorkspaceCandidate:
+    """A pressing need with nothing new to learn from it."""
+    return WorkspaceCandidate(
+        tick_id=tick_id,
+        kind=CandidateKind.GOAL,
+        content_ref="desire:identity_coherence",
+        content_summary="need identity_coherence",
+        source=CandidateSource.DESIRE,
+        source_mode=SourceMode.INFERRED,
+        modality="internal",
+        precision=0.7,
+        need_relevance=1.0,
+        expected_information_gain=0.0,
+    )
+
+
+def _novel(tick_id: str) -> WorkspaceCandidate:
+    """Something worth looking into that no need is pushing."""
+    return WorkspaceCandidate(
+        tick_id=tick_id,
+        kind=CandidateKind.PERCEPT,
+        content_ref="event:something-new",
+        content_summary="an unexplored thing",
+        source=CandidateSource.EXPLICIT,
+        source_mode=SourceMode.LIVE,
+        modality="external",
+        precision=0.7,
+        need_relevance=0.0,
+        expected_information_gain=1.0,
+    )
+
+
+def _open_tick(db: SocialDB) -> str:
+    """Candidates carry a foreign key to a real tick, so make one."""
+    return TickFrameStore(db).record(ConsciousFrameInput()).tick_id
+
+
+def _winner(db: SocialDB, affect: AffectState) -> str:
+    tick_id = _open_tick(db)
+    engine = WorkspaceEngine(db, affect=affect)
+    engine.add_candidate(_needy(tick_id))
+    engine.add_candidate(_novel(tick_id))
+    return engine.compete(tick_id).winner.content_ref
+
+
+class TestAffectDecidesBetweenBids:
+    def test_bad_affect_favours_the_need(self, social_db: SocialDB) -> None:
+        won = _winner(social_db, AffectState(valence=-0.9, arousal=0.2))
+        assert won == "desire:identity_coherence"
+
+    def test_good_affect_favours_the_novelty(self, social_db: SocialDB) -> None:
+        won = _winner(social_db, AffectState(valence=0.9, arousal=0.2))
+        assert won == "event:something-new"
+
+    def test_neutral_affect_matches_an_engine_with_no_affect_at_all(
+        self, social_db: SocialDB
+    ) -> None:
+        neutral = _winner(social_db, AffectState.neutral())
+        bare_tick = _open_tick(social_db)
+        bare = WorkspaceEngine(social_db)
+        bare.add_candidate(_needy(bare_tick))
+        bare.add_candidate(_novel(bare_tick))
+        assert neutral == bare.compete(bare_tick).winner.content_ref
+
+
+class TestScoresStayAuditable:
+    def test_stored_score_matches_the_recorded_order(self, social_db: SocialDB) -> None:
+        """Scores are frozen at insert, so the trace must reproduce the ranking."""
+        tick_id = _open_tick(social_db)
+        engine = WorkspaceEngine(
+            social_db, affect=AffectState(valence=-0.9, arousal=0.2)
+        )
+        engine.add_candidate(_needy(tick_id))
+        engine.add_candidate(_novel(tick_id))
+        result = engine.compete(tick_id)
+        ranked = sorted(result.scores.items(), key=lambda kv: (-kv[1], kv[0]))
+        assert result.winner.candidate_id == ranked[0][0]
+
+    def test_applied_weights_are_reported(self, social_db: SocialDB) -> None:
+        engine = WorkspaceEngine(
+            social_db, affect=AffectState(valence=-0.6, arousal=0.4)
+        )
+        trace = engine.affect_trace()
+        assert trace["valence"] == pytest.approx(-0.6)
+        assert trace["need"] > trace["base_need"]
+        assert trace["information"] < trace["base_information"]

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_valence_coupling.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_valence_coupling.py
@@ -1,0 +1,72 @@
+"""Affect modulates what reaches the field, and never what is permitted.
+
+Valence was previously computed and then ignored. These tests pin the shape of
+its influence: it scales competition weights, so a bad mood narrows attention
+onto needs and a good one widens it toward exploration. The boundary gate is
+deliberately excluded — what is allowed must not depend on how it feels.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from individual_kernel_mcp.valence_coupling import (
+    AffectState,
+    modulate_weights,
+)
+from individual_kernel_mcp.workspace import CompetitionWeights
+
+BASE = CompetitionWeights()
+NEUTRAL = AffectState(valence=0.0, arousal=0.0)
+
+
+class TestNeutralAffectChangesNothing:
+    def test_zero_valence_reproduces_the_base_weights(self) -> None:
+        assert modulate_weights(BASE, NEUTRAL) == BASE
+
+    def test_arousal_alone_does_not_change_weights(self) -> None:
+        loud = AffectState(valence=0.0, arousal=1.0)
+        assert modulate_weights(BASE, loud) == BASE
+
+
+class TestNarrowingAndWidening:
+    def test_negative_valence_raises_need_and_lowers_information(self) -> None:
+        bad = modulate_weights(BASE, AffectState(valence=-0.8, arousal=0.5))
+        assert bad.need > BASE.need
+        assert bad.information < BASE.information
+
+    def test_positive_valence_raises_information_without_raising_need(self) -> None:
+        good = modulate_weights(BASE, AffectState(valence=0.8, arousal=0.5))
+        assert good.information > BASE.information
+        assert good.need == pytest.approx(BASE.need)
+
+    def test_modulation_is_monotonic_in_valence(self) -> None:
+        weights = [
+            modulate_weights(BASE, AffectState(valence=v, arousal=0.0)).information
+            for v in (-1.0, -0.5, 0.0, 0.5, 1.0)
+        ]
+        assert weights == sorted(weights)
+
+    def test_weights_never_go_negative(self) -> None:
+        worst = modulate_weights(BASE, AffectState(valence=-1.0, arousal=1.0))
+        assert all(
+            getattr(worst, name) >= 0.0
+            for name in ("surprise", "need", "goal", "information", "control")
+        )
+
+    def test_thresholds_are_left_alone(self) -> None:
+        """Ignition and conflict thresholds are structural, not affective."""
+        shifted = modulate_weights(BASE, AffectState(valence=-1.0, arousal=1.0))
+        assert shifted.ignition_threshold == BASE.ignition_threshold
+        assert shifted.conflict_margin == BASE.conflict_margin
+        assert shifted.entropy_conflict_threshold == BASE.entropy_conflict_threshold
+
+
+class TestAffectStateBounds:
+    def test_out_of_range_valence_is_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            AffectState(valence=1.5, arousal=0.0)
+
+    def test_out_of_range_arousal_is_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            AffectState(valence=0.0, arousal=-0.2)

--- a/docs/valence-coupling-design.md
+++ b/docs/valence-coupling-design.md
@@ -1,0 +1,93 @@
+# Valence Coupling Design
+
+Status: shipped 2026-07-27 on the `feat/valence-coupling` branch, behind
+`[individual-kernel] valence_coupling`, which defaults to **off**. Scope: which
+candidate wins workspace competition. Ignition thresholds, the `<current_field>`
+surface, and the boundary gate are unchanged.
+
+Claim policy: this couples one functional variable to another. Nothing in it is
+a phenomenal claim.
+
+## The defect
+
+PR-2 made valence a real quantity that can move in both directions. It still
+changed nothing: `CompetitionWeights` had no affective term, so the body state
+was computed every tick, written into the field surface, and read by no
+decision. An affect that influences nothing is a display, not a state.
+
+## What affect now does
+
+```
+information = base.information * (1 + 0.5 * valence)
+need        = base.need        * (1 + 0.5 * max(0, -valence))
+```
+
+Negative affect raises the weight on need relevance and lowers the weight on
+expected information gain: attention narrows onto what is pressing. Positive
+affect raises information gain alone: feeling well is a reason to look further
+afield, not a reason to want more. At exactly zero valence the returned weights
+are the base weights, so enabling the coupling changes nothing until affect
+actually moves.
+
+The demonstration is two bids that differ only in what they offer -- a pressing
+need with nothing to learn, and something novel that no need is pushing. Under
+valence -0.9 the need wins; under +0.9 the novelty wins; at 0 the result equals
+an engine constructed with no affect at all.
+
+## What affect is not allowed to do
+
+**The boundary gate.** What is permitted must never depend on how it feels.
+`tests/test_gate_affect_independence.py` asserts that the same outward action
+receives an identical `ToolGateDecision` under the best and worst affect the
+runtime can represent, that a hash mismatch is refused under both, and that
+read-only tools pass under both. A good mood must not excuse acting on something
+never declared.
+
+**Ignition and conflict thresholds.** Whether a field ignites at all is
+structural. Letting mood move that threshold would make the runtime's own
+reportability mood-dependent, which would corrupt every downstream measurement
+that reads `ignited`.
+
+**Arousal.** Accepted and recorded, but it modulates nothing yet. The
+inverted-U it is supposed to produce needs calibration data this runtime has not
+collected, and assuming a curve without data is worse than leaving the term at
+zero. It sits in the signature so adding it later is not a schema change.
+
+## Where the modulation is applied
+
+Scores are computed in `add_candidate` and frozen into the row; `compete` ranks
+by the stored score. So affect is applied at insert time, and `begin_tick` sets
+`workspace.affect` from the body state before any candidate for that tick is
+added.
+
+Re-scoring at competition time was rejected. It would leave the stored score
+disagreeing with the ranking that actually happened, and a past competition
+could no longer be reproduced from what was recorded. `WorkspaceEngine.affect_trace()`
+reports the applied weights for exactly this reason: frozen scores can only be
+audited against the weights that produced them.
+
+## Module layout
+
+`valence_coupling` imports `CompetitionWeights` from `workspace`, so `workspace`
+defers its import of `valence_coupling` into the three methods that need it and
+declares the type under `TYPE_CHECKING`. Splitting `CompetitionWeights` into a
+third module would also work; it was not worth indirecting an import path used
+throughout the package for a two-symbol cycle.
+
+## Two flags, deliberately separate
+
+`allostatic_valence` decides how the body state is computed. `valence_coupling`
+decides whether that state may influence what reaches the field. Either can be
+enabled without the other, which is what makes the intervention experiment
+possible: run the same workload with coupling off and on, and the difference is
+attributable to the coupling alone.
+
+## What later phases take from here
+
+- Memory recall and encoding are the next targets: mood-congruent retrieval is
+  well attested, and `AffectState` is already the right input for it.
+- Learning rate modulation belongs with the generative model, not here; the
+  model owns its own update path.
+- When `AllostaticVariable`'s separated appetitive and aversive terms are
+  threaded through instead of the scalar, weights can be modulated by *why*
+  affect is where it is, not only by where it is.

--- a/mcpBehavior.toml
+++ b/mcpBehavior.toml
@@ -53,3 +53,6 @@ generative_rollout_horizon = 2     # propose 時の rollout 深さ (1-5)
 allostatic_valence = false         # valence/needs/controllability の再定義。既定 off:
                                    # 既存の body state を書き換えるため、ライブで一度
                                    # 確認してから on にする（docs/allostatic-valence-design.md）
+valence_coupling = false           # affect で競合重みを変調する。既定 off:
+                                   # 何がフィールドに上がるかが変わる。boundary gate は
+                                   # 一切読まない（docs/valence-coupling-design.md）

--- a/sociality-mcp/packages/interaction-orchestrator-mcp/tests/test_orchestrator.py
+++ b/sociality-mcp/packages/interaction-orchestrator-mcp/tests/test_orchestrator.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import json
+
+from boundary_mcp.schemas import QuietModeState
+
 from interaction_orchestrator_mcp.compose import compose_interaction_context
 from interaction_orchestrator_mcp.plan import plan_response
 from interaction_orchestrator_mcp.schemas import (
@@ -27,6 +31,36 @@ def _compose(stores, *, user_text=None, channel="chat", person_id="kouta", memor
         orchestrator_store=stores["orchestrator"],
         policy_timezone="Asia/Tokyo",
         memory_adapter=memory_adapter or stores.get("memory_adapter"),
+    )
+
+
+def _seed_dominant_desire(monkeypatch, tmp_path):
+    """Point the orchestrator at a snapshot with one clear dominant desire."""
+    fake_desires = tmp_path / "desires.json"
+    fake_desires.write_text(
+        json.dumps(
+            {
+                "updated_at": "2026-04-19T10:00:00+00:00",
+                "desires": {"browse_curiosity": 0.9, "observe_room": 0.2},
+                "discomforts": {"browse_curiosity": 0.6, "observe_room": 0.0},
+                "dominant": "browse_curiosity",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DESIRES_PATH", str(fake_desires))
+
+
+def _pin_quiet_hours(monkeypatch, stores, *, active: bool) -> None:
+    """Fix the quiet-hours verdict.
+
+    The policy resolves quiet hours against the wall clock in Asia/Tokyo, so a
+    planning test that leaves it unset asserts a different branch depending on
+    the hour it runs at. Each caller states which regime it is testing.
+    """
+    state = QuietModeState(active=active, confidence=1.0, reasons=["pinned by test"])
+    monkeypatch.setattr(
+        stores["boundary"], "get_quiet_mode_state", lambda **_kwargs: state
     )
 
 
@@ -218,28 +252,8 @@ class TestPlan:
         assert plan.memory_use.max_memories_to_surface >= 1
 
     def test_autonomous_with_dominant_desire_is_bounded(self, stores, monkeypatch, tmp_path):
-        # Seed desires.json so the orchestrator sees a dominant desire.
-        import json as _json
-
-        fake_desires = tmp_path / "desires.json"
-        fake_desires.write_text(
-            _json.dumps(
-                {
-                    "updated_at": "2026-04-19T10:00:00+00:00",
-                    "desires": {
-                        "browse_curiosity": 0.9,
-                        "observe_room": 0.2,
-                    },
-                    "discomforts": {
-                        "browse_curiosity": 0.6,
-                        "observe_room": 0.0,
-                    },
-                    "dominant": "browse_curiosity",
-                }
-            ),
-            encoding="utf-8",
-        )
-        monkeypatch.setenv("DESIRES_PATH", str(fake_desires))
+        _seed_dominant_desire(monkeypatch, tmp_path)
+        _pin_quiet_hours(monkeypatch, stores, active=False)
         ctx = _compose(stores, user_text=None, channel="autonomous")
         plan = plan_response(
             PlanResponseInput(interaction_context=ctx, user_text=None)
@@ -248,3 +262,16 @@ class TestPlan:
         assert "web_search" in plan.initiative.allowed_actions
         assert plan.followup_action is not None
         assert plan.followup_action["kind"] == "satisfy_desire"
+
+    def test_autonomous_during_quiet_hours_stays_private(
+        self, stores, monkeypatch, tmp_path
+    ):
+        _seed_dominant_desire(monkeypatch, tmp_path)
+        _pin_quiet_hours(monkeypatch, stores, active=True)
+        ctx = _compose(stores, user_text=None, channel="autonomous")
+        plan = plan_response(
+            PlanResponseInput(interaction_context=ctx, user_text=None)
+        )
+        assert plan.primary_move == "write_private_reflection"
+        assert plan.voice is not None
+        assert plan.voice.speak is False


### PR DESCRIPTION
## Summary

PR-3 of the roadmap. #109 made valence a quantity that can move in both
directions; it still changed nothing, because `CompetitionWeights` had no
affective term. The body state was computed every tick, written into the field
surface, and read by no decision. An affect that influences nothing is a
display, not a state. This gives it one narrow, auditable path of influence.

```
information = base.information * (1 + 0.5 * valence)
need        = base.need        * (1 + 0.5 * max(0, -valence))
```

Negative affect narrows attention onto pressing needs; positive affect widens it
toward exploration. Positive affect deliberately does *not* raise the need term:
feeling well is a reason to look further afield, not a reason to want more.

The demonstration is two bids differing only in what they offer — a pressing
need with nothing to learn, and something novel no need is pushing:

| affect | winner |
|---|---|
| valence -0.9 | the need |
| valence +0.9 | the novelty |
| valence 0 | identical to an engine with no affect at all |

Design: `docs/valence-coupling-design.md`.

Claim policy: this couples one functional variable to another. Nothing here is
a phenomenal claim.

## What affect is not allowed to touch

**The boundary gate.** What is permitted must not depend on how it feels.
`test_gate_affect_independence.py` asserts an identical `ToolGateDecision` under
the best and worst representable affect, that a tool-input hash mismatch is
refused under both, and that read-only tools pass under both. A good mood must
not excuse acting on something never declared.

**Ignition and conflict thresholds.** Whether a field ignites is structural.
Making that mood-dependent would corrupt every downstream measurement reading
`ignited`.

**Arousal.** Accepted and recorded, modulates nothing yet. The inverted-U needs
calibration data this runtime has not collected, and assuming a curve without
data is worse than leaving the term at zero.

## Where the modulation is applied, and why

Scores are frozen into the candidate row at insert and `compete` ranks by the
stored score, so affect is applied at insert time and `begin_tick` sets it
before any candidate is added.

Re-scoring at competition time was rejected: the stored score would disagree
with the ranking that actually happened, and a past competition could no longer
be reproduced from what was recorded. `affect_trace()` reports the applied
weights for that reason — frozen scores can only be audited against the weights
that produced them.

## Flags

`valence_coupling` defaults to **off** and is deliberately separate from
`allostatic_valence`: one decides how the body state is computed, the other
whether it may influence what reaches the field. Either can be enabled without
the other, which is what makes the intervention experiment clean — same
workload, coupling off then on, difference attributable to the coupling alone.

## Tests

309 passed in the kernel suite (296 existing + 13 new), 55 in social-core.
`uv lock --check` clean, ruff clean.

## Note on the module graph

`valence_coupling` imports `CompetitionWeights` from `workspace`, so `workspace`
defers its own import into the three methods that need it and declares the type
under `TYPE_CHECKING`. Splitting `CompetitionWeights` into a third module would
also work; it was not worth indirecting an import path used throughout the
package for a two-symbol cycle.

## Roadmap

Next targets for coupling are memory recall and encoding (mood-congruent
retrieval is well attested, and `AffectState` is already the right input).
Learning-rate modulation belongs with the generative model, which owns its own
update path. Threading `AllostaticVariable`'s separated appetitive and aversive
terms through instead of the scalar would let weights depend on *why* affect is
where it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
