### PR TITLE
feat(individual-kernel): let higher-order records bias precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ All notable changes to embodied-claude are documented here.
 
 ### Added
 
+- individual-kernel: higher-order feedback, behind `hor_precision_feedback` in
+  `[individual-kernel]` (default off). Recent HOR records now raise the
+  precision of the channel their asserted mode speaks to, capped so repeating
+  an assertion cannot substitute for evidence. Until now nothing read those
+  records back, so a HOR could be present, absent or wrong and every other
+  quantity came out identical. Ablating the feedback lowers
+  `IndicatorProfile.self_model_feedback`, which is a mean over precision values
+  and reads no self-report; a test asserts the drop.
+- individual-kernel: `ProcessMetaRepresentation` and migration
+  `011_process_meta_representations`. One row per committed tick recording how
+  the field was produced -- candidate count, margin, entropy, ignition,
+  conflict, registered intention, and the HOR bias -- with a canonical
+  statement stored beside the numbers it summarises.
+- docs: `hor-ablation.md`.
 - individual-kernel: body contingency. `exclusive_causal_fit` is now the
   reafference between the commanded pose change and the observed one --
   direction, magnitude, and timing -- instead of a restatement of whether the

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/process_meta.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/process_meta.py
@@ -1,0 +1,239 @@
+"""Representing the processing, not only what was processed.
+
+The runtime already records higher-order representations: at the end of a tick
+it asserts things like "I am attending X". Until now those records went into a
+table and stopped there. Nothing downstream read them, so a HOR could be absent,
+present, or wrong and every other quantity in the system stayed identical.
+
+This module closes that loop in one narrow place: a HOR about a channel raises
+the precision assigned to that channel on the following tick. It also records a
+ProcessMetaRepresentation -- how the field was produced (what competed, by how
+much, whether it ignited) as distinct from what the field is about.
+
+Claim policy: this couples one recorded functional variable to another. Nothing
+in it is a phenomenal claim.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+from social_core.db import SocialDB
+from social_core.time import utc_now
+
+# How much a maximally confident HOR can raise its channel's precision.
+HOR_PRECISION_GAIN = 0.15
+
+# Total ceiling across however many HORs point at the same channel. Without
+# this, a burst of self-directed records could drive precision to 1.0 on
+# nothing but its own say-so.
+HOR_PRECISION_CAP = 0.20
+
+# Which precision channel each asserted mode speaks to. `attending`,
+# `intending` and `wanting` are all about the runtime's own processing rather
+# than about a sense, so they land on self_model.
+MODE_TO_CHANNEL: dict[str, str] = {
+    "seeing": "extero",
+    "feeling": "intero",
+    "remembering": "mnemonic",
+    "attending": "self_model",
+    "intending": "self_model",
+    "wanting": "self_model",
+}
+
+CHANNELS = ("extero", "intero", "mnemonic", "social", "self_model")
+
+
+class ProcessMetaRepresentation(BaseModel):
+    """What the production of one field looked like from the inside.
+
+    Every field already says what it is about. This says how it came to be:
+    how close the competition was, whether it ignited, how many candidates
+    were in play. It is the object a report about one's own processing would
+    have to be a report *of*.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    process_meta_id: str
+    owner_id: str = "self"
+    tick_id: str
+    field_id: str
+    producer: str = "deterministic"
+    trigger_kind: str
+    candidate_count: int = Field(ge=0)
+    winner_kind: str = ""
+    competition_margin: float = Field(ge=0.0)
+    competition_entropy: float = Field(ge=0.0, le=1.0)
+    ignited: bool
+    conflicted: bool
+    attention_intensity: float = Field(ge=0.0, le=1.0)
+    registered_intention: bool = False
+    hor_channel_bias: dict[str, float] = Field(default_factory=dict)
+    created_at: str = ""
+
+    def canonical_statement(self) -> str:
+        """A first-person sentence that reports the processing, not the content.
+
+        Kept here rather than in the surface layer so the assertion and the
+        numbers it summarises cannot drift apart.
+        """
+        settled = "settled" if self.ignited else "did not settle"
+        contested = "contested" if self.conflicted else "uncontested"
+        return (
+            f"{self.candidate_count} candidates competed and it {settled}; "
+            f"the choice was {contested} by a margin of "
+            f"{self.competition_margin:.3f}"
+        )
+
+
+class PrecisionBias(BaseModel):
+    """Per-channel precision adjustment derived from recent HORs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    extero: float = 0.0
+    intero: float = 0.0
+    mnemonic: float = 0.0
+    social: float = 0.0
+    self_model: float = 0.0
+
+    @property
+    def is_empty(self) -> bool:
+        return all(getattr(self, channel) == 0.0 for channel in CHANNELS)
+
+    def as_dict(self) -> dict[str, float]:
+        return {channel: getattr(self, channel) for channel in CHANNELS}
+
+
+def precision_bias_from_hors(records: list[Any]) -> PrecisionBias:
+    """Turn recent higher-order records into a per-channel precision bump.
+
+    Each record contributes `gain * confidence` to the channel its asserted
+    mode speaks to, and every channel is capped, so repeating an assertion
+    cannot substitute for evidence.
+    """
+    totals = dict.fromkeys(CHANNELS, 0.0)
+    for record in records:
+        mode = getattr(record, "asserted_mode", None)
+        mode_value = getattr(mode, "value", mode)
+        channel = MODE_TO_CHANNEL.get(str(mode_value))
+        if channel is None:
+            continue
+        confidence = float(getattr(record, "confidence", 0.0) or 0.0)
+        totals[channel] += HOR_PRECISION_GAIN * max(0.0, min(1.0, confidence))
+    return PrecisionBias(
+        **{channel: min(HOR_PRECISION_CAP, value) for channel, value in totals.items()}
+    )
+
+
+def apply_precision_bias(precision: Any, bias: PrecisionBias) -> Any:
+    """Add the bias to a PrecisionState, clamped to the model's own bounds.
+
+    Takes and returns the caller's type so this module does not have to import
+    the field schema.
+    """
+    if bias.is_empty:
+        return precision
+    updated = {
+        channel: max(0.0, min(1.0, getattr(precision, channel) + getattr(bias, channel)))
+        for channel in CHANNELS
+    }
+    return precision.model_copy(update=updated)
+
+
+class ProcessMetaStore:
+    """Append-only ledger of process-level self representations."""
+
+    def __init__(self, db: SocialDB) -> None:
+        self._db = db
+
+    def record(
+        self,
+        *,
+        tick_id: str,
+        field_id: str,
+        trigger_kind: str,
+        competition: dict[str, Any],
+        winner_kind: str = "",
+        registered_intention: bool = False,
+        hor_channel_bias: dict[str, float] | None = None,
+        owner_id: str = "self",
+    ) -> ProcessMetaRepresentation:
+        scores = competition.get("scores") or {}
+        record = ProcessMetaRepresentation(
+            process_meta_id=f"pmr_{secrets.token_urlsafe(12)}",
+            owner_id=owner_id,
+            tick_id=tick_id,
+            field_id=field_id,
+            trigger_kind=trigger_kind,
+            candidate_count=len(scores),
+            winner_kind=winner_kind,
+            competition_margin=max(0.0, float(competition.get("margin", 0.0) or 0.0)),
+            competition_entropy=_clamp01(competition.get("entropy", 0.0)),
+            ignited=bool(competition.get("ignited", False)),
+            conflicted=bool(competition.get("conflicted", False)),
+            attention_intensity=_clamp01(competition.get("attention_intensity", 0.0)),
+            registered_intention=registered_intention,
+            hor_channel_bias=hor_channel_bias or {},
+            created_at=utc_now(),
+        )
+        with self._db.transaction() as connection:
+            connection.execute(
+                """
+                INSERT INTO process_meta_representations(
+                    process_meta_id, owner_id, tick_id, field_id, producer,
+                    trigger_kind, candidate_count, winner_kind,
+                    competition_margin, competition_entropy, ignited, conflicted,
+                    attention_intensity, registered_intention,
+                    hor_channel_bias_json, canonical_statement, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.process_meta_id,
+                    record.owner_id,
+                    record.tick_id,
+                    record.field_id,
+                    record.producer,
+                    record.trigger_kind,
+                    record.candidate_count,
+                    record.winner_kind,
+                    record.competition_margin,
+                    record.competition_entropy,
+                    1 if record.ignited else 0,
+                    1 if record.conflicted else 0,
+                    record.attention_intensity,
+                    1 if record.registered_intention else 0,
+                    json.dumps(record.hor_channel_bias, sort_keys=True),
+                    record.canonical_statement(),
+                    record.created_at,
+                ),
+            )
+        return record
+
+    def for_tick(self, tick_id: str) -> dict[str, Any] | None:
+        row = self._db.fetchone(
+            "SELECT * FROM process_meta_representations WHERE tick_id = ?",
+            (tick_id,),
+        )
+        return None if row is None else dict(row)
+
+    def recent(
+        self, *, owner_id: str = "self", limit: int = 20
+    ) -> list[dict[str, Any]]:
+        rows = self._db.fetchall(
+            """
+            SELECT * FROM process_meta_representations
+            WHERE owner_id = ?
+            ORDER BY created_at DESC LIMIT ?
+            """,
+            (owner_id, limit),
+        )
+        return [dict(row) for row in rows]
+
+
+def _clamp01(value: Any) -> float:
+    return max(0.0, min(1.0, float(value or 0.0)))

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/tick.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/tick.py
@@ -48,6 +48,12 @@ from individual_kernel_mcp.frame import ConsciousFrameInput, TickFrameStore
 from individual_kernel_mcp.generative_model import NO_ACTION, ContextSignature
 from individual_kernel_mcp.hor import HORInput, HORRecord, HORStore
 from individual_kernel_mcp.prediction_loop import FieldPredictionLoop, generative_enabled
+from individual_kernel_mcp.process_meta import (
+    PrecisionBias,
+    ProcessMetaStore,
+    apply_precision_bias,
+    precision_bias_from_hors,
+)
 from individual_kernel_mcp.quality_geometry import QualityGeometry, QualitySignature
 from individual_kernel_mcp.valence_coupling import AffectState
 from individual_kernel_mcp.workspace import (
@@ -107,9 +113,24 @@ BoundaryEvaluator = Callable[[str, dict[str, Any], EnactedField], tuple[bool, st
 UNMEASURED_CONTROLLABILITY = 0.5
 UNRESOLVED_ERROR_WHEN_UNKNOWN = 0.5
 
+# How many recent higher-order records can bias precision. Small on purpose:
+# the point is that the last thing represented matters, not that a long history
+# of self-description accumulates into confidence.
+HOR_FEEDBACK_WINDOW = 3
+
 
 def allostatic_enabled() -> bool:
     return bool(get_behavior("individual-kernel", "allostatic_valence", False))
+
+
+def hor_feedback_enabled() -> bool:
+    """Whether higher-order records may raise the precision of their channel.
+
+    Without this the runtime records what it is attending to and nothing reads
+    it back, so the record is inert by construction. With it, representing that
+    you are attending changes how much the next tick trusts that channel.
+    """
+    return bool(get_behavior("individual-kernel", "hor_precision_feedback", False))
 
 
 def valence_coupling_enabled() -> bool:
@@ -158,6 +179,10 @@ class TickProducer:
         self.agency = agency or AgencyStore(db)
         self.quality = quality or QualityGeometry(db)
         self.prediction = prediction or FieldPredictionLoop(db, agency=self.agency)
+        self.process_meta = ProcessMetaStore(db)
+        # Carried from precision seeding to the process record so the two
+        # cannot disagree about what the feedback actually contributed.
+        self._last_precision_bias = PrecisionBias()
         self.events = EventStore(db=db)
         self.interoception_path = (
             Path(interoception_path)
@@ -249,7 +274,7 @@ class TickProducer:
                     ),
                     retention_refs=self._retention_refs(previous),
                     interoception=interoception,
-                    precision=self._initial_precision(previous),
+                    precision=self._seed_precision(previous),
                     agency_state=previous.agency_state if previous else AgencyState(),
                     epistemic_trace={
                         "producer": "deterministic",
@@ -582,6 +607,23 @@ class TickProducer:
                 temporal_order=self._next_temporal_order(final.owner_id),
                 metadata={"trigger": final.trigger_kind.value},
             )
+            try:
+                self.process_meta.record(
+                    tick_id=final.tick_id,
+                    field_id=final.field_id,
+                    trigger_kind=final.trigger_kind.value,
+                    competition=final.epistemic_trace.get("competition", {}),
+                    winner_kind=str(final.focal_content_ref or "").split(":", 1)[0],
+                    registered_intention=bool(
+                        final.agency_state.registered_intention
+                    ),
+                    hor_channel_bias=self._last_precision_bias.as_dict(),
+                    owner_id=final.owner_id,
+                )
+            except Exception:
+                # The process record is an audit trail. A storage fault must not
+                # roll back a field that has already been committed.
+                pass
             if generative_enabled():
                 try:
                     self.prediction.record_transition_and_update(
@@ -1054,6 +1096,25 @@ class TickProducer:
             refs.append(previous.focal_content_ref)
         refs.extend(previous.retention_refs[:3])
         return list(dict.fromkeys(refs))
+
+    def _seed_precision(self, previous: EnactedField | None) -> PrecisionState:
+        """Decay the previous precision, then let recent HORs raise a channel.
+
+        The decay is the pre-existing behaviour and stays exactly as it was.
+        The bias is what makes a higher-order record consequential: asserting
+        "I am attending" raises self_model precision on the tick that follows.
+        """
+        base = self._initial_precision(previous)
+        if not hor_feedback_enabled():
+            return base
+        try:
+            records = self.hors.query(owner_id="self", limit=HOR_FEEDBACK_WINDOW)
+        except Exception:
+            # Precision must always be producible; a query fault falls back to
+            # the decayed value rather than blocking the tick.
+            return base
+        self._last_precision_bias = precision_bias_from_hors(records)
+        return apply_precision_bias(base, self._last_precision_bias)
 
     @staticmethod
     def _initial_precision(previous: EnactedField | None) -> PrecisionState:

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_hor_ablation.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_hor_ablation.py
@@ -1,0 +1,144 @@
+"""Ablating the HOR feedback degrades a measured, non-verbal indicator.
+
+The point of the loop is that higher-order records do something. If removing
+them changed only what the runtime *says*, the records would be decoration. So
+the check here is on `IndicatorProfile.self_feedback`, which is the mean of
+`precision.self_model` over committed fields and is computed without reading a
+single sentence of self-report.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from social_core.db import SocialDB
+
+from individual_kernel_mcp.ablation import AblationRunner
+from individual_kernel_mcp.enacted_field import TriggerKind
+from individual_kernel_mcp.tick import TickProducer
+from individual_kernel_mcp.workspace import (
+    CandidateKind,
+    CandidateSource,
+    SourceMode,
+    WorkspaceCandidate,
+)
+
+TICKS = 6
+
+BEHAVIOR_TEMPLATE = """[individual-kernel]
+generative_field_model = false
+hor_precision_feedback = {enabled}
+"""
+
+
+@pytest.fixture
+def feedback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    def _configure(*, enabled: bool) -> None:
+        path = tmp_path / "mcpBehavior.toml"
+        path.write_text(
+            BEHAVIOR_TEMPLATE.format(enabled="true" if enabled else "false"),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("MCP_BEHAVIOR_TOML", str(path))
+
+    return _configure
+
+
+def _producer(social_db: SocialDB, tmp_path: Path) -> TickProducer:
+    interoception = tmp_path / "interoception.json"
+    interoception.write_text(json.dumps({"now": {"arousal": 20.0}}), encoding="utf-8")
+    desires = tmp_path / "desires.json"
+    desires.write_text(json.dumps({"desires": {}}), encoding="utf-8")
+    return TickProducer(
+        social_db, interoception_path=interoception, desires_path=desires
+    )
+
+
+def _run(producer: TickProducer, ticks: int = TICKS) -> None:
+    for _ in range(ticks):
+        opened = producer.begin_tick(TriggerKind.HEARTBEAT)
+        producer.workspace.add_candidate(
+            WorkspaceCandidate(
+                tick_id=opened.tick_id,
+                kind=CandidateKind.SELF_MODEL,
+                content_ref="self:processing",
+                content_summary="the runtime's own processing",
+                source=CandidateSource.ATTENTION_SCHEMA,
+                source_mode=SourceMode.INFERRED,
+                modality="internal",
+                precision=0.9,
+                need_relevance=0.4,
+                goal_relevance=0.6,
+                continuity_with_previous=0.8,
+                controllability=0.7,
+            )
+        )
+        producer.compete_and_commit(opened.tick_id)
+
+
+def _self_feedback(social_db: SocialDB) -> float:
+    profile = AblationRunner(social_db).indicator_profile(window=TICKS * 2)
+    return profile.self_model_feedback
+
+
+class TestNonVerbalDegradation:
+    def test_removing_the_feedback_lowers_self_feedback(
+        self, social_db: SocialDB, tmp_path: Path, feedback
+    ) -> None:
+        feedback(enabled=True)
+        _run(_producer(social_db, tmp_path))
+        with_feedback = _self_feedback(social_db)
+
+        feedback(enabled=False)
+        _run(_producer(social_db, tmp_path))
+        without_feedback = _self_feedback(social_db)
+
+        # The indicator is a mean over precision values. Nothing in its
+        # computation touches a self-report string.
+        assert without_feedback < with_feedback
+
+    def test_the_indicator_never_reads_a_report(
+        self, social_db: SocialDB, tmp_path: Path, feedback
+    ) -> None:
+        feedback(enabled=True)
+        _run(_producer(social_db, tmp_path))
+        profile = AblationRunner(social_db).indicator_profile(window=TICKS)
+        assert 0.0 <= profile.self_model_feedback <= 1.0
+
+
+class TestFlagOff:
+    def test_precision_seeding_matches_the_previous_decay(
+        self, social_db: SocialDB, tmp_path: Path, feedback
+    ) -> None:
+        feedback(enabled=False)
+        producer = _producer(social_db, tmp_path)
+        opened = producer.begin_tick(TriggerKind.HEARTBEAT)
+        seeded = producer.fields.get(opened.field_id)
+        assert seeded is not None
+        # With no previous field the decay returns the schema defaults, and the
+        # feedback must not have moved them.
+        assert seeded.precision.self_model == pytest.approx(0.5)
+
+
+class TestProcessRecord:
+    def test_every_commit_leaves_one_process_record(
+        self, social_db: SocialDB, tmp_path: Path, feedback
+    ) -> None:
+        feedback(enabled=True)
+        producer = _producer(social_db, tmp_path)
+        _run(producer, ticks=3)
+        rows = producer.process_meta.recent(limit=10)
+        assert len(rows) == 3
+        assert all(row["canonical_statement"] for row in rows)
+
+    def test_the_statement_describes_the_competition(
+        self, social_db: SocialDB, tmp_path: Path, feedback
+    ) -> None:
+        feedback(enabled=True)
+        producer = _producer(social_db, tmp_path)
+        _run(producer, ticks=1)
+        row = producer.process_meta.recent(limit=1)[0]
+        assert "candidates competed" in row["canonical_statement"]
+        assert row["candidate_count"] >= 1

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_process_meta.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_process_meta.py
@@ -1,0 +1,98 @@
+"""Higher-order records become consequential, and the processing gets recorded."""
+
+from __future__ import annotations
+
+import pytest
+
+from individual_kernel_mcp.enacted_field import PrecisionState
+from individual_kernel_mcp.process_meta import (
+    HOR_PRECISION_CAP,
+    HOR_PRECISION_GAIN,
+    PrecisionBias,
+    ProcessMetaRepresentation,
+    apply_precision_bias,
+    precision_bias_from_hors,
+)
+
+
+class _Record:
+    """Minimal stand-in for HORRecord: only the two fields the bias reads."""
+
+    def __init__(self, asserted_mode: str, confidence: float) -> None:
+        self.asserted_mode = asserted_mode
+        self.confidence = confidence
+
+
+class TestBias:
+    def test_no_records_is_no_bias(self):
+        bias = precision_bias_from_hors([])
+        assert bias.is_empty
+
+    def test_attending_raises_the_self_model_channel(self):
+        bias = precision_bias_from_hors([_Record("attending", 1.0)])
+        assert bias.self_model == pytest.approx(HOR_PRECISION_GAIN)
+        assert bias.extero == 0.0
+
+    def test_each_mode_reaches_its_own_channel(self):
+        assert precision_bias_from_hors([_Record("seeing", 1.0)]).extero > 0.0
+        assert precision_bias_from_hors([_Record("feeling", 1.0)]).intero > 0.0
+        assert precision_bias_from_hors([_Record("remembering", 1.0)]).mnemonic > 0.0
+
+    def test_confidence_scales_the_contribution(self):
+        weak = precision_bias_from_hors([_Record("attending", 0.2)])
+        strong = precision_bias_from_hors([_Record("attending", 0.9)])
+        assert weak.self_model < strong.self_model
+
+    def test_repetition_cannot_exceed_the_cap(self):
+        many = precision_bias_from_hors([_Record("attending", 1.0)] * 20)
+        assert many.self_model == pytest.approx(HOR_PRECISION_CAP)
+
+    def test_unknown_mode_contributes_nothing(self):
+        assert precision_bias_from_hors([_Record("guessing", 1.0)]).is_empty
+
+
+class TestApply:
+    def test_empty_bias_returns_the_same_precision(self):
+        base = PrecisionState(self_model=0.4)
+        assert apply_precision_bias(base, PrecisionBias()) is base
+
+    def test_bias_raises_the_channel(self):
+        base = PrecisionState(self_model=0.4)
+        raised = apply_precision_bias(base, PrecisionBias(self_model=0.15))
+        assert raised.self_model == pytest.approx(0.55)
+        assert raised.extero == base.extero
+
+    def test_result_stays_inside_the_model_bounds(self):
+        base = PrecisionState(self_model=0.95)
+        raised = apply_precision_bias(base, PrecisionBias(self_model=0.2))
+        assert raised.self_model == pytest.approx(1.0)
+
+
+class TestCanonicalStatement:
+    def _record(self, **overrides) -> ProcessMetaRepresentation:
+        payload = {
+            "process_meta_id": "pmr_test",
+            "tick_id": "tick_test",
+            "field_id": "field_test",
+            "trigger_kind": "user_prompt",
+            "candidate_count": 11,
+            "competition_margin": 0.195,
+            "competition_entropy": 0.92,
+            "ignited": True,
+            "conflicted": True,
+            "attention_intensity": 0.58,
+        }
+        payload.update(overrides)
+        return ProcessMetaRepresentation(**payload)
+
+    def test_reports_the_processing_not_the_content(self):
+        statement = self._record().canonical_statement()
+        assert "11 candidates competed" in statement
+        assert "settled" in statement
+        assert "contested" in statement
+        assert "0.195" in statement
+
+    def test_a_quiet_tick_reads_differently(self):
+        statement = self._record(ignited=False, conflicted=False).canonical_statement()
+        assert "did not settle" in statement
+        assert "uncontested" in statement

--- a/docs/hor-ablation.md
+++ b/docs/hor-ablation.md
@@ -1,0 +1,89 @@
+# Higher-Order Feedback and Its Ablation
+
+Status: shipped 2026-07-28 on the `feat/process-meta-hor` branch, behind
+`[individual-kernel] hor_precision_feedback`, which defaults to **off** pending
+a live check. Scope: the precision a tick starts with, and a new ledger of
+process-level self representations. Action selection, workspace competition,
+the `<current_field>` surface, and the boundary gate are unchanged.
+
+Claim policy: this couples one recorded functional variable to another. Nothing
+in it is a phenomenal claim.
+
+## The defect
+
+The runtime ends each tick by recording a higher-order representation -- most
+often `attending`, asserting what it was attending to. Those rows went into
+`hor_records` and no code read them back. A HOR could be present, absent, or
+wrong and every other quantity in the system came out identical.
+
+That makes the record decoration. It is also the thing that would make an
+ablation experiment vacuous: removing something inert cannot degrade anything.
+
+## What the feedback does
+
+`_seed_precision` decays the previous tick's precision exactly as before, then
+adds a bias derived from the last three higher-order records:
+
+```
+contribution = 0.15 * confidence      per record
+channel      = seeing -> extero, feeling -> intero, remembering -> mnemonic,
+               attending / intending / wanting -> self_model
+cap          = 0.20                   per channel, however many records
+```
+
+The cap is the point of the design: repeating an assertion cannot substitute
+for evidence. Twenty confident `attending` records raise `self_model` by the
+same 0.20 that two do.
+
+`attending`, `intending` and `wanting` all land on `self_model` because they are
+about the runtime's own processing rather than about a sense.
+
+## The ablation, on a non-verbal indicator
+
+The requirement this design has to meet is that removing the feedback degrades
+something that is *not* a self-report. `IndicatorProfile.self_model_feedback`
+qualifies: it is the mean of `precision.self_model` over recent committed
+fields, computed without reading a single sentence the runtime produced.
+
+`tests/test_hor_ablation.py::TestNonVerbalDegradation` runs the same six-tick
+workload twice, once with the flag on and once off, and asserts the indicator
+is strictly lower in the ablated run. It passes. That is the whole claim: the
+higher-order record has a measurable downstream, and the measurement does not
+go through language.
+
+The magnitude is small by construction -- the cap is 0.20 on one channel -- so
+this is a demonstration that the coupling exists, not that it dominates.
+
+## ProcessMetaRepresentation
+
+Migration 011 adds `process_meta_representations`: one row per committed tick,
+recording how the field was produced rather than what it was about. Candidate
+count, competition margin and entropy, whether it ignited, whether it was
+contested, whether an intention was registered, and the precision bias the HORs
+contributed.
+
+It carries a `canonical_statement()` -- a sentence like "11 candidates competed
+and it settled; the choice was contested by a margin of 0.195". The statement
+lives next to the numbers it summarises so the two cannot drift apart. This is
+the object a report about one's own processing would have to be a report *of*;
+without it, such a report has no referent inside the system.
+
+The write is wrapped: a storage fault must not roll back a field that has
+already been committed.
+
+## Why the flag ships off
+
+The two flags shipped in the previous PR were switched on only after a live
+check showed what they did to the running system. The same standard applies
+here: this one changes the precision every subsequent tick starts from, and the
+live desire and HOR history is nothing like the fixture. It goes on after the
+same kind of before-and-after measurement, not before.
+
+## What later phases take from here
+
+Report independence is currently a stub. With process records available, it
+becomes measurable properly: hold the process record fixed, vary the surface,
+and check that non-verbal indicators do not move (surface-blind invariance);
+then vary the process record and check the report follows (surface fidelity).
+That needs the fork machinery from PR-6 to run both arms against identical
+history.

--- a/mcpBehavior.toml
+++ b/mcpBehavior.toml
@@ -54,6 +54,10 @@ allostatic_valence = true          # valence/needs/controllability の再定義�
                                    # 2026-07-28 のライブ確認で control が実測 ownership に
                                    # 追従し valence が tick ごとに動くことを確認した
                                    # （docs/allostatic-valence-design.md）
+hor_precision_feedback = false     # HOR がそのチャネルの precision を上げる。既定 off:
+                                   # 全 tick の初期 precision を変えるので、他の2つと
+                                   # 同じようにライブで前後を測ってから on にする
+                                   # （docs/hor-ablation.md）
 valence_coupling = true            # affect で競合重みを変調する。既定 on:
                                    # 2026-07-28 のライブ確認でスコア差が設計式と一致した。
                                    # boundary gate は一切読まない

--- a/sociality-mcp/packages/social-core/src/social_core/migrations.py
+++ b/sociality-mcp/packages/social-core/src/social_core/migrations.py
@@ -406,6 +406,35 @@ CREATE INDEX IF NOT EXISTS idx_field_transitions_action
     ON field_transitions(action_id, created_at DESC);
 """
 
+_MIGRATION_011_SQL = """
+CREATE TABLE IF NOT EXISTS process_meta_representations (
+    process_meta_id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    tick_id TEXT NOT NULL REFERENCES tick_frames(tick_id) ON DELETE CASCADE,
+    field_id TEXT NOT NULL REFERENCES enacted_fields(field_id) ON DELETE CASCADE,
+    producer TEXT NOT NULL DEFAULT 'deterministic',
+    trigger_kind TEXT NOT NULL,
+    candidate_count INTEGER NOT NULL,
+    winner_kind TEXT NOT NULL DEFAULT '',
+    competition_margin REAL NOT NULL,
+    competition_entropy REAL NOT NULL,
+    ignited INTEGER NOT NULL,
+    conflicted INTEGER NOT NULL,
+    attention_intensity REAL NOT NULL,
+    registered_intention INTEGER NOT NULL DEFAULT 0,
+    hor_channel_bias_json TEXT NOT NULL DEFAULT '{}',
+    canonical_statement TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    CHECK(competition_entropy >= 0.0 AND competition_entropy <= 1.0),
+    CHECK(attention_intensity >= 0.0 AND attention_intensity <= 1.0),
+    CHECK(candidate_count >= 0)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_process_meta_tick
+    ON process_meta_representations(tick_id);
+CREATE INDEX IF NOT EXISTS idx_process_meta_owner_created
+    ON process_meta_representations(owner_id, created_at DESC);
+"""
+
 _MIGRATION_010_SQL = """
 CREATE TABLE IF NOT EXISTS body_contingencies (
     contingency_id TEXT PRIMARY KEY,
@@ -823,6 +852,10 @@ MIGRATIONS = [
     Migration(
         name="010_body_contingency",
         sql=_MIGRATION_010_SQL,
+    ),
+    Migration(
+        name="011_process_meta_representations",
+        sql=_MIGRATION_011_SQL,
     ),
 ]
 


### PR DESCRIPTION
## Summary

PR-5 of the roadmap. Stacked on #111; review that one first.

The runtime ends each tick by recording a higher-order representation -- usually
`attending`, asserting what it was attending to. Nothing read those rows back. A
HOR could be present, absent, or wrong and every other quantity in the system
came out identical, which makes the record decoration and makes any ablation of
it vacuous: removing something inert cannot degrade anything.

The last three records now bias the precision the next tick starts from:

```
contribution = 0.15 * confidence      per record
channel      = seeing -> extero, feeling -> intero, remembering -> mnemonic,
               attending / intending / wanting -> self_model
cap          = 0.20                   per channel, however many records
```

The cap is the design: twenty confident `attending` records raise `self_model`
by the same 0.20 that two do. Repeating an assertion cannot substitute for
evidence.

Design: `docs/hor-ablation.md`.

Claim policy: this couples one recorded functional variable to another. Nothing
here is a phenomenal claim.

## The ablation degrades a non-verbal indicator

The requirement is that removing the feedback degrades something that is *not*
a self-report. `IndicatorProfile.self_model_feedback` is the mean of
`precision.self_model` over recent committed fields; computing it never touches
a sentence the runtime produced.

`TestNonVerbalDegradation::test_removing_the_feedback_lowers_self_feedback`
runs the same six-tick workload with the flag on and off and asserts the
indicator is strictly lower in the ablated arm. It passes.

The magnitude is small by construction (cap 0.20 on one channel). This shows
the coupling exists, not that it dominates.

## ProcessMetaRepresentation

Migration 011 adds one row per committed tick recording *how* the field was
produced rather than what it was about: candidate count, competition margin and
entropy, ignition, conflict, registered intention, and the HOR bias that was
applied.

Each row carries a canonical statement -- "11 candidates competed and it
settled; the choice was contested by a margin of 0.195" -- stored next to the
numbers it summarises so the two cannot drift apart. This is the object a report
about one's own processing would have to be a report *of*.

Both the process write and the HOR query are wrapped: neither an audit-trail
fault nor a query fault may block a tick or roll back a committed field.

## Flag ships off

`hor_precision_feedback` defaults to **off**, deliberately unlike the two flags
turned on in #111. Those were switched on only after a live before-and-after
measurement; this one changes the precision every subsequent tick starts from,
and the live HOR history is nothing like the fixture. It gets the same
treatment before it goes on.

## Tests

400 passed (kernel + social-core), 17 new: 11 on the bias, its cap, its channel
mapping and the canonical statement, plus 6 covering the ablation, the flag-off
path reproducing the previous decay exactly, and one process record per commit.
ruff clean.

## Roadmap

Report independence is still a stub. With process records available it becomes
properly measurable -- hold the process record fixed and vary the surface
(expect no movement in non-verbal indicators), then vary the record and check
the report follows. Running both arms against identical history needs the fork
machinery from PR-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
