### PR TITLE
feat(individual-kernel): distinguish experienced, told, and imagined routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ All notable changes to embodied-claude are documented here.
 
 ### Added
 
+- individual-kernel: provenance routes. `knowledge_source` now accepts all four
+  routes information can arrive by -- experienced, told, imagined, replayed --
+  and the generative model refuses to learn from any of them but `experienced`,
+  so hearsay and imagination can be remembered in full without training a
+  sensorimotor contingency. Content is identified by `info_content_hash`
+  independently of its route, so a divergence between two arms is attributable
+  to the route rather than the payload.
+- individual-kernel: `fork_history`, an isolated snapshot of the history for
+  running two arms from one starting point. Namespacing by `owner_id` was
+  rejected because several readers query without an owner filter and would have
+  leaked across arms quietly.
+- docs: `experienced-told-imagined.md`, `fork-divergence.md`.
 - individual-kernel: higher-order feedback, behind `hor_precision_feedback` in
   `[individual-kernel]` (default off). Recent HOR records now raise the
   precision of the channel their asserted mode speaks to, capped so repeating

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/experienced_transition.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/experienced_transition.py
@@ -6,9 +6,10 @@ UNIQUE, so recording is idempotent; learning consumption is guarded by
 `applied_at` (see `CountBasedGenerativeFieldModel.update`).
 
 Source discipline: a transition row never carries imagined or remembered
-source modes, and `knowledge_source` is fixed to 'experienced' in this
-version (told/imagined/replayed ingestion arrives with the fork experiments;
-the schema already reserves the values).
+source modes. `knowledge_source` records which of the four routes the
+information arrived by and is deliberately permissive -- the gate is in
+`CountBasedGenerativeFieldModel.update`, which trains on `experienced` alone,
+so hearsay and imagination can be remembered without being learned from.
 """
 
 from __future__ import annotations
@@ -22,10 +23,13 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from social_core.db import SocialDB
 from social_core.time import utc_now
 
+from .fork import KNOWLEDGE_SOURCES
 from .workspace import SourceMode
 
 _ALLOWED_SOURCE_MODES = {SourceMode.LIVE, SourceMode.INFERRED, SourceMode.MIXED}
-_KNOWLEDGE_SOURCES_V1 = {"experienced"}
+# Routes by which information can reach the runtime are defined in `fork`, the
+# module that has no dependency on either this schema or the model that gates
+# on them. Recording the route is permissive; learning from it is not.
 
 
 class ExperiencedTransition(BaseModel):
@@ -86,10 +90,17 @@ class ExperiencedTransition(BaseModel):
 
     @field_validator("knowledge_source")
     @classmethod
-    def _knowledge_source_v1(cls, value: str) -> str:
-        if value not in _KNOWLEDGE_SOURCES_V1:
+    def _known_route(cls, value: str) -> str:
+        """Accept any of the four routes information can arrive by.
+
+        The route is recorded here and gated where it matters: the generative
+        model refuses to learn from anything that is not `experienced`, so
+        hearsay and imagination cannot train a sensorimotor contingency.
+        """
+        if value not in KNOWLEDGE_SOURCES:
             raise ValueError(
-                "knowledge_source is fixed to 'experienced' in this version"
+                f"unknown knowledge_source {value!r}; "
+                f"expected one of {', '.join(KNOWLEDGE_SOURCES)}"
             )
         return value
 

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/fork.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/fork.py
@@ -1,0 +1,82 @@
+"""Forking the history so the same content can arrive by different routes.
+
+The question this exists to answer is whether the runtime distinguishes
+*knowing because it happened to me* from *knowing because I was told* and from
+*knowing because I imagined it*. That cannot be settled by asking; it has to be
+settled by running identical information down each route from identical history
+and looking at what diverges.
+
+A fork is a separate database file holding a consistent snapshot of the source,
+taken through SQLite's backup API. Copying the file directly is not enough:
+these databases run in WAL mode, so recent commits are still in the `-wal`
+sidecar and a plain copy starts the arm from an older, emptier history -- which
+would look like a working fork right up until the comparison mattered.
+Namespacing by owner_id was rejected for a related reason: several readers in
+this package query without an owner filter, so an in-database fork would leak
+across arms and quietly invalidate the comparison.
+
+Claim policy: this measures how records differ by provenance. Nothing in it is
+a phenomenal claim.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from pathlib import Path
+from types import TracebackType
+
+from social_core.db import SocialDB
+
+# Routes by which a piece of information can reach the runtime. `replayed` is
+# reserved for consolidation and is not produced by the ingest paths here.
+KNOWLEDGE_SOURCES = ("experienced", "told", "imagined", "replayed")
+
+# The only route that may train the sensorimotor model. Lives here rather than
+# beside the transition schema so the model and the schema can both import it
+# without importing each other.
+LEARNABLE_KNOWLEDGE_SOURCE = "experienced"
+
+
+def info_content_hash(content: str) -> str:
+    """Identify the information itself, independent of how it arrived.
+
+    Two arms of a fork use this to assert they were given the same content, so
+    any divergence downstream is attributable to the route and not the payload.
+    """
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+class ForkHandle:
+    """An isolated copy of the history, opened as its own database."""
+
+    def __init__(self, source: SocialDB, directory: Path, label: str) -> None:
+        self.fork_id = f"fork_{secrets.token_urlsafe(8)}"
+        self.label = label
+        self.path = directory / f"{self.fork_id}.db"
+        directory.mkdir(parents=True, exist_ok=True)
+        self.db = SocialDB(self.path)
+        source.connect().backup(self.db.connect())
+
+    def close(self) -> None:
+        self.db.close()
+
+    def __enter__(self) -> "ForkHandle":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+
+def fork_history(source: SocialDB, directory: Path, *, label: str) -> ForkHandle:
+    """Snapshot a database into a new file and open it.
+
+    The source is left untouched, so an experiment can never write back into
+    the history it branched from.
+    """
+    return ForkHandle(source, Path(directory), label)

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/generative_model.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/generative_model.py
@@ -19,6 +19,7 @@ from social_core.db import SocialDB
 from social_core.time import utc_now
 
 from .enacted_field import EnactedField
+from .fork import LEARNABLE_KNOWLEDGE_SOURCE
 from .workspace import SourceMode
 
 if TYPE_CHECKING:
@@ -570,8 +571,13 @@ class CountBasedGenerativeFieldModel:
         """Count one experienced transition into the stats, exactly once.
 
         Returns False when the transition was already applied (idempotent
-        across processes via the `applied_at` row guard).
+        across processes via the `applied_at` row guard), and False for any
+        route other than `experienced`: being told a contingency, or imagining
+        one, must not train it. This is the gate that makes the route recorded
+        on a transition consequential rather than cosmetic.
         """
+        if transition.knowledge_source != LEARNABLE_KNOWLEDGE_SOURCE:
+            return False
         signature = ContextSignature.from_key(transition.context_signature)
         now = utc_now()
         with self._db.transaction() as connection:

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_experienced_told_imagined.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_experienced_told_imagined.py
@@ -1,0 +1,252 @@
+"""The same content, arriving by three routes, must not leave the same trace.
+
+If being told a contingency trained it as strongly as undergoing it, the
+recorded provenance would be cosmetic. These tests run identical information
+down each route from identical history and check what diverges.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+from social_core.db import SocialDB
+
+from individual_kernel_mcp.enacted_field import TriggerKind
+from individual_kernel_mcp.experienced_transition import (
+    ExperiencedTransition,
+    ExperiencedTransitionStore,
+)
+from individual_kernel_mcp.fork import (
+    KNOWLEDGE_SOURCES,
+    fork_history,
+    info_content_hash,
+)
+from individual_kernel_mcp.generative_model import CountBasedGenerativeFieldModel
+from individual_kernel_mcp.tick import TickProducer
+from individual_kernel_mcp.workspace import (
+    CandidateKind,
+    CandidateSource,
+    SourceMode,
+    WorkspaceCandidate,
+)
+
+CONTENT = "panning left brings the window into view"
+SIGNATURE = "desire|user_prompt|look_outside|neu|low|tool:look_left"
+
+
+def _transition(
+    *, route: str, field_id: str = "f", tick_id: str = "t"
+) -> ExperiencedTransition:
+    return ExperiencedTransition(
+        next_field_id=field_id,
+        next_tick_id=tick_id,
+        context_signature=SIGNATURE,
+        action_kind="tool:look_left",
+        outcome_bucket="ok/short/percept/=",
+        source_mode=SourceMode.LIVE,
+        knowledge_source=route,
+        info_content_hash=info_content_hash(CONTENT),
+        mean_prediction_error=0.2,
+        valence_before=0.0,
+        valence_after=0.1,
+        valence_change=0.1,
+        arousal_before=0.2,
+        arousal_after=0.2,
+        agency_confidence=0.8,
+        ownership_confidence=0.8,
+    )
+
+
+def _observations(db: SocialDB) -> float:
+    row = db.fetchone(
+        "SELECT COALESCE(SUM(observation_count), 0.0) AS total "
+        "FROM generative_transition_stats",
+        (),
+    )
+    return float(row["total"]) if row else 0.0
+
+
+@contextmanager
+def _runtime_recording_paused() -> Iterator[None]:
+    """Commit a field without the prediction loop claiming it.
+
+    Every commit that has a predecessor is recorded by the runtime as
+    `experienced`, and the store is idempotent per field, so a test that wants
+    to choose the route has to commit its field with that recording switched
+    off. The behaviour flag already allows it: it is re-read on every call.
+    """
+    path = Path(os.environ["MCP_BEHAVIOR_TOML"])
+    original = path.read_text(encoding="utf-8")
+    path.write_text(
+        original.replace(
+            "generative_field_model = true", "generative_field_model = false"
+        ),
+        encoding="utf-8",
+    )
+    try:
+        yield
+    finally:
+        path.write_text(original, encoding="utf-8")
+
+
+def _committed_field(db: SocialDB, tmp_path: Path) -> tuple[str, str]:
+    """Commit a real tick and return its (field_id, tick_id).
+
+    Transitions carry foreign keys into the field and frame tables, so a
+    synthetic id cannot be stored at all. Running against real committed
+    history is also what makes the comparison a fair one.
+    """
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    interoception = tmp_path / "interoception.json"
+    interoception.write_text(json.dumps({"now": {"arousal": 20.0}}), encoding="utf-8")
+    desires = tmp_path / "desires.json"
+    desires.write_text(json.dumps({"desires": {}}), encoding="utf-8")
+    producer = TickProducer(db, interoception_path=interoception, desires_path=desires)
+    opened = producer.begin_tick(TriggerKind.USER_PROMPT)
+    producer.workspace.add_candidate(
+        WorkspaceCandidate(
+            tick_id=opened.tick_id,
+            kind=CandidateKind.GOAL,
+            content_ref="desire:look_outside",
+            content_summary="need look_outside",
+            source=CandidateSource.DESIRE,
+            source_mode=SourceMode.INFERRED,
+            modality="internal",
+            precision=1.0,
+            need_relevance=1.0,
+            goal_relevance=1.0,
+            continuity_with_previous=1.0,
+            controllability=1.0,
+        )
+    )
+    field = producer.compete_and_commit(opened.tick_id).field
+    return field.field_id, field.tick_id
+
+
+def _ingest(db: SocialDB, tmp_path: Path, *, route: str) -> bool:
+    """Store one transition and offer it to the model, as the runtime would.
+
+    The store step matters: `update` guards on the stored row's `applied_at`,
+    so a transition that was never recorded can never be learned from either.
+    """
+    with _runtime_recording_paused():
+        field_id, tick_id = _committed_field(db, tmp_path)
+    transition = _transition(route=route, field_id=field_id, tick_id=tick_id)
+    ExperiencedTransitionStore(db).record(transition)
+    return CountBasedGenerativeFieldModel(db).update(transition)
+
+
+class TestRoutesDiverge:
+    def test_experience_trains_the_model(
+        self, social_db: SocialDB, tmp_path: Path
+    ) -> None:
+        before = _observations(social_db)
+        assert _ingest(social_db, tmp_path, route="experienced")
+        assert _observations(social_db) > before
+
+    @pytest.mark.parametrize("route", ["told", "imagined", "replayed"])
+    def test_other_routes_do_not_train_the_model(
+        self, social_db: SocialDB, tmp_path: Path, route: str
+    ) -> None:
+        before = _observations(social_db)
+        assert not _ingest(social_db, tmp_path, route=route)
+        assert _observations(social_db) == before
+
+    def test_identical_content_diverges_only_by_route(
+        self, social_db: SocialDB, tmp_path: Path
+    ) -> None:
+        told = _transition(route="told")
+        lived = _transition(route="experienced")
+        # Same information by construction, so anything downstream that differs
+        # is attributable to the route.
+        assert told.info_content_hash == lived.info_content_hash
+        assert told.context_signature == lived.context_signature
+
+        assert _ingest(social_db, tmp_path, route="told") is False
+        assert _ingest(social_db, tmp_path, route="experienced") is True
+
+
+class TestRouteValidation:
+    @pytest.mark.parametrize("route", list(KNOWLEDGE_SOURCES))
+    def test_every_declared_route_is_accepted(self, route: str) -> None:
+        assert _transition(route=route).knowledge_source == route
+
+    def test_an_undeclared_route_is_refused(self) -> None:
+        with pytest.raises(ValueError):
+            _transition(route="dreamt")
+
+    def test_imagined_content_still_cannot_claim_a_live_source_mode(self) -> None:
+        # The pre-existing invariant is untouched: whatever the route, the
+        # source mode may not be imagined or remembered.
+        with pytest.raises(ValueError):
+            ExperiencedTransition(
+                next_field_id="f",
+                next_tick_id="t",
+                context_signature=SIGNATURE,
+                action_kind="tool:look_left",
+                outcome_bucket="ok/short/percept/=",
+                source_mode=SourceMode.IMAGINED,
+                knowledge_source="imagined",
+                mean_prediction_error=0.2,
+                valence_before=0.0,
+                valence_after=0.0,
+                valence_change=0.0,
+                arousal_before=0.2,
+                arousal_after=0.2,
+                agency_confidence=0.5,
+                ownership_confidence=0.5,
+            )
+
+
+class TestFork:
+    def test_a_fork_starts_from_the_same_history(
+        self, social_db: SocialDB, tmp_path: Path
+    ) -> None:
+        _ingest(social_db, tmp_path, route="experienced")
+        seeded = _observations(social_db)
+        assert seeded > 0.0
+        with fork_history(social_db, tmp_path / "forks", label="told") as arm:
+            assert _observations(arm.db) == seeded
+
+    def test_writing_in_one_arm_leaves_the_source_untouched(
+        self, social_db: SocialDB, tmp_path: Path
+    ) -> None:
+        before = _observations(social_db)
+        with fork_history(social_db, tmp_path / "forks", label="lived") as arm:
+            _ingest(arm.db, tmp_path / "arm", route="experienced")
+            assert _observations(arm.db) > before
+        assert _observations(social_db) == before
+
+    def test_two_arms_diverge_by_route_alone(
+        self, social_db: SocialDB, tmp_path: Path
+    ) -> None:
+        _ingest(social_db, tmp_path / "seed", route="experienced")
+        seeded = _observations(social_db)
+        assert seeded > 0.0
+        directory = tmp_path / "forks"
+        with (
+            fork_history(social_db, directory, label="lived") as lived,
+            fork_history(social_db, directory, label="told") as told,
+        ):
+            assert lived.fork_id != told.fork_id
+            # Both arms demonstrably start from the same non-empty history.
+            assert _observations(lived.db) == seeded
+            assert _observations(told.db) == seeded
+            _ingest(lived.db, tmp_path / "a", route="experienced")
+            _ingest(told.db, tmp_path / "b", route="told")
+            # Identical content, identical starting history, different route.
+            assert _observations(lived.db) > seeded
+            assert _observations(told.db) == seeded
+
+
+class TestContentHash:
+    def test_same_content_hashes_alike(self) -> None:
+        assert info_content_hash(CONTENT) == info_content_hash(CONTENT)
+
+    def test_different_content_hashes_differently(self) -> None:
+        assert info_content_hash(CONTENT) != info_content_hash(CONTENT + ".")

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_experienced_transition.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_experienced_transition.py
@@ -112,14 +112,23 @@ class TestSourceDiscipline:
             with pytest.raises(ValidationError):
                 _transition(None, field, source_mode=mode)
 
-    def test_knowledge_source_is_experienced_only_in_v1(
-        self, social_db, tmp_path
-    ) -> None:
+    def test_every_declared_route_may_be_recorded(self, social_db, tmp_path) -> None:
+        # Recording the route is permissive; learning from it is not. The gate
+        # lives in the generative model, which refuses anything but
+        # `experienced` -- see test_experienced_told_imagined.
         producer = _producer(social_db, tmp_path)
         field = _commit(producer)
         for value in ("told", "imagined", "replayed"):
-            with pytest.raises(ValidationError):
-                _transition(None, field, knowledge_source=value)
+            assert (
+                _transition(None, field, knowledge_source=value).knowledge_source
+                == value
+            )
+
+    def test_an_undeclared_route_is_rejected(self, social_db, tmp_path) -> None:
+        producer = _producer(social_db, tmp_path)
+        field = _commit(producer)
+        with pytest.raises(ValidationError):
+            _transition(None, field, knowledge_source="dreamt")
 
 
 class TestIdempotentRecording:

--- a/docs/experienced-told-imagined.md
+++ b/docs/experienced-told-imagined.md
@@ -1,0 +1,90 @@
+# Experienced, Told, Imagined
+
+Status: shipped 2026-07-28 on the `feat/experienced-told-imagined` branch. Scope:
+which route a transition arrived by, and which routes may train the sensorimotor
+model. Action selection, workspace competition, the `<current_field>` surface,
+and the boundary gate are unchanged.
+
+Claim policy: this measures how records differ by provenance. Nothing in it is a
+phenomenal claim.
+
+## The question
+
+Does the runtime distinguish knowing because it happened from knowing because it
+was told and from knowing because it was imagined?
+
+Asking cannot settle it. A system with no such distinction can still produce the
+sentence "I know that because I did it" -- the sentence is cheap, and its
+presence is evidence about the surface rather than about the machinery. The
+question is only settled by running identical information down each route from
+identical history and looking at what actually diverges.
+
+## Four routes, one gate
+
+`ExperiencedTransition.knowledge_source` takes one of four values, declared in
+`fork.py` so that neither the schema nor the model has to import the other:
+
+```
+experienced   underwent it
+told          someone reported it
+imagined      rolled it out internally
+replayed      reconstructed during consolidation
+```
+
+Recording is permissive: all four are storable, and an undeclared route is
+rejected outright. Learning is not. `CountBasedGenerativeFieldModel.update`
+returns `False` for anything but `experienced` before it touches a count:
+
+```python
+if transition.knowledge_source != LEARNABLE_KNOWLEDGE_SOURCE:
+    return False
+```
+
+So hearsay and imagination can be remembered in full and still fail to move a
+sensorimotor contingency. That asymmetry -- rememberable, not learnable -- is the
+whole content of the distinction as implemented.
+
+The route is orthogonal to `source_mode`, which was already enforced: a
+transition may never carry `imagined` or `remembered` as its source mode,
+whatever its route. An imagined scenario is recorded as an imagined *route* over
+an inferred *mode*; it never gets promoted into a live perception.
+
+## Identity of content
+
+A divergence is only attributable to the route if the payload was the same.
+`info_content_hash` is a sha256 over the content itself, computed independently
+of how it arrived, and the two arms of an experiment assert equality on it
+before they diverge. Without that the comparison would silently become a
+comparison of two different pieces of information.
+
+## What was measured
+
+`test_experienced_told_imagined.py`, 16 tests:
+
+- one `experienced` transition raises the model's total observation count;
+  `told`, `imagined` and `replayed` each leave it exactly unchanged
+- the same content with the same context signature returns `True` by the lived
+  route and `False` by the told route, in the same database, one after the other
+- two forks of one seeded history start at an equal, non-zero observation count,
+  and after ingesting identical content only the lived arm moves
+- every declared route is storable; `dreamt` raises
+- imagined content still cannot claim a live source mode
+
+The pre-existing test asserting `experienced`-only recording was replaced rather
+than deleted: the invariant it protected has moved from the schema to the model,
+and the new test says so.
+
+## Limits
+
+The divergence demonstrated here is the learning gate, which is a single
+conditional. It shows the routes are not interchangeable; it does not show the
+rest of the system treats them differently. Recall weighting, confidence in
+reports, and whether a told contingency decays differently from a lived one are
+all untouched -- each would be its own measurement.
+
+There is also no ingestion API yet. `ingest_told_report` and
+`ingest_imagined_scenario` remain to be built; today a route is set by whoever
+constructs the transition, which is enough for the experiment and not enough for
+live use.
+
+See also `docs/fork-divergence.md` for how the two arms are kept apart.

--- a/docs/fork-divergence.md
+++ b/docs/fork-divergence.md
@@ -1,0 +1,81 @@
+# Forking the History
+
+Status: shipped 2026-07-28 on the `feat/experienced-told-imagined` branch. Scope:
+running two arms from one history without either contaminating the other. No
+runtime path forks anything yet; this is experiment machinery.
+
+Claim policy: this is an isolation mechanism for comparisons. Nothing in it is a
+phenomenal claim.
+
+## Why an isolated copy at all
+
+A provenance experiment has one requirement that is easy to state and easy to
+get wrong: the two arms must start from the *same* history and must not be able
+to see each other's writes. If the told arm can observe what the lived arm
+learned, the comparison measures the plumbing.
+
+## What was rejected
+
+**Namespacing by `owner_id`.** The obvious cheap option: give each arm its own
+owner and keep one database. It does not hold. Several readers in this package
+query without an owner filter, so an in-database fork would leak across arms --
+and it would leak quietly, producing a plausible number rather than an error.
+
+**Copying the database file.** The first implementation did `shutil.copy2` on
+the `.db`. It was wrong, and the tests caught it: a fork of a seeded history
+came back with zero observations. `SocialDB.connect` sets
+`PRAGMA journal_mode=WAL`, so recent commits are still in the `-wal` sidecar and
+a copy of the main file alone starts the arm from an older, emptier state. The
+failure mode is the dangerous one: no exception, just an arm that quietly
+branched from the wrong point.
+
+## What it does
+
+`fork_history` opens a fresh `SocialDB` at a new path and fills it via SQLite's
+backup API:
+
+```python
+self.db = SocialDB(self.path)
+source.connect().backup(self.db.connect())
+```
+
+The backup takes a consistent snapshot under SQLite's own locking, WAL content
+included, and the source is only ever read -- an experiment cannot write back
+into the history it branched from. The handle is a context manager, so an arm
+closes with its `with` block.
+
+Each fork gets a `fork_id`, and `imagined_trajectories`,
+`protention_distributions` and `experienced_transitions` all carry a nullable
+`fork_id` column reserved for labelling rows by arm.
+
+## What was measured
+
+In `test_experienced_told_imagined.py::TestFork`:
+
+- a fork of a seeded history reports the same observation count as its source
+- writing in an arm leaves the source's count exactly unchanged
+- two arms of one seeded history start equal, and after identical content only
+  the arm that received it by the lived route moves
+
+The second of those is what the file copy would have passed while being broken:
+an empty arm also leaves the source untouched. The first is what caught it.
+
+## A note for tests that fork
+
+The prediction loop records a transition for every commit that has a
+predecessor, as `experienced`, and the store is idempotent per field. A test
+that wants to choose the route has to commit its field with that recording
+switched off, which the `generative_field_model` behaviour flag already allows
+because it is re-read on every call. `_runtime_recording_paused` in the test
+module does exactly that and nothing else.
+
+## Limits
+
+A fork is a whole-database snapshot, so it is O(database size) per arm. That is
+fine for fixtures and for occasional experiments against live history; it is not
+a mechanism for forking on every tick.
+
+Nothing labels rows with `fork_id` yet. The column exists so that an arm's
+writes can be identified after a merge-back, and no merge-back is implemented.
+
+See also `docs/experienced-told-imagined.md` for what the arms are comparing.


### PR DESCRIPTION
## Summary

PR-6 of the roadmap. Stacked on #112; review that one first.

Does the runtime distinguish knowing because it happened from knowing because it
was told? Asking cannot settle it -- a system with no such distinction can still
produce the sentence. The only thing that settles it is running identical
content down each route from identical history and seeing what diverges.

`knowledge_source` now takes all four routes (experienced, told, imagined,
replayed) and the generative model refuses to learn from any but `experienced`:

```python
if transition.knowledge_source != LEARNABLE_KNOWLEDGE_SOURCE:
    return False
```

Recording is permissive, learning is not. Hearsay and imagination can be
remembered in full and still fail to move a sensorimotor contingency.
`info_content_hash` identifies the content independently of its route, so a
divergence is attributable to the route rather than the payload.

Design: `docs/experienced-told-imagined.md`, `docs/fork-divergence.md`.

Claim policy: this measures how records differ by provenance. Nothing here is a
phenomenal claim.

## A real bug the tests caught

`fork_history` originally did `shutil.copy2` on the `.db` file. A fork of a
seeded history came back with **zero** observations: `SocialDB.connect` sets
`PRAGMA journal_mode=WAL`, so recent commits are still in the `-wal` sidecar and
copying the main file alone branches from an older, emptier state.

The failure mode is the dangerous kind -- no exception, just an arm quietly
starting from the wrong point, which would have made every future comparison
look clean and mean nothing. It now uses SQLite's backup API, which snapshots
consistently under SQLite's own locking. The source is only ever read.

Note that `test_writing_in_one_arm_leaves_the_source_untouched` would have
passed the whole time: an empty arm also leaves the source untouched. The test
that caught it is the one asserting the arm *starts equal*.

## Tests

417 passed (kernel + social-core), 16 new. The substantive ones:

- `experienced` raises the observation count; `told`, `imagined` and `replayed`
  each leave it exactly unchanged
- two forks of one seeded history start at an equal non-zero count, and after
  identical content only the lived arm moves
- a fork's writes never reach the source

`uv lock --check` clean, ruff clean on `consciousness-mcp` and `sociality-mcp`.

## Replaced, not deleted

`test_knowledge_source_is_experienced_only_in_v1` asserted the invariant this PR
lifts. It is replaced by two tests saying where the invariant went: every
declared route is recordable, an undeclared one raises, and the gate now lives
in the model.

## Roadmap

No ingestion API yet -- `ingest_told_report` and `ingest_imagined_scenario`
remain, and today a route is set by whoever constructs the transition. That is
enough for the experiment and not enough for live use.

Nothing labels rows with `fork_id`; the column exists for a merge-back that is
not implemented.

The divergence shown here is one conditional. It establishes the routes are not
interchangeable; it does not show the rest of the system treats them
differently. Recall weighting and differential decay would each be their own
measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
