### PR TITLE
feat(individual-kernel): score causal fit from the reafference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to embodied-claude are documented here.
 
 ### Added
 
+- individual-kernel: body contingency. `exclusive_causal_fit` is now the
+  reafference between the commanded pose change and the observed one --
+  direction, magnitude, and timing -- instead of a restatement of whether the
+  tool call returned successfully. A camera that moves with nothing commanded
+  scores `externally_caused`, one that moves the wrong way `inverted`, and one
+  that does not move at all `unresponsive`; each caps the score well below a
+  matched movement. Actions with no body channel resolve to `unverified` and
+  keep the previous 1.0/0.65 heuristic exactly, so nothing outside the camera
+  tools is re-scored. Verdicts land in a new `body_contingencies` ledger, one
+  row per action.
+- social-core: migration `010_body_contingency`.
+- docs: `body-agency.md`.
 - individual-kernel: affective modulation of workspace competition, behind
   `valence_coupling` in `[individual-kernel]` (default off). Negative affect
   raises the weight on need relevance and lowers expected information gain;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to embodied-claude are documented here.
 
 ## [Unreleased]
 
+### Changed
+
+- individual-kernel: `allostatic_valence` and `valence_coupling` now ship
+  **on**. Both were held off pending a live check, which ran on 2026-07-28:
+  `controllability` tracked the measured `ownership_score` tick by tick instead
+  of sitting at 0.575, and the competition scores moved by exactly the amount
+  the coupling formula predicts. A flag that ships off indefinitely is dead
+  code, so they are on and the arithmetic is documented. The desire snapshot is
+  still written by nothing, so every projected need saturates; that is a
+  known limit of the input, not of the composition.
+
 ### Added
 
 - individual-kernel: body contingency. `exclusive_causal_fit` is now the

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/agency.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/agency.py
@@ -15,6 +15,19 @@ from pydantic import BaseModel, ConfigDict, Field
 from social_core.db import SocialDB
 from social_core.time import utc_now
 
+from individual_kernel_mcp.body_contingency import (
+    BodyContingencyStore,
+    BodyObservation,
+    ContingencyVerdict,
+    commanded_delta_from_tool,
+    evaluate_reafference,
+)
+
+# Fallback causal fit when no body observation exists. This is the pre-PR-4
+# heuristic, kept so actions with no body channel score exactly as before.
+UNVERIFIED_CAUSAL_FIT_SUCCESS = 1.0
+UNVERIFIED_CAUSAL_FIT_FAILURE = 0.65
+
 
 class IntentionStatus(StrEnum):
     PENDING = "PENDING"
@@ -254,6 +267,7 @@ class AgencyStore:
         success: bool,
         actual_result_ref: str | None = None,
         latency_ms: int | None = None,
+        body_observation: BodyObservation | None = None,
     ) -> tuple[ActionOutcome, AgencyAssessment]:
         intention = self.get(action_id)
         if intention is None:
@@ -269,12 +283,18 @@ class AgencyStore:
             success=success,
             latency_ms=latency_ms,
         )
+        causal_fit, reafference = self._causal_fit(
+            intention=intention,
+            success=success,
+            body_observation=body_observation,
+            latency_ms=latency_ms,
+        )
         assessment = self.assess(
             registered_intention=True,
             mismatch_vector=mismatch,
             latency_ms=latency_ms,
             expected_latency_ms=intention.expected_latency_ms,
-            exclusive_causal_fit=1.0 if success else 0.65,
+            exclusive_causal_fit=causal_fit,
         )
         outcome_id = f"out_{secrets.token_urlsafe(12)}"
         now = utc_now()
@@ -338,6 +358,55 @@ class AgencyStore:
         outcome = self.outcome_for_action(action_id)
         assert outcome is not None
         return outcome, assessment
+
+    def _causal_fit(
+        self,
+        *,
+        intention: IntentionRecord,
+        success: bool,
+        body_observation: BodyObservation | None,
+        latency_ms: int | None,
+    ) -> tuple[float, Any]:
+        """Derive exclusive causal fit from the reafference when one exists.
+
+        Without a body observation there is nothing to compare, so the old
+        success heuristic stands and the verdict is recorded as UNVERIFIED
+        rather than dressed up as evidence.
+        """
+        commanded = commanded_delta_from_tool(
+            intention.tool_name, intention.normalized_tool_input
+        )
+        observation = body_observation
+        if observation is not None and observation.observed_latency_ms is None:
+            observation = observation.model_copy(
+                update={"observed_latency_ms": latency_ms}
+            )
+        verdict = evaluate_reafference(
+            commanded_delta=commanded,
+            observation=observation,
+            expected_latency_ms=intention.expected_latency_ms,
+        )
+        try:
+            BodyContingencyStore(self._db).record(
+                verdict=verdict,
+                observation=observation,
+                action_id=intention.action_id,
+                field_id=intention.field_id,
+                tick_id=intention.tick_id,
+                expected_latency_ms=intention.expected_latency_ms,
+            )
+        except Exception:
+            # The ledger is an audit trail, not a precondition for closing an
+            # action. A storage fault must not strand a pending intention.
+            pass
+        if verdict.verdict is ContingencyVerdict.UNVERIFIED:
+            fallback = (
+                UNVERIFIED_CAUSAL_FIT_SUCCESS
+                if success
+                else UNVERIFIED_CAUSAL_FIT_FAILURE
+            )
+            return fallback, verdict
+        return verdict.score, verdict
 
     def assess_uncommanded_outcome(
         self,

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/body_contingency.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/body_contingency.py
@@ -1,0 +1,416 @@
+"""Sensorimotor contingency: did the body move the way it was told to?
+
+`exclusive_causal_fit` previously restated whether the tool call returned
+successfully. That cannot tell a movement the runtime commanded apart from one
+somebody else caused, which is the only thing the term was meant to measure.
+
+This module scores the reafference instead: the observed body change against
+the commanded one, in direction, magnitude, and timing. Everything is a pure
+function over explicit arguments, so a verdict is reproducible from the stored
+record alone.
+
+Claim policy: this relates one functional variable to another. Nothing in it is
+a phenomenal claim.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import secrets
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+from social_core.db import SocialDB
+from social_core.time import utc_now
+
+# Direction dominates. Moving the wrong way is stronger evidence that something
+# else caused the change than moving the right way by the wrong amount.
+DIRECTION_WEIGHT = 0.5
+MAGNITUDE_WEIGHT = 0.3
+TIMING_WEIGHT = 0.2
+
+# Ratio error tolerated in full before the magnitude term starts to fall.
+MAGNITUDE_TOLERANCE = 0.35
+
+# Movement below this is indistinguishable from encoder noise on the PTZ
+# hardware, so it counts as no movement.
+NOISE_FLOOR_DEGREES = 1.0
+
+# Ceilings applied after scoring. "Something else moved me" must not keep a high
+# score just because the timing happened to look right.
+EXTERNALLY_CAUSED_CEILING = 0.10
+INVERTED_CEILING = 0.10
+UNRESPONSIVE_CEILING = 0.15
+
+# Neither commanded nor observed: consistent, but no evidence either way.
+NO_CHANGE_SCORE = 0.5
+
+
+class ContingencyVerdict(str, Enum):
+    """How an observed body change relates to the commanded one."""
+
+    SELF_CAUSED = "self_caused"
+    INVERTED = "inverted"
+    UNRESPONSIVE = "unresponsive"
+    EXTERNALLY_CAUSED = "externally_caused"
+    NO_CHANGE = "no_change"
+    UNVERIFIED = "unverified"
+
+
+class BodyPose(BaseModel):
+    """Absolute pose of a controllable body channel, in degrees."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    pan: float = 0.0
+    tilt: float = 0.0
+
+    def delta_to(self, other: "BodyPose") -> dict[str, float]:
+        return {"pan": other.pan - self.pan, "tilt": other.tilt - self.tilt}
+
+
+class BodyObservation(BaseModel):
+    """A measured or declared body state before and after an action."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    channel: str = "camera_pose"
+    before: BodyPose
+    after: BodyPose
+    observed_latency_ms: int | None = None
+    # `measured` came from hardware; `declared` is the caller's assertion and is
+    # kept separable so a later audit can discount it.
+    source: Literal["measured", "declared"] = "measured"
+
+
+class ReafferenceVerdict(BaseModel):
+    """The scored comparison, carrying every term that produced the score."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    verdict: ContingencyVerdict
+    score: float = Field(ge=0.0, le=1.0)
+    direction_score: float = Field(ge=0.0, le=1.0)
+    magnitude_score: float = Field(ge=0.0, le=1.0)
+    timing_score: float = Field(ge=0.0, le=1.0)
+    magnitude_ratio: float | None = None
+    commanded_delta: dict[str, float] = Field(default_factory=dict)
+    observed_delta: dict[str, float] = Field(default_factory=dict)
+    rationale: list[str] = Field(default_factory=list)
+
+
+def evaluate_reafference(
+    *,
+    commanded_delta: dict[str, float] | None,
+    observation: BodyObservation | None,
+    expected_latency_ms: int | None = None,
+) -> ReafferenceVerdict:
+    """Score an observed body change against the one that was commanded.
+
+    Returns an UNVERIFIED verdict when there is nothing to compare, so callers
+    can fall back to whatever they did before rather than inventing evidence.
+    """
+    if observation is None or commanded_delta is None:
+        return ReafferenceVerdict(
+            verdict=ContingencyVerdict.UNVERIFIED,
+            score=NO_CHANGE_SCORE,
+            direction_score=0.0,
+            magnitude_score=0.0,
+            timing_score=0.0,
+            commanded_delta=dict(commanded_delta or {}),
+            observed_delta={},
+            rationale=["no body observation for this action"],
+        )
+
+    observed_delta = observation.before.delta_to(observation.after)
+    commanded = _as_vector(commanded_delta)
+    observed = _as_vector(observed_delta)
+    commanded_magnitude = _magnitude(commanded)
+    observed_magnitude = _magnitude(observed)
+
+    commanded_moved = commanded_magnitude >= NOISE_FLOOR_DEGREES
+    observed_moved = observed_magnitude >= NOISE_FLOOR_DEGREES
+
+    timing = _timing_score(observation.observed_latency_ms, expected_latency_ms)
+
+    if not commanded_moved and not observed_moved:
+        return ReafferenceVerdict(
+            verdict=ContingencyVerdict.NO_CHANGE,
+            score=NO_CHANGE_SCORE,
+            direction_score=0.0,
+            magnitude_score=0.0,
+            timing_score=timing,
+            commanded_delta=dict(commanded_delta),
+            observed_delta=observed_delta,
+            rationale=["nothing commanded and nothing moved"],
+        )
+
+    if not commanded_moved and observed_moved:
+        return ReafferenceVerdict(
+            verdict=ContingencyVerdict.EXTERNALLY_CAUSED,
+            score=EXTERNALLY_CAUSED_CEILING,
+            direction_score=0.0,
+            magnitude_score=0.0,
+            timing_score=timing,
+            commanded_delta=dict(commanded_delta),
+            observed_delta=observed_delta,
+            magnitude_ratio=None,
+            rationale=[
+                f"body moved {observed_magnitude:.1f} deg with nothing commanded"
+            ],
+        )
+
+    if commanded_moved and not observed_moved:
+        return ReafferenceVerdict(
+            verdict=ContingencyVerdict.UNRESPONSIVE,
+            score=UNRESPONSIVE_CEILING,
+            direction_score=0.0,
+            magnitude_score=0.0,
+            timing_score=timing,
+            commanded_delta=dict(commanded_delta),
+            observed_delta=observed_delta,
+            magnitude_ratio=0.0,
+            rationale=[
+                f"commanded {commanded_magnitude:.1f} deg but the body did not move"
+            ],
+        )
+
+    cosine = _cosine(commanded, observed)
+    direction = (cosine + 1.0) / 2.0
+    ratio = observed_magnitude / commanded_magnitude
+    magnitude = _magnitude_score(ratio)
+    score = (
+        DIRECTION_WEIGHT * direction
+        + MAGNITUDE_WEIGHT * magnitude
+        + TIMING_WEIGHT * timing
+    )
+
+    if cosine < 0.0:
+        return ReafferenceVerdict(
+            verdict=ContingencyVerdict.INVERTED,
+            score=min(score, INVERTED_CEILING),
+            direction_score=direction,
+            magnitude_score=magnitude,
+            timing_score=timing,
+            magnitude_ratio=ratio,
+            commanded_delta=dict(commanded_delta),
+            observed_delta=observed_delta,
+            rationale=[f"observed movement opposes the command (cos={cosine:.2f})"],
+        )
+
+    return ReafferenceVerdict(
+        verdict=ContingencyVerdict.SELF_CAUSED,
+        score=_clamp01(score),
+        direction_score=direction,
+        magnitude_score=magnitude,
+        timing_score=timing,
+        magnitude_ratio=ratio,
+        commanded_delta=dict(commanded_delta),
+        observed_delta=observed_delta,
+        rationale=[
+            f"direction cos={cosine:.2f}",
+            f"magnitude ratio={ratio:.2f}",
+        ],
+    )
+
+
+def commanded_delta_from_tool(
+    tool_name: str, tool_input: dict[str, object]
+) -> dict[str, float] | None:
+    """Read the intended pose change out of a camera tool call.
+
+    Returns None for tools that do not move the body, which is what makes the
+    verdict UNVERIFIED rather than a fabricated zero.
+    """
+    axis_sign = _CAMERA_TOOLS.get(tool_name)
+    if axis_sign is None:
+        return None
+    axis, sign = axis_sign
+    degrees = tool_input.get("degrees")
+    if degrees is None:
+        degrees = _DEFAULT_DEGREES[axis]
+    try:
+        amount = float(degrees)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    delta = {"pan": 0.0, "tilt": 0.0}
+    delta[axis] = sign * amount
+    return delta
+
+
+# Tool name -> (axis, sign). Left and down are negative by the same convention
+# the camera package uses for its own position tracking.
+_CAMERA_TOOLS: dict[str, tuple[str, float]] = {
+    "look_left": ("pan", -1.0),
+    "look_right": ("pan", 1.0),
+    "look_up": ("tilt", 1.0),
+    "look_down": ("tilt", -1.0),
+    "right_eye_look_left": ("pan", -1.0),
+    "right_eye_look_right": ("pan", 1.0),
+    "right_eye_look_up": ("tilt", 1.0),
+    "right_eye_look_down": ("tilt", -1.0),
+    "both_eyes_look_left": ("pan", -1.0),
+    "both_eyes_look_right": ("pan", 1.0),
+    "both_eyes_look_up": ("tilt", 1.0),
+    "both_eyes_look_down": ("tilt", -1.0),
+}
+
+# Matches the camera tool defaults, so an omitted `degrees` is still checkable.
+_DEFAULT_DEGREES = {"pan": 30.0, "tilt": 20.0}
+
+
+def _as_vector(delta: dict[str, float]) -> tuple[float, float]:
+    return (float(delta.get("pan", 0.0)), float(delta.get("tilt", 0.0)))
+
+
+def _magnitude(vector: tuple[float, float]) -> float:
+    return math.hypot(vector[0], vector[1])
+
+
+def _cosine(a: tuple[float, float], b: tuple[float, float]) -> float:
+    denominator = _magnitude(a) * _magnitude(b)
+    if denominator == 0.0:
+        return 0.0
+    return _clamp((a[0] * b[0] + a[1] * b[1]) / denominator, -1.0, 1.0)
+
+
+def _magnitude_score(ratio: float) -> float:
+    """1.0 while the ratio error stays inside tolerance, falling to 0 at 2x."""
+    error = abs(ratio - 1.0)
+    if error <= MAGNITUDE_TOLERANCE:
+        return 1.0
+    return _clamp01(1.0 - (error - MAGNITUDE_TOLERANCE) / (1.0 - MAGNITUDE_TOLERANCE))
+
+
+def _timing_score(
+    observed_latency_ms: int | None, expected_latency_ms: int | None
+) -> float:
+    if observed_latency_ms is None or expected_latency_ms is None:
+        return 0.5
+    scale = max(500.0, float(expected_latency_ms))
+    return _clamp01(
+        math.exp(-abs(observed_latency_ms - expected_latency_ms) / (2.0 * scale))
+    )
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, float(value)))
+
+
+def _clamp01(value: float) -> float:
+    return _clamp(value, 0.0, 1.0)
+
+
+class BodyContingencyStore:
+    """Append-only ledger of reafference verdicts, one per action at most."""
+
+    def __init__(self, db: SocialDB) -> None:
+        self._db = db
+
+    def record(
+        self,
+        *,
+        verdict: ReafferenceVerdict,
+        observation: BodyObservation | None,
+        owner_id: str = "self",
+        action_id: str | None = None,
+        outcome_ref: str | None = None,
+        field_id: str | None = None,
+        tick_id: str | None = None,
+        expected_latency_ms: int | None = None,
+    ) -> str:
+        """Store one verdict, returning the row id.
+
+        An action already carrying a verdict keeps the one it has: outcomes are
+        closed once, and a second write would mean the ledger disagreed with
+        the ownership score that was actually used.
+        """
+        if action_id is not None:
+            existing = self._db.fetchone(
+                "SELECT contingency_id FROM body_contingencies WHERE action_id = ?",
+                (action_id,),
+            )
+            if existing is not None:
+                return str(existing["contingency_id"])
+
+        contingency_id = f"bct_{secrets.token_urlsafe(12)}"
+        before = observation.before.model_dump() if observation else {}
+        after = observation.after.model_dump() if observation else {}
+        with self._db.transaction() as connection:
+            connection.execute(
+                """
+                INSERT INTO body_contingencies(
+                    contingency_id, owner_id, action_id, outcome_ref, field_id,
+                    tick_id, channel, commanded_delta_json, observed_before_json,
+                    observed_after_json, observed_delta_json, verdict,
+                    reafference_score, direction_score, magnitude_score,
+                    timing_score, magnitude_ratio, observed_latency_ms,
+                    expected_latency_ms, observation_source, rationale_json,
+                    created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    contingency_id,
+                    owner_id,
+                    action_id,
+                    outcome_ref,
+                    field_id,
+                    tick_id,
+                    observation.channel if observation else "camera_pose",
+                    _dumps(verdict.commanded_delta),
+                    _dumps(before),
+                    _dumps(after),
+                    _dumps(verdict.observed_delta),
+                    verdict.verdict.value,
+                    verdict.score,
+                    verdict.direction_score,
+                    verdict.magnitude_score,
+                    verdict.timing_score,
+                    verdict.magnitude_ratio,
+                    observation.observed_latency_ms if observation else None,
+                    expected_latency_ms,
+                    observation.source if observation else "measured",
+                    _dumps(verdict.rationale),
+                    utc_now(),
+                ),
+            )
+        return contingency_id
+
+    def for_action(self, action_id: str) -> dict[str, Any] | None:
+        row = self._db.fetchone(
+            "SELECT * FROM body_contingencies WHERE action_id = ?", (action_id,)
+        )
+        return None if row is None else dict(row)
+
+    def recent(
+        self,
+        *,
+        owner_id: str = "self",
+        verdict: ContingencyVerdict | None = None,
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        if verdict is None:
+            rows = self._db.fetchall(
+                """
+                SELECT * FROM body_contingencies
+                WHERE owner_id = ?
+                ORDER BY created_at DESC LIMIT ?
+                """,
+                (owner_id, limit),
+            )
+        else:
+            rows = self._db.fetchall(
+                """
+                SELECT * FROM body_contingencies
+                WHERE owner_id = ? AND verdict = ?
+                ORDER BY created_at DESC LIMIT ?
+                """,
+                (owner_id, verdict.value, limit),
+            )
+        return [dict(row) for row in rows]
+
+
+def _dumps(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/conftest.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/conftest.py
@@ -8,6 +8,25 @@ from pathlib import Path
 import pytest
 from social_core.db import SocialDB
 
+# Baseline the whole suite runs against. Without this, every test reads the
+# repository's mcpBehavior.toml, so changing a shipped default silently changes
+# what unrelated tests assert. Tests that care about a flag set it themselves.
+BASELINE_BEHAVIOR = """[individual-kernel]
+generative_field_model = true
+generative_rollout_horizon = 2
+allostatic_valence = false
+valence_coupling = false
+"""
+
+
+@pytest.fixture(autouse=True)
+def baseline_behavior(
+    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path_factory.mktemp("behavior") / "mcpBehavior.toml"
+    path.write_text(BASELINE_BEHAVIOR, encoding="utf-8")
+    monkeypatch.setenv("MCP_BEHAVIOR_TOML", str(path))
+
 
 @pytest.fixture
 def temp_db_path(tmp_path: Path) -> Path:

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_body_agency_integration.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_body_agency_integration.py
@@ -1,0 +1,196 @@
+"""Closing a body action: the reafference, not the return code, sets causal fit."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from social_core.db import SocialDB
+
+from individual_kernel_mcp.agency import ActionProposal, AgencyStore
+from individual_kernel_mcp.body_contingency import (
+    BodyContingencyStore,
+    BodyObservation,
+    BodyPose,
+)
+from individual_kernel_mcp.enacted_field import EnactedField, TriggerKind
+from individual_kernel_mcp.tick import TickProducer
+from individual_kernel_mcp.workspace import (
+    CandidateKind,
+    CandidateSource,
+    SourceMode,
+    WorkspaceCandidate,
+)
+
+
+def _producer(social_db: SocialDB, tmp_path: Path) -> TickProducer:
+    interoception = tmp_path / "interoception.json"
+    interoception.write_text(json.dumps({"now": {"arousal": 20.0}}), encoding="utf-8")
+    desires = tmp_path / "desires.json"
+    desires.write_text(json.dumps({"desires": {}}), encoding="utf-8")
+    return TickProducer(
+        social_db, interoception_path=interoception, desires_path=desires
+    )
+
+
+def _commit(producer: TickProducer) -> EnactedField:
+    opened = producer.begin_tick(TriggerKind.USER_PROMPT)
+    producer.workspace.add_candidate(
+        WorkspaceCandidate(
+            tick_id=opened.tick_id,
+            kind=CandidateKind.GOAL,
+            content_ref="desire:look_outside",
+            content_summary="need look_outside",
+            source=CandidateSource.DESIRE,
+            source_mode=SourceMode.INFERRED,
+            modality="internal",
+            precision=1.0,
+            need_relevance=1.0,
+            goal_relevance=1.0,
+            continuity_with_previous=1.0,
+            controllability=1.0,
+        )
+    )
+    return producer.compete_and_commit(opened.tick_id).field
+
+
+def _propose(
+    agency: AgencyStore, field: EnactedField, *, tool_name: str = "look_left"
+) -> str:
+    record = agency.propose(
+        ActionProposal(
+            field_id=field.field_id,
+            tool_name=tool_name,
+            tool_input={"degrees": 30},
+            goal="look toward the window",
+            confidence=0.8,
+            # Stated so the timing term is actually scored rather than falling
+            # back to the neutral 0.5 an unknown expectation earns.
+            expected_latency_ms=800,
+        )
+    )
+    return record.action_id
+
+
+def _observation(pan_after: float) -> BodyObservation:
+    return BodyObservation(
+        before=BodyPose(pan=0.0, tilt=0.0),
+        after=BodyPose(pan=pan_after, tilt=0.0),
+        observed_latency_ms=800,
+    )
+
+
+class TestCausalFitFollowsTheBody:
+    def test_matched_movement_beats_movement_nobody_commanded(
+        self, social_db: SocialDB, tmp_path: Path
+    ) -> None:
+        producer = _producer(social_db, tmp_path)
+        agency = AgencyStore(social_db)
+
+        matched_id = _propose(agency, _commit(producer))
+        _, matched = agency.close(
+            action_id=matched_id,
+            actual_result_summary="panned left",
+            success=True,
+            latency_ms=800,
+            body_observation=_observation(-30.0),
+        )
+
+        # Same successful tool call, but the body went the other way.
+        inverted_id = _propose(agency, _commit(producer))
+        _, inverted = agency.close(
+            action_id=inverted_id,
+            actual_result_summary="panned left",
+            success=True,
+            latency_ms=800,
+            body_observation=_observation(30.0),
+        )
+
+        assert matched.exclusive_causal_fit > 0.9
+        assert inverted.exclusive_causal_fit <= 0.1
+        assert inverted.ownership_score < matched.ownership_score
+
+    def test_success_alone_no_longer_grants_full_causal_fit(
+        self, social_db: SocialDB, tmp_path: Path
+    ) -> None:
+        producer = _producer(social_db, tmp_path)
+        agency = AgencyStore(social_db)
+        action_id = _propose(agency, _commit(producer))
+
+        # The call returned success but the body never moved.
+        _, assessment = agency.close(
+            action_id=action_id,
+            actual_result_summary="panned left",
+            success=True,
+            latency_ms=800,
+            body_observation=_observation(0.0),
+        )
+        assert assessment.exclusive_causal_fit <= 0.15
+
+
+class TestNoBodyChannel:
+    def test_non_body_tool_keeps_the_previous_scoring(
+        self, social_db: SocialDB, tmp_path: Path
+    ) -> None:
+        producer = _producer(social_db, tmp_path)
+        agency = AgencyStore(social_db)
+        action_id = _propose(agency, _commit(producer), tool_name="Bash")
+        _, assessment = agency.close(
+            action_id=action_id,
+            actual_result_summary="ok",
+            success=True,
+            latency_ms=800,
+        )
+        assert assessment.exclusive_causal_fit == pytest.approx(1.0)
+
+    def test_failed_non_body_tool_keeps_the_previous_penalty(
+        self, social_db: SocialDB, tmp_path: Path
+    ) -> None:
+        producer = _producer(social_db, tmp_path)
+        agency = AgencyStore(social_db)
+        action_id = _propose(agency, _commit(producer), tool_name="Bash")
+        _, assessment = agency.close(
+            action_id=action_id,
+            actual_result_summary="failed",
+            success=False,
+            latency_ms=800,
+        )
+        assert assessment.exclusive_causal_fit == pytest.approx(0.65)
+
+
+class TestLedger:
+    def test_every_close_leaves_one_verdict(
+        self, social_db: SocialDB, tmp_path: Path
+    ) -> None:
+        producer = _producer(social_db, tmp_path)
+        agency = AgencyStore(social_db)
+        action_id = _propose(agency, _commit(producer))
+        agency.close(
+            action_id=action_id,
+            actual_result_summary="panned left",
+            success=True,
+            latency_ms=800,
+            body_observation=_observation(-30.0),
+        )
+        stored = BodyContingencyStore(social_db).for_action(action_id)
+        assert stored is not None
+        assert stored["verdict"] == "self_caused"
+        assert json.loads(stored["commanded_delta_json"])["pan"] == -30.0
+
+    def test_closing_twice_does_not_duplicate_the_verdict(
+        self, social_db: SocialDB, tmp_path: Path
+    ) -> None:
+        producer = _producer(social_db, tmp_path)
+        agency = AgencyStore(social_db)
+        action_id = _propose(agency, _commit(producer))
+        for _ in range(2):
+            agency.close(
+                action_id=action_id,
+                actual_result_summary="panned left",
+                success=True,
+                latency_ms=800,
+                body_observation=_observation(-30.0),
+            )
+        rows = BodyContingencyStore(social_db).recent(limit=50)
+        assert len([row for row in rows if row["action_id"] == action_id]) == 1

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_body_contingency.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_body_contingency.py
@@ -1,0 +1,174 @@
+"""Reafference scoring: the commanded body change against the observed one."""
+
+from __future__ import annotations
+
+import pytest
+
+from individual_kernel_mcp.body_contingency import (
+    BodyObservation,
+    BodyPose,
+    ContingencyVerdict,
+    commanded_delta_from_tool,
+    evaluate_reafference,
+)
+
+EXPECTED_LATENCY_MS = 1000
+
+
+def _observation(
+    *,
+    pan_before: float = 0.0,
+    tilt_before: float = 0.0,
+    pan_after: float = 0.0,
+    tilt_after: float = 0.0,
+    latency_ms: int | None = EXPECTED_LATENCY_MS,
+) -> BodyObservation:
+    return BodyObservation(
+        before=BodyPose(pan=pan_before, tilt=tilt_before),
+        after=BodyPose(pan=pan_after, tilt=tilt_after),
+        observed_latency_ms=latency_ms,
+    )
+
+
+class TestMatchedMovement:
+    def test_commanded_and_observed_agree_scores_high(self):
+        verdict = evaluate_reafference(
+            commanded_delta={"pan": 30.0, "tilt": 0.0},
+            observation=_observation(pan_after=30.0),
+            expected_latency_ms=EXPECTED_LATENCY_MS,
+        )
+        assert verdict.verdict is ContingencyVerdict.SELF_CAUSED
+        assert verdict.score > 0.9
+        assert verdict.magnitude_ratio == pytest.approx(1.0)
+
+    def test_slightly_short_movement_still_self_caused(self):
+        verdict = evaluate_reafference(
+            commanded_delta={"pan": 30.0, "tilt": 0.0},
+            observation=_observation(pan_after=24.0),
+            expected_latency_ms=EXPECTED_LATENCY_MS,
+        )
+        assert verdict.verdict is ContingencyVerdict.SELF_CAUSED
+        # 20% short is inside tolerance, so magnitude is not penalised at all.
+        assert verdict.magnitude_score == pytest.approx(1.0)
+
+    def test_overshoot_beyond_tolerance_lowers_the_score(self):
+        tight = evaluate_reafference(
+            commanded_delta={"pan": 30.0, "tilt": 0.0},
+            observation=_observation(pan_after=30.0),
+            expected_latency_ms=EXPECTED_LATENCY_MS,
+        )
+        loose = evaluate_reafference(
+            commanded_delta={"pan": 30.0, "tilt": 0.0},
+            observation=_observation(pan_after=55.0),
+            expected_latency_ms=EXPECTED_LATENCY_MS,
+        )
+        assert loose.verdict is ContingencyVerdict.SELF_CAUSED
+        assert loose.score < tight.score
+
+
+class TestDelayedMovement:
+    def test_late_arrival_lowers_the_score_but_keeps_the_verdict(self):
+        prompt = evaluate_reafference(
+            commanded_delta={"pan": 30.0, "tilt": 0.0},
+            observation=_observation(pan_after=30.0, latency_ms=1000),
+            expected_latency_ms=EXPECTED_LATENCY_MS,
+        )
+        late = evaluate_reafference(
+            commanded_delta={"pan": 30.0, "tilt": 0.0},
+            observation=_observation(pan_after=30.0, latency_ms=20000),
+            expected_latency_ms=EXPECTED_LATENCY_MS,
+        )
+        assert late.verdict is ContingencyVerdict.SELF_CAUSED
+        assert late.timing_score < prompt.timing_score
+        assert late.score < prompt.score
+
+
+class TestFalseMovement:
+    def test_movement_with_nothing_commanded_is_externally_caused(self):
+        verdict = evaluate_reafference(
+            commanded_delta={"pan": 0.0, "tilt": 0.0},
+            observation=_observation(pan_after=25.0),
+            expected_latency_ms=EXPECTED_LATENCY_MS,
+        )
+        assert verdict.verdict is ContingencyVerdict.EXTERNALLY_CAUSED
+        assert verdict.score <= 0.1
+
+    def test_command_with_no_movement_is_unresponsive(self):
+        verdict = evaluate_reafference(
+            commanded_delta={"pan": 30.0, "tilt": 0.0},
+            observation=_observation(pan_after=0.2),
+            expected_latency_ms=EXPECTED_LATENCY_MS,
+        )
+        assert verdict.verdict is ContingencyVerdict.UNRESPONSIVE
+        assert verdict.score <= 0.15
+
+    def test_still_body_with_no_command_carries_no_evidence(self):
+        verdict = evaluate_reafference(
+            commanded_delta={"pan": 0.0, "tilt": 0.0},
+            observation=_observation(),
+            expected_latency_ms=EXPECTED_LATENCY_MS,
+        )
+        assert verdict.verdict is ContingencyVerdict.NO_CHANGE
+        assert verdict.score == pytest.approx(0.5)
+
+
+class TestInvertedMovement:
+    def test_opposite_direction_scores_at_the_floor(self):
+        verdict = evaluate_reafference(
+            commanded_delta={"pan": 30.0, "tilt": 0.0},
+            observation=_observation(pan_after=-30.0),
+            expected_latency_ms=EXPECTED_LATENCY_MS,
+        )
+        assert verdict.verdict is ContingencyVerdict.INVERTED
+        assert verdict.score <= 0.1
+
+    def test_inverted_scores_below_a_perfectly_matched_move(self):
+        matched = evaluate_reafference(
+            commanded_delta={"pan": 30.0, "tilt": 0.0},
+            observation=_observation(pan_after=30.0),
+            expected_latency_ms=EXPECTED_LATENCY_MS,
+        )
+        inverted = evaluate_reafference(
+            commanded_delta={"pan": 30.0, "tilt": 0.0},
+            observation=_observation(pan_after=-30.0),
+            expected_latency_ms=EXPECTED_LATENCY_MS,
+        )
+        assert inverted.score < matched.score
+
+
+class TestUnverified:
+    def test_missing_observation_is_unverified(self):
+        verdict = evaluate_reafference(
+            commanded_delta={"pan": 30.0, "tilt": 0.0},
+            observation=None,
+            expected_latency_ms=EXPECTED_LATENCY_MS,
+        )
+        assert verdict.verdict is ContingencyVerdict.UNVERIFIED
+
+    def test_missing_command_is_unverified(self):
+        verdict = evaluate_reafference(
+            commanded_delta=None,
+            observation=_observation(pan_after=30.0),
+            expected_latency_ms=EXPECTED_LATENCY_MS,
+        )
+        assert verdict.verdict is ContingencyVerdict.UNVERIFIED
+
+
+class TestCommandedDeltaFromTool:
+    def test_reads_direction_and_amount(self):
+        assert commanded_delta_from_tool("look_left", {"degrees": 45}) == {
+            "pan": -45.0,
+            "tilt": 0.0,
+        }
+        assert commanded_delta_from_tool("look_up", {"degrees": 20}) == {
+            "pan": 0.0,
+            "tilt": 20.0,
+        }
+
+    def test_omitted_degrees_falls_back_to_the_tool_default(self):
+        assert commanded_delta_from_tool("look_right", {}) == {"pan": 30.0, "tilt": 0.0}
+        assert commanded_delta_from_tool("look_down", {}) == {"pan": 0.0, "tilt": -20.0}
+
+    def test_non_body_tool_returns_none(self):
+        assert commanded_delta_from_tool("Bash", {"command": "ls"}) is None
+        assert commanded_delta_from_tool("see", {}) is None

--- a/docs/allostatic-valence-design.md
+++ b/docs/allostatic-valence-design.md
@@ -1,7 +1,7 @@
 # Allostatic Valence Design
 
 Status: shipped 2026-07-27 on the `feat/allostatic-valence` branch, behind
-`[individual-kernel] allostatic_valence`, which defaults to **off**. Scope: the
+`[individual-kernel] allostatic_valence`, which defaults to **on** (verified live 2026-07-28). Scope: the
 body state only. Action selection, workspace competition, the `<current_field>`
 surface, and the boundary gate are unchanged.
 
@@ -101,7 +101,7 @@ No migration is required. Every input already existed:
 measured control, `experienced_transitions` for unresolved error, and the desire
 file for needs.
 
-## Why the flag defaults to off
+## Why the flag shipped off first
 
 The generative layer in PR #108 shipped enabled because it only *added* rows.
 This change rewrites a value the whole runtime reads, including workspace

--- a/docs/body-agency.md
+++ b/docs/body-agency.md
@@ -1,0 +1,98 @@
+# Body Agency Design
+
+Status: shipped 2026-07-28 on the `feat/body-contingency` branch. Scope: the
+`exclusive_causal_fit` term of the agency assessment, and a new ledger of
+reafference verdicts. Action selection, workspace competition, the
+`<current_field>` surface, and the boundary gate are unchanged.
+
+Claim policy: this compares one measured quantity against another. Nothing in
+it is a phenomenal claim.
+
+## The defect
+
+`AgencyStore.close` set `exclusive_causal_fit = 1.0 if success else 0.65`. The
+term is supposed to answer "was this change caused by me and not by something
+else", and it was answering "did the tool call return without raising". Those
+are different questions, and the difference is exactly the interesting case: if
+someone else turns the camera, or the camera drifts, or the motor stalls while
+the API still reports success, the old rule awards full causal credit.
+
+The term carries weight 0.15 in the ownership score, so the error was small but
+systematic, and it made `ownership_score` unusable as evidence about the body.
+
+## The reafference test
+
+For a commanded body change, compare the observed change against it:
+
+```
+direction = (cos(commanded, observed) + 1) / 2
+magnitude = 1 while |observed/commanded - 1| <= 0.35, falling to 0 at 2x
+timing    = exp(-|observed_latency - expected_latency| / (2 * expected))
+score     = 0.5*direction + 0.3*magnitude + 0.2*timing
+```
+
+Direction is weighted highest because moving the *wrong way* is stronger
+evidence of an external cause than moving the right way by the wrong amount.
+
+The score is then capped by a verdict, so a favourable component cannot rescue
+an unfavourable classification:
+
+| verdict | when | ceiling |
+|---|---|---|
+| `self_caused` | commanded and observed agree in direction | none |
+| `inverted` | observed opposes the command | 0.10 |
+| `externally_caused` | the body moved with nothing commanded | 0.10 |
+| `unresponsive` | commanded, but the body did not move | 0.15 |
+| `no_change` | nothing commanded and nothing moved | 0.50 (no evidence) |
+| `unverified` | no observation, or a tool that does not move the body | falls back |
+
+Movement below 1.0 degree counts as no movement: that is the encoder noise floor
+on the PTZ hardware, and treating jitter as motion would manufacture
+`externally_caused` verdicts out of a stationary camera.
+
+## What stays the same without a body channel
+
+Most actions are not body actions. `commanded_delta_from_tool` returns None for
+anything outside the camera tool set, which yields `unverified`, which restores
+the old `1.0 / 0.65` heuristic exactly. Two tests assert this, so the change is
+additive for every non-camera action rather than a silent re-scoring of the
+whole history.
+
+## Where observations come from
+
+The kernel does not import the camera package. `AgencyStore.close` takes an
+optional `BodyObservation` (a before pose, an after pose, and a latency), and
+the caller supplies it. `source` distinguishes `measured` from `declared` so a
+later audit can discount poses that were asserted rather than read back from
+`get_hw_position()`.
+
+This keeps the dependency pointing the right way and leaves the verdict
+reproducible from the stored row alone.
+
+## Ledger
+
+Migration 010 adds `body_contingencies`: one row per action at most, enforced by
+a partial unique index on `action_id`. Closing an action twice returns the
+existing row rather than writing a second one, because the outcome it justified
+was also written once. A storage fault while recording is swallowed: the ledger
+is an audit trail, not a precondition for closing an action, and a failed insert
+must not strand a pending intention.
+
+## What was deliberately left out
+
+**Replacing the mismatch tokenizer with embedding cosine.** The roadmap called
+for this here. Hooks are a fresh subprocess per call, so an embedding model
+would be loaded on every tool invocation; the target for hook latency is under
+100ms and a transformer load is two orders of magnitude past that. The
+CJK-aware token overlap from PR-1 stays until an embedding can live in a
+resident process, which is what the PR-7 daemon provides.
+
+**Arousal-weighted timing.** The timing term uses the stated expectation only.
+An unknown expectation scores a neutral 0.5 rather than guessing.
+
+## What later phases take from here
+
+The ledger is the substrate for a self/other discrimination measurement: the
+rate of `externally_caused` verdicts over a window is a direct, non-verbal
+indicator, and it belongs in the indicator profile once enough rows exist to
+make the rate meaningful.

--- a/docs/valence-coupling-design.md
+++ b/docs/valence-coupling-design.md
@@ -1,7 +1,7 @@
 # Valence Coupling Design
 
 Status: shipped 2026-07-27 on the `feat/valence-coupling` branch, behind
-`[individual-kernel] valence_coupling`, which defaults to **off**. Scope: which
+`[individual-kernel] valence_coupling`, which defaults to **on** (verified live 2026-07-28). Scope: which
 candidate wins workspace competition. Ignition thresholds, the `<current_field>`
 surface, and the boundary gate are unchanged.
 

--- a/mcpBehavior.toml
+++ b/mcpBehavior.toml
@@ -50,9 +50,11 @@ port = 8080
 [individual-kernel]
 generative_field_model = true      # 予測・学習ループ（追加テーブルへの書き込みのみ、行為選択は不変）
 generative_rollout_horizon = 2     # propose 時の rollout 深さ (1-5)
-allostatic_valence = false         # valence/needs/controllability の再定義。既定 off:
-                                   # 既存の body state を書き換えるため、ライブで一度
-                                   # 確認してから on にする（docs/allostatic-valence-design.md）
-valence_coupling = false           # affect で競合重みを変調する。既定 off:
-                                   # 何がフィールドに上がるかが変わる。boundary gate は
-                                   # 一切読まない（docs/valence-coupling-design.md）
+allostatic_valence = true          # valence/needs/controllability の再定義。既定 on:
+                                   # 2026-07-28 のライブ確認で control が実測 ownership に
+                                   # 追従し valence が tick ごとに動くことを確認した
+                                   # （docs/allostatic-valence-design.md）
+valence_coupling = true            # affect で競合重みを変調する。既定 on:
+                                   # 2026-07-28 のライブ確認でスコア差が設計式と一致した。
+                                   # boundary gate は一切読まない
+                                   # （docs/valence-coupling-design.md）

--- a/sociality-mcp/packages/social-core/src/social_core/migrations.py
+++ b/sociality-mcp/packages/social-core/src/social_core/migrations.py
@@ -406,6 +406,48 @@ CREATE INDEX IF NOT EXISTS idx_field_transitions_action
     ON field_transitions(action_id, created_at DESC);
 """
 
+_MIGRATION_010_SQL = """
+CREATE TABLE IF NOT EXISTS body_contingencies (
+    contingency_id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    action_id TEXT REFERENCES field_intentions(action_id) ON DELETE SET NULL,
+    outcome_ref TEXT REFERENCES field_action_outcomes(outcome_id) ON DELETE SET NULL,
+    field_id TEXT REFERENCES enacted_fields(field_id) ON DELETE CASCADE,
+    tick_id TEXT REFERENCES tick_frames(tick_id) ON DELETE CASCADE,
+    channel TEXT NOT NULL DEFAULT 'camera_pose',
+    commanded_delta_json TEXT NOT NULL DEFAULT '{}',
+    observed_before_json TEXT NOT NULL DEFAULT '{}',
+    observed_after_json TEXT NOT NULL DEFAULT '{}',
+    observed_delta_json TEXT NOT NULL DEFAULT '{}',
+    verdict TEXT NOT NULL,
+    reafference_score REAL NOT NULL,
+    direction_score REAL NOT NULL,
+    magnitude_score REAL NOT NULL,
+    timing_score REAL NOT NULL,
+    magnitude_ratio REAL,
+    observed_latency_ms INTEGER,
+    expected_latency_ms INTEGER,
+    observation_source TEXT NOT NULL DEFAULT 'measured',
+    rationale_json TEXT NOT NULL DEFAULT '[]',
+    created_at TEXT NOT NULL,
+    CHECK(reafference_score >= 0.0 AND reafference_score <= 1.0),
+    CHECK(direction_score >= 0.0 AND direction_score <= 1.0),
+    CHECK(magnitude_score >= 0.0 AND magnitude_score <= 1.0),
+    CHECK(timing_score >= 0.0 AND timing_score <= 1.0),
+    CHECK(observation_source IN ('measured', 'declared')),
+    CHECK(verdict IN (
+        'self_caused', 'inverted', 'unresponsive',
+        'externally_caused', 'no_change', 'unverified'
+    ))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_body_contingencies_action
+    ON body_contingencies(action_id) WHERE action_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_body_contingencies_owner_created
+    ON body_contingencies(owner_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_body_contingencies_verdict
+    ON body_contingencies(verdict, created_at DESC);
+"""
+
 _MIGRATION_009_SQL = """
 CREATE TABLE IF NOT EXISTS protention_distributions (
     distribution_id TEXT PRIMARY KEY,
@@ -777,6 +819,10 @@ MIGRATIONS = [
     Migration(
         name="009_generative_field_model",
         sql=_MIGRATION_009_SQL,
+    ),
+    Migration(
+        name="010_body_contingency",
+        sql=_MIGRATION_010_SQL,
     ),
 ]
 


### PR DESCRIPTION
## Summary

PR-4 of the roadmap, plus the live check PR-2 and PR-3 deferred.

`exclusive_causal_fit` was `1.0 if success else 0.65`. The term exists to
separate changes the runtime caused from changes something else caused, and it
was reporting whether the tool call raised. A camera someone else turns, a
camera that drifts, and a motor that stalls behind a successful API call all
scored full causal credit.

It now scores the reafference:

```
direction = (cos(commanded, observed) + 1) / 2
magnitude = 1 while |observed/commanded - 1| <= 0.35, falling to 0 at 2x
timing    = exp(-|observed_latency - expected_latency| / (2 * expected))
score     = 0.5*direction + 0.3*magnitude + 0.2*timing
```

then caps it by verdict, so a favourable component cannot rescue an
unfavourable classification:

| verdict | when | ceiling |
|---|---|---|
| `self_caused` | direction agrees | none |
| `inverted` | observed opposes the command | 0.10 |
| `externally_caused` | body moved, nothing commanded | 0.10 |
| `unresponsive` | commanded, body did not move | 0.15 |
| `no_change` | nothing commanded, nothing moved | 0.50 |
| `unverified` | no observation, or a non-body tool | falls back |

Design: `docs/body-agency.md`. Migration 010 adds `body_contingencies`, one row
per action, enforced by a partial unique index.

Claim policy: this compares one measured quantity against another. Nothing here
is a phenomenal claim.

## Nothing outside the camera tools is re-scored

`commanded_delta_from_tool` returns None for any tool that does not move the
body, which yields `unverified`, which restores the old `1.0 / 0.65` exactly.
Two tests assert both branches of that, so this is additive rather than a silent
re-scoring of every past action.

The kernel does not import the camera package. `close()` takes an optional
`BodyObservation` and the caller supplies it; `source` separates `measured` from
`declared` so a later audit can discount asserted poses.

## Flags now ship on

`allostatic_valence` and `valence_coupling` were held off pending a live check.
It ran on 2026-07-28 against the running hook:

- **allostatic**: `control` moved from a frozen 0.575 to the measured
  `ownership_score` and tracked it tick by tick (0.872 -> 0.850 -> 0.856);
  `need_vector` went from one pinned entry to five.
- **coupling**: the need-relevant candidate went 1.9325 -> 2.04251 and an
  information-bearing one 0.79 -> 0.755775. At valence -0.48893 the formula
  predicts +0.110009 and -0.034225. Both match to seven decimals.

A flag that ships off indefinitely is dead code. They are on, and the evidence
is in the CHANGELOG rather than in a commit message nobody re-reads.

One honest limit: the desire snapshot has not been written since 2026-05-18, so
after 71 days of projection every need saturates and `need_vector` is determined
by set points alone. That is a property of the input, not the composition, and
it is what PR-7 fixes by moving the clock into the kernel.

## The suite no longer reads the repository's config

Flipping those defaults broke `test_from_committed_field_is_deterministic`,
which asserted `valence_bucket == "neu"` while the flag it depended on lived in
a file it never mentioned. An autouse conftest fixture now pins the baseline, so
changing a shipped default cannot silently change what unrelated tests assert.
Tests that care about a flag still set it themselves.

## Deliberately not done here

The roadmap put "replace the mismatch tokenizer with embedding cosine" in this
PR. Hooks are a fresh subprocess per call, so that means loading a transformer
on every tool invocation against a sub-100ms latency target. The CJK-aware token
overlap from #108 stays until an embedding can live in a resident process, which
is what the PR-7 daemon provides. Reasoned in `docs/body-agency.md`.

## Tests

384 passed (kernel + social-core), 14 new reafference cases covering matched,
delayed, false, inverted, unresponsive and unverified, plus 6 integration cases
asserting causal fit follows the body and the ledger holds one row per action.
`uv lock --check` clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
