### PR TITLE
feat(individual-kernel): give the runtime a clock of its own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,30 @@ All notable changes to embodied-claude are documented here.
   still written by nothing, so every projected need saturates; that is a
   known limit of the input, not of the composition.
 
+### Fixed
+
+- individual-kernel: the sleep consolidator's quiet-hours gate. Its default
+  predicate returned `True` at every hour, so the gate it advertised was open
+  all the time. The served consolidator now asks `BoundaryStore`, which is the
+  same `[global] quiet_hours` and `timezone` that already govern speaking and
+  posting.
+
 ### Added
 
+- individual-kernel: internal time, behind `organism_daemon` in
+  `[individual-kernel]` (default off). `TriggerKind.AUTONOMOUS` had been in the
+  enum since the beginning with nothing producing it, so with no input nothing
+  in the runtime moved. One turn of the clock decays transition counts on a
+  one-week half-life, retires imagined trajectories nobody took up, and opens a
+  tick when unmet need and elapsed silence are both high enough -- the first
+  producer of an autonomous tick. Measured against a fork of the live history:
+  counts halved exactly across a week, 571 pending trajectories that nothing
+  had ever been able to retire were retired, and a tick opened with no input.
+  The flag ships off because the first live run rewrites recorded history and
+  because nothing schedules it yet, not for want of evidence.
+- social-core: migration `012_organism_runs`, one row per turn of the clock
+  recording its inputs, its score, and the reason it did or did not fire.
+- docs: `organism-daemon.md`.
 - individual-kernel: provenance routes. `knowledge_source` now accepts all four
   routes information can arrive by -- experienced, told, imagined, replayed --
   and the generative model refuses to learn from any of them but `experienced`,

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/organism.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/organism.py
@@ -1,0 +1,392 @@
+"""Internal time: what changes when nothing is said to it.
+
+Every tick so far was caused from outside -- a prompt, a tool result, a hook
+firing on someone else's action. `TriggerKind.AUTONOMOUS` existed in the enum
+and nothing produced it, which is to say the runtime had no clock of its own:
+with no input, nothing in it moved.
+
+This module is that clock, and it is deliberately not a model. Every quantity
+is read from recorded state and combined arithmetically, so a step is
+reproducible from the database and the instant it ran at. Three things drift
+and one fires:
+
+    decay        transition counts lose weight with elapsed time, so a
+                 contingency that stopped holding stops being believed
+    expiry       an imagined trajectory nobody took up stops being pending
+    projection   needs grow along their own ramps (see `allostasis`)
+    ignition     when unmet need and elapsed silence are both high enough,
+                 a tick opens with TriggerKind.AUTONOMOUS
+
+Claim policy: this is a scheduler over recorded state. Nothing in it is a
+phenomenal claim.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+from social_core.db import SocialDB
+from social_core.time import utc_now
+
+from individual_kernel_mcp._behavior import get_behavior
+from individual_kernel_mcp.allostasis import project_desires
+from individual_kernel_mcp.enacted_field import TriggerKind
+from individual_kernel_mcp.tick import TickProducer
+from individual_kernel_mcp.trajectory import TrajectoryStatus, TrajectoryStore
+
+# A week: a contingency observed once and never again is worth about half as
+# much a week later. Slow enough that ordinary gaps between sessions do not
+# erase what was learned.
+STATS_HALF_LIFE_HOURS = 168.0
+
+# Counts stop decaying here rather than being deleted. A row at the floor still
+# records that the transition was seen; it just stops dominating the estimate.
+MIN_OBSERVATION_COUNT = 0.05
+
+# How long an imagined trajectory stays pending before it is no longer a
+# prediction about anything.
+PROTENTION_TTL_SECONDS = 1800.0
+
+IGNITION_NEED_WEIGHT = 0.6
+IGNITION_SILENCE_WEIGHT = 0.4
+IGNITION_SILENCE_SATURATION_SECONDS = 7200.0
+IGNITION_THRESHOLD = 0.55
+MIN_IGNITION_INTERVAL_SECONDS = 900.0
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def parse_iso(raw: Any) -> datetime | None:
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def decay_factor(elapsed_seconds: float, half_life_hours: float) -> float:
+    """Weight retained after `elapsed_seconds` at the given half-life.
+
+    Compounding this over successive steps gives the same result as applying it
+    once over the total elapsed time, so the daemon may run at any cadence --
+    or twice in a row -- without changing what a count ends up at.
+    """
+
+    if elapsed_seconds <= 0.0 or half_life_hours <= 0.0:
+        return 1.0
+    return 0.5 ** ((elapsed_seconds / 3600.0) / half_life_hours)
+
+
+def ignition_score(
+    *, max_discomfort: float, seconds_since_last_field: float
+) -> float:
+    """Combine unmet need with elapsed silence.
+
+    Both terms are load-bearing. Need alone would fire continuously during a
+    session, when the runtime is already awake and the need is being addressed.
+    Silence alone would fire on a schedule, which is a cron job in a costume.
+    """
+
+    need = _clamp01(max_discomfort)
+    silence = _clamp01(seconds_since_last_field / IGNITION_SILENCE_SATURATION_SECONDS)
+    return _clamp01(IGNITION_NEED_WEIGHT * need + IGNITION_SILENCE_WEIGHT * silence)
+
+
+def should_ignite(
+    score: float,
+    *,
+    seconds_since_last_field: float,
+    threshold: float = IGNITION_THRESHOLD,
+    min_interval: float = MIN_IGNITION_INTERVAL_SECONDS,
+) -> tuple[bool, str]:
+    """Decide, and say why not when the answer is no.
+
+    The interval is a hard floor rather than another weighted term: a tick that
+    just happened means the runtime is already awake, and no amount of need
+    justifies opening a second one on top of it.
+    """
+
+    if seconds_since_last_field < min_interval:
+        return False, (
+            f"a field was committed {seconds_since_last_field:.0f}s ago; "
+            f"the floor is {min_interval:.0f}s"
+        )
+    if score < threshold:
+        return False, f"score {score:.3f} is below the threshold {threshold:.3f}"
+    return True, f"score {score:.3f} reached the threshold {threshold:.3f}"
+
+
+def expiry_deadline(
+    *, created_at: Any, expires_at: Any, ttl_seconds: float
+) -> datetime | None:
+    """When a pending trajectory stops being a prediction.
+
+    `expires_at` is honoured when a producer set one; otherwise the deadline is
+    derived from creation, so trajectories written before anything populated
+    that column still expire.
+    """
+
+    explicit = parse_iso(expires_at)
+    if explicit is not None:
+        return explicit
+    created = parse_iso(created_at)
+    if created is None:
+        return None
+    return created + timedelta(seconds=ttl_seconds)
+
+
+class OrganismStep(BaseModel):
+    """What one turn of the clock did."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str = Field(default_factory=lambda: f"org_{secrets.token_urlsafe(10)}")
+    owner_id: str = "self"
+    ran_at: str = Field(default_factory=utc_now)
+    elapsed_seconds: float = 0.0
+    stats_decayed: int = 0
+    decay_factor: float = 1.0
+    protentions_expired: int = 0
+    max_discomfort: float = 0.0
+    dominant_desire: str | None = None
+    seconds_since_last_field: float = 0.0
+    ignition_score: float = 0.0
+    ignited: bool = False
+    tick_id: str | None = None
+    reason: str = ""
+
+
+class OrganismRunStore:
+    """Append-only ledger of daemon steps; also the daemon's own clock."""
+
+    def __init__(self, db: SocialDB) -> None:
+        self._db = db
+
+    def record(self, step: OrganismStep) -> OrganismStep:
+        self._db.execute(
+            """
+            INSERT INTO organism_runs(
+                run_id, owner_id, ran_at, elapsed_seconds, stats_decayed,
+                decay_factor, protentions_expired, max_discomfort,
+                dominant_desire, seconds_since_last_field, ignition_score,
+                ignited, tick_id, reason, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                step.run_id,
+                step.owner_id,
+                step.ran_at,
+                step.elapsed_seconds,
+                step.stats_decayed,
+                step.decay_factor,
+                step.protentions_expired,
+                step.max_discomfort,
+                step.dominant_desire,
+                step.seconds_since_last_field,
+                step.ignition_score,
+                int(step.ignited),
+                step.tick_id,
+                step.reason,
+                step.ran_at,
+            ),
+        )
+        return step
+
+    def last_run_at(self, owner_id: str = "self") -> datetime | None:
+        row = self._db.fetchone(
+            "SELECT ran_at FROM organism_runs WHERE owner_id = ? "
+            "ORDER BY ran_at DESC LIMIT 1",
+            (owner_id,),
+        )
+        return None if row is None else parse_iso(row["ran_at"])
+
+    def recent(self, owner_id: str = "self", limit: int = 20) -> list[dict[str, Any]]:
+        rows = self._db.fetchall(
+            "SELECT * FROM organism_runs WHERE owner_id = ? "
+            "ORDER BY ran_at DESC LIMIT ?",
+            (owner_id, max(1, min(int(limit), 200))),
+        )
+        return [dict(row) for row in rows]
+
+
+def organism_enabled() -> bool:
+    """Whether a scheduler may run the clock. Re-read on every call."""
+    return bool(get_behavior("individual-kernel", "organism_daemon", False))
+
+
+class OrganismDaemon:
+    """One turn of the clock: drift what drifts, then decide whether to wake.
+
+    There is no long-lived process here, so a step derives its elapsed time
+    from the previous recorded run rather than from how long it slept. A
+    scheduler may call it at any cadence, or twice in a row, and the state it
+    arrives at is the same.
+
+    The behaviour flag is checked by callers, not here: this is the mechanism,
+    and a test that wants to exercise it should not have to edit configuration.
+    """
+
+    def __init__(
+        self,
+        db: SocialDB,
+        producer: TickProducer,
+        *,
+        owner_id: str = "self",
+        half_life_hours: float = STATS_HALF_LIFE_HOURS,
+        protention_ttl_seconds: float = PROTENTION_TTL_SECONDS,
+        ignition_threshold: float = IGNITION_THRESHOLD,
+        min_ignition_interval: float = MIN_IGNITION_INTERVAL_SECONDS,
+    ) -> None:
+        self._db = db
+        self._producer = producer
+        self._owner_id = owner_id
+        self._half_life_hours = half_life_hours
+        self._ttl_seconds = protention_ttl_seconds
+        self._threshold = ignition_threshold
+        self._min_interval = min_ignition_interval
+        self.runs = OrganismRunStore(db)
+        self.trajectories = TrajectoryStore(db)
+
+    def step(
+        self,
+        *,
+        now: datetime | None = None,
+        force: bool = False,
+        dry_run: bool = False,
+    ) -> OrganismStep:
+        """Advance internal time once and record what it did.
+
+        `force` overrides the ignition decision only; the drift still follows
+        elapsed time. `dry_run` computes everything and writes nothing, which
+        is how a scheduler can ask what would happen.
+        """
+
+        moment = now or datetime.now(timezone.utc)
+        ran_at = moment.isoformat().replace("+00:00", "Z")
+        previous = self.runs.last_run_at(self._owner_id)
+        elapsed = max(0.0, (moment - previous).total_seconds()) if previous else 0.0
+
+        factor = decay_factor(elapsed, self._half_life_hours)
+        decayed = 0 if dry_run else self._decay_stats(factor, ran_at)
+        expired = 0 if dry_run else self._expire_protentions(moment)
+
+        projection = project_desires(self._read_desires(), now=moment)
+        max_discomfort = max(projection.discomforts.values(), default=0.0)
+        silence = self._seconds_since_last_field(moment)
+        score = ignition_score(
+            max_discomfort=max_discomfort, seconds_since_last_field=silence
+        )
+        ignite, reason = should_ignite(
+            score,
+            seconds_since_last_field=silence,
+            threshold=self._threshold,
+            min_interval=self._min_interval,
+        )
+        if force:
+            ignite, reason = True, "ignition was forced"
+
+        tick_id: str | None = None
+        if ignite and not dry_run:
+            try:
+                tick_id = self._open_autonomous_tick()
+            except Exception as error:  # noqa: BLE001 - recorded, not swallowed
+                ignite = False
+                reason = f"ignition failed: {error}"
+
+        step = OrganismStep(
+            owner_id=self._owner_id,
+            ran_at=ran_at,
+            elapsed_seconds=elapsed,
+            stats_decayed=decayed,
+            decay_factor=factor,
+            protentions_expired=expired,
+            max_discomfort=_clamp01(max_discomfort),
+            dominant_desire=projection.dominant,
+            seconds_since_last_field=silence,
+            ignition_score=score,
+            ignited=ignite,
+            tick_id=tick_id,
+            reason=reason,
+        )
+        if not dry_run:
+            self.runs.record(step)
+        return step
+
+    def _decay_stats(self, factor: float, ran_at: str) -> int:
+        """Shrink observation counts, stopping at the floor rather than deleting."""
+        if factor >= 1.0:
+            return 0
+        with self._db.transaction() as connection:
+            cursor = connection.execute(
+                "UPDATE generative_transition_stats "
+                "SET observation_count = observation_count * ?, updated_at = ? "
+                "WHERE owner_id = ? AND observation_count > ?",
+                (factor, ran_at, self._owner_id, MIN_OBSERVATION_COUNT),
+            )
+            return int(cursor.rowcount)
+
+    def _expire_protentions(self, moment: datetime) -> int:
+        """Retire imaginings nobody took up.
+
+        Only `imagined` trajectories expire. One that reached `intended` was
+        claimed by an intention and has to be resolved by its outcome, not by
+        the clock.
+        """
+
+        rows = self._db.fetchall(
+            "SELECT trajectory_id, created_at, expires_at FROM imagined_trajectories "
+            "WHERE owner_id = ? AND status = 'imagined' "
+            "ORDER BY created_at LIMIT 500",
+            (self._owner_id,),
+        )
+        expired = 0
+        for row in rows:
+            deadline = expiry_deadline(
+                created_at=row["created_at"],
+                expires_at=row["expires_at"],
+                ttl_seconds=self._ttl_seconds,
+            )
+            if deadline is None or deadline > moment:
+                continue
+            self.trajectories.transition(
+                row["trajectory_id"],
+                TrajectoryStatus.EXPIRED,
+                reason="the moment this predicted has passed",
+            )
+            expired += 1
+        return expired
+
+    def _seconds_since_last_field(self, moment: datetime) -> float:
+        row = self._db.fetchone(
+            "SELECT created_at FROM enacted_fields WHERE owner_id = ? "
+            "ORDER BY created_at DESC LIMIT 1",
+            (self._owner_id,),
+        )
+        last = parse_iso(row["created_at"]) if row is not None else None
+        if last is None:
+            # Nothing has ever happened. That is the most silent a runtime gets,
+            # so a first step is allowed to be the one that starts it.
+            return IGNITION_SILENCE_SATURATION_SECONDS
+        return max(0.0, (moment - last).total_seconds())
+
+    def _open_autonomous_tick(self) -> str:
+        opened = self._producer.begin_tick(TriggerKind.AUTONOMOUS)
+        self._producer.compete_and_commit(opened.tick_id)
+        return opened.tick_id
+
+    def _read_desires(self) -> dict[str, Any]:
+        path = Path(self._producer.desires_path)
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return {}
+        return payload if isinstance(payload, dict) else {}

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/server.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/server.py
@@ -74,10 +74,11 @@ from individual_kernel_mcp.hor import (
     TargetKind,
 )
 from individual_kernel_mcp.introspect import introspect
+from individual_kernel_mcp.organism import OrganismDaemon, organism_enabled
 from individual_kernel_mcp.prediction_loop import FieldPredictionLoop
 from individual_kernel_mcp.quality_geometry import QualityGeometry
 from individual_kernel_mcp.reflect import reflect_attention_schema
-from individual_kernel_mcp.sleep import SleepConsolidator
+from individual_kernel_mcp.sleep import SleepConsolidator, quiet_hours_from_policy
 from individual_kernel_mcp.tick import FieldRuntime, TickProducer
 from individual_kernel_mcp.workspace import WorkspaceCandidate, WorkspaceEngine
 
@@ -89,6 +90,7 @@ class IndividualKernelStores:
     db: SocialDB
     counterfactual: CounterfactualStore
     sleep: SleepConsolidator
+    organism: OrganismDaemon
     tick_frames: TickFrameStore
     attention_tracker: AttentionSchemaTracker
     hor_store: HORStore
@@ -104,10 +106,12 @@ class IndividualKernelStores:
 @lru_cache(maxsize=1)
 def _stores() -> IndividualKernelStores:
     db = SocialDB()
+    boundary = BoundaryStore(db=db)
     counterfactual_store = CounterfactualStore(db)
     sleep_consolidator = SleepConsolidator(
         db=db,
         counterfactual_store=counterfactual_store,
+        is_quiet_hours=quiet_hours_from_policy(boundary),
     )
     tick_frames = TickFrameStore(db)
     attention_tracker = AttentionSchemaTracker(db=db, owner_id="self")
@@ -131,13 +135,15 @@ def _stores() -> IndividualKernelStores:
     field_runtime = FieldRuntime(
         db,
         producer=tick_producer,
-        boundary_evaluator=BoundaryPolicyAdapter(BoundaryStore(db=db)),
+        boundary_evaluator=BoundaryPolicyAdapter(boundary),
     )
     ablation = AblationRunner(db, fields=enacted_fields)
+    organism = OrganismDaemon(db, tick_producer)
     return IndividualKernelStores(
         db=db,
         counterfactual=counterfactual_store,
         sleep=sleep_consolidator,
+        organism=organism,
         tick_frames=tick_frames,
         attention_tracker=attention_tracker,
         hor_store=hor_store,
@@ -282,6 +288,27 @@ def sleep_consolidate(
     """Run the quiet-hours-gated sleep-consolidation glue."""
     result = _stores().sleep.run(force=force, dry_run=dry_run)
     return result.model_dump(mode="json")
+
+
+@mcp.tool()
+def organism_step(force: bool = False, dry_run: bool = False) -> dict[str, Any]:
+    """Advance internal time once: decay stats, expire protentions, maybe ignite.
+
+    Gated by `[individual-kernel] organism_daemon` in mcpBehavior.toml, which
+    is re-read here on every call. With the flag off nothing is written and the
+    reason says so. `force` overrides only the ignition decision; `dry_run`
+    computes the step and writes nothing.
+    """
+    if not organism_enabled():
+        return {"ran": False, "reason": "organism_daemon is off in mcpBehavior.toml"}
+    step = _stores().organism.step(force=force, dry_run=dry_run)
+    return {"ran": True, **step.model_dump(mode="json")}
+
+
+@mcp.tool()
+def query_organism_runs(limit: int = 20) -> list[dict[str, Any]]:
+    """Recent turns of the internal clock, newest first."""
+    return _stores().organism.runs.recent(limit=limit)
 
 
 # -----------------------------------------------------------------------------

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/sleep.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/sleep.py
@@ -21,6 +21,7 @@ from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from boundary_mcp.store import BoundaryStore
 from pydantic import BaseModel, ConfigDict, Field
 from social_core.db import SocialDB
 from social_core.time import utc_now
@@ -70,7 +71,29 @@ class SleepConsolidationResult(BaseModel):
     briefing_path: str | None = None
 
 
+def quiet_hours_from_policy(store: BoundaryStore) -> QuietPredicate:
+    """Ask the configured policy whether an instant is inside quiet hours.
+
+    The default used to be a predicate that returned True unconditionally, so
+    the gate was open at every hour and the consolidator ran whenever anything
+    called it. Reusing `BoundaryStore` keeps one definition of quiet hours: the
+    `[global] quiet_hours` and `timezone` in socialPolicy.toml that already
+    govern speaking and posting.
+    """
+
+    def predicate(ts: str) -> bool:
+        return store.get_quiet_mode_state(ts=ts).active
+
+    return predicate
+
+
 def _always_quiet(_ts: str) -> bool:
+    """Fallback for a caller that supplies no policy.
+
+    Kept permissive on purpose: a consolidator constructed without a boundary
+    store has no way to know the hour, and refusing every run would be a silent
+    failure rather than a safe one. Callers that can supply a store should.
+    """
     return True
 
 

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_organism.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_organism.py
@@ -1,0 +1,336 @@
+"""Internal time has to do something, not merely exist.
+
+The claim under test is narrow and checkable: with no input at all, recorded
+state changes, and under the right internal conditions a tick opens that nobody
+asked for.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from social_core.db import SocialDB
+
+from individual_kernel_mcp.enacted_field import TriggerKind
+from individual_kernel_mcp.generative_model import FieldBelief, TrajectoryStep
+from individual_kernel_mcp.organism import (
+    MIN_OBSERVATION_COUNT,
+    STATS_HALF_LIFE_HOURS,
+    OrganismDaemon,
+    decay_factor,
+    expiry_deadline,
+    ignition_score,
+    should_ignite,
+)
+from individual_kernel_mcp.tick import TickProducer
+from individual_kernel_mcp.trajectory import (
+    ImaginedTrajectory,
+    ProtentionDistribution,
+    TrajectoryStatus,
+    TrajectoryStore,
+    normalized_entropy,
+)
+from individual_kernel_mcp.workspace import (
+    CandidateKind,
+    CandidateSource,
+    SourceMode,
+    WorkspaceCandidate,
+)
+
+WEEK_SECONDS = STATS_HALF_LIFE_HOURS * 3600.0
+
+
+def _iso(moment: datetime) -> str:
+    return moment.isoformat().replace("+00:00", "Z")
+
+
+def _producer(social_db: SocialDB, tmp_path: Path, *, unmet: bool = True) -> TickProducer:
+    """A producer whose desire snapshot is either strained or settled.
+
+    `look_outside` sits well above its set point when unmet, which is the only
+    thing that makes the need term of the ignition score nonzero.
+    """
+    interoception = tmp_path / "interoception.json"
+    interoception.write_text(json.dumps({"now": {"arousal": 50.0}}), encoding="utf-8")
+    desires = tmp_path / "desires.json"
+    desires.write_text(
+        json.dumps(
+            {
+                "desires": {"look_outside": 1.0 if unmet else 0.3},
+                "dominant": "look_outside",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return TickProducer(
+        social_db, interoception_path=interoception, desires_path=desires
+    )
+
+
+def _commit(producer: TickProducer):
+    opened = producer.begin_tick(TriggerKind.USER_PROMPT)
+    producer.workspace.add_candidate(
+        WorkspaceCandidate(
+            tick_id=opened.tick_id,
+            kind=CandidateKind.GOAL,
+            content_ref="desire:look_outside",
+            content_summary="need look_outside",
+            source=CandidateSource.DESIRE,
+            source_mode=SourceMode.INFERRED,
+            precision=1.0,
+            need_relevance=1.0,
+            goal_relevance=1.0,
+            continuity_with_previous=1.0,
+            controllability=1.0,
+        )
+    )
+    return producer.compete_and_commit(opened.tick_id).field
+
+
+def _seed_stat(db: SocialDB, count: float) -> None:
+    db.execute(
+        "INSERT INTO generative_transition_stats("
+        "owner_id, focus_kind, trigger_kind, dominant_desire, valence_bucket, "
+        "arousal_bucket, action_kind, outcome_bucket, observation_count, "
+        "model_version, first_observed_at, updated_at"
+        ") VALUES ('self', 'desire', 'user_prompt', 'look_outside', 'neu', "
+        "'mid', 'tool:look_left', 'ok/short/percept/=', ?, 'v1', ?, ?)",
+        (count, "2026-07-01T00:00:00Z", "2026-07-01T00:00:00Z"),
+    )
+
+
+def _observations(db: SocialDB) -> float:
+    row = db.fetchone(
+        "SELECT COALESCE(SUM(observation_count), 0.0) AS total "
+        "FROM generative_transition_stats",
+        (),
+    )
+    return float(row["total"]) if row else 0.0
+
+
+class TestDecay:
+    def test_a_half_life_halves(self) -> None:
+        assert decay_factor(WEEK_SECONDS, STATS_HALF_LIFE_HOURS) == pytest.approx(0.5)
+
+    def test_no_elapsed_time_retains_everything(self) -> None:
+        assert decay_factor(0.0, STATS_HALF_LIFE_HOURS) == 1.0
+
+    def test_two_steps_equal_one_long_step(self) -> None:
+        # This is what lets a scheduler run at any cadence: the state reached
+        # depends on total elapsed time, not on how it was divided up.
+        split = decay_factor(3600.0, 24.0) * decay_factor(7200.0, 24.0)
+        assert split == pytest.approx(decay_factor(10800.0, 24.0))
+
+
+class TestIgnitionScore:
+    def test_need_without_silence_is_not_enough_on_its_own(self) -> None:
+        score = ignition_score(max_discomfort=1.0, seconds_since_last_field=0.0)
+        ignite, reason = should_ignite(score, seconds_since_last_field=0.0)
+        assert not ignite
+        assert "floor" in reason
+
+    def test_silence_without_need_stays_below_the_threshold(self) -> None:
+        score = ignition_score(max_discomfort=0.0, seconds_since_last_field=1e6)
+        ignite, reason = should_ignite(score, seconds_since_last_field=1e6)
+        assert not ignite
+        assert "threshold" in reason
+
+    def test_both_together_ignite(self) -> None:
+        score = ignition_score(max_discomfort=1.0, seconds_since_last_field=1e6)
+        ignite, _ = should_ignite(score, seconds_since_last_field=1e6)
+        assert ignite
+
+    def test_the_score_rises_with_each_term(self) -> None:
+        low = ignition_score(max_discomfort=0.2, seconds_since_last_field=600.0)
+        more_need = ignition_score(max_discomfort=0.8, seconds_since_last_field=600.0)
+        more_silence = ignition_score(max_discomfort=0.2, seconds_since_last_field=6000.0)
+        assert more_need > low
+        assert more_silence > low
+
+
+class TestExpiryDeadline:
+    def test_an_explicit_deadline_wins(self) -> None:
+        deadline = expiry_deadline(
+            created_at="2026-07-01T00:00:00Z",
+            expires_at="2026-07-01T12:00:00Z",
+            ttl_seconds=60.0,
+        )
+        assert deadline == datetime(2026, 7, 1, 12, tzinfo=timezone.utc)
+
+    def test_creation_plus_ttl_is_the_fallback(self) -> None:
+        deadline = expiry_deadline(
+            created_at="2026-07-01T00:00:00Z", expires_at=None, ttl_seconds=1800.0
+        )
+        assert deadline == datetime(2026, 7, 1, 0, 30, tzinfo=timezone.utc)
+
+    def test_an_unreadable_row_has_no_deadline(self) -> None:
+        assert expiry_deadline(created_at=None, expires_at=None, ttl_seconds=60.0) is None
+
+
+def _trajectory(
+    field,
+    distribution_id: str,
+    *,
+    probability: float,
+    created_at: str,
+    action_kind: str = "tool:look_left",
+) -> ImaginedTrajectory:
+    return ImaginedTrajectory(
+        distribution_id=distribution_id,
+        field_id=field.field_id,
+        tick_id=field.tick_id,
+        action_kind=action_kind,
+        context_signature="desire|user_prompt|look_outside|neu|mid|" + action_kind,
+        horizon=1,
+        steps=[
+            TrajectoryStep(
+                step_index=1,
+                predicted_belief=FieldBelief(source_mode=SourceMode.IMAGINED),
+                outcome_bucket="ok/short/percept/=",
+                conditional_probability=0.5,
+                uncertainty=0.5,
+                support_observations=0.0,
+                basis="prior",
+            )
+        ],
+        probability=probability,
+        uncertainty=0.5,
+        created_at=created_at,
+    )
+
+
+class TestStep:
+    def test_a_first_step_records_a_run(self, social_db, tmp_path) -> None:
+        daemon = OrganismDaemon(
+            social_db, _producer(social_db, tmp_path), ignition_threshold=2.0
+        )
+        step = daemon.step()
+        assert step.elapsed_seconds == 0.0
+        assert daemon.runs.recent()[0]["run_id"] == step.run_id
+
+    def test_elapsed_comes_from_the_previous_run(self, social_db, tmp_path) -> None:
+        # The daemon has no process to time itself by, so this is the only
+        # thing that makes its clock a clock.
+        daemon = OrganismDaemon(
+            social_db, _producer(social_db, tmp_path), ignition_threshold=2.0
+        )
+        start = datetime(2026, 7, 1, 3, tzinfo=timezone.utc)
+        daemon.step(now=start)
+        second = daemon.step(now=start + timedelta(hours=6))
+        assert second.elapsed_seconds == pytest.approx(6 * 3600.0)
+
+    def test_counts_decay_by_elapsed_time(self, social_db, tmp_path) -> None:
+        _seed_stat(social_db, 4.0)
+        daemon = OrganismDaemon(
+            social_db, _producer(social_db, tmp_path), ignition_threshold=2.0
+        )
+        start = datetime(2026, 7, 1, 3, tzinfo=timezone.utc)
+        daemon.step(now=start)
+        assert _observations(social_db) == pytest.approx(4.0)
+        step = daemon.step(now=start + timedelta(seconds=WEEK_SECONDS))
+        assert step.stats_decayed == 1
+        assert _observations(social_db) == pytest.approx(2.0)
+
+    def test_counts_stop_at_the_floor_rather_than_vanishing(
+        self, social_db, tmp_path
+    ) -> None:
+        _seed_stat(social_db, MIN_OBSERVATION_COUNT)
+        daemon = OrganismDaemon(
+            social_db, _producer(social_db, tmp_path), ignition_threshold=2.0
+        )
+        start = datetime(2026, 7, 1, 3, tzinfo=timezone.utc)
+        daemon.step(now=start)
+        step = daemon.step(now=start + timedelta(days=365))
+        assert step.stats_decayed == 0
+        assert _observations(social_db) == pytest.approx(MIN_OBSERVATION_COUNT)
+
+    def test_a_dry_run_changes_nothing(self, social_db, tmp_path) -> None:
+        _seed_stat(social_db, 4.0)
+        daemon = OrganismDaemon(
+            social_db, _producer(social_db, tmp_path), ignition_threshold=2.0
+        )
+        start = datetime(2026, 7, 1, 3, tzinfo=timezone.utc)
+        daemon.step(now=start)
+        daemon.step(now=start + timedelta(seconds=WEEK_SECONDS), dry_run=True)
+        assert _observations(social_db) == pytest.approx(4.0)
+        assert len(daemon.runs.recent()) == 1
+
+
+class TestProtentionExpiry:
+    def test_an_untaken_imagining_expires_and_a_fresh_one_does_not(
+        self, social_db, tmp_path
+    ) -> None:
+        producer = _producer(social_db, tmp_path)
+        field = _commit(producer)
+        moment = datetime.now(timezone.utc)
+        stale = _trajectory(
+            field,
+            "prot_expiry_test",
+            probability=0.6,
+            created_at=_iso(moment - timedelta(hours=2)),
+        )
+        fresh = _trajectory(
+            field,
+            "prot_expiry_test",
+            probability=0.4,
+            created_at=_iso(moment),
+            action_kind="no_action",
+        )
+        store = TrajectoryStore(social_db)
+        store.create_distribution(
+            ProtentionDistribution(
+                distribution_id="prot_expiry_test",
+                field_id=field.field_id,
+                tick_id=field.tick_id,
+                trajectories=[stale, fresh],
+                entropy=normalized_entropy([0.6, 0.4]),
+            )
+        )
+        daemon = OrganismDaemon(social_db, producer, ignition_threshold=2.0)
+        step = daemon.step(now=moment)
+        assert step.protentions_expired == 1
+        assert store.get_trajectory(stale.trajectory_id).status is (
+            TrajectoryStatus.EXPIRED
+        )
+        assert store.get_trajectory(fresh.trajectory_id).status is (
+            TrajectoryStatus.IMAGINED
+        )
+
+
+class TestIgnition:
+    def test_need_and_silence_open_a_tick_nobody_asked_for(
+        self, social_db, tmp_path
+    ) -> None:
+        producer = _producer(social_db, tmp_path)
+        _commit(producer)
+        daemon = OrganismDaemon(social_db, producer)
+        step = daemon.step(now=datetime.now(timezone.utc) + timedelta(hours=3))
+        assert step.ignited
+        assert step.tick_id is not None
+        row = social_db.fetchone(
+            "SELECT trigger_kind FROM enacted_fields WHERE tick_id = ?",
+            (step.tick_id,),
+        )
+        assert row["trigger_kind"] == TriggerKind.AUTONOMOUS.value
+
+    def test_a_recent_field_holds_ignition_off(self, social_db, tmp_path) -> None:
+        producer = _producer(social_db, tmp_path)
+        _commit(producer)
+        daemon = OrganismDaemon(social_db, producer)
+        step = daemon.step()
+        assert not step.ignited
+        assert step.tick_id is None
+        assert "floor" in step.reason
+
+    def test_a_settled_need_holds_ignition_off_through_any_silence(
+        self, social_db, tmp_path
+    ) -> None:
+        producer = _producer(social_db, tmp_path, unmet=False)
+        _commit(producer)
+        daemon = OrganismDaemon(social_db, producer)
+        step = daemon.step(now=datetime.now(timezone.utc) + timedelta(hours=3))
+        assert not step.ignited
+        assert "threshold" in step.reason

--- a/docs/organism-daemon.md
+++ b/docs/organism-daemon.md
@@ -1,0 +1,119 @@
+# Internal Time
+
+Status: shipped 2026-07-28 on the `feat/organism-daemon` branch, behind
+`[individual-kernel] organism_daemon`, which defaults to **off**. Scope: what
+changes when nothing is said to the runtime, and the conditions under which a
+tick opens that nobody asked for. Action selection inside a tick, the boundary
+gate, and the `<current_field>` surface are unchanged.
+
+Claim policy: this is a scheduler over recorded state. Nothing in it is a
+phenomenal claim.
+
+## The defect
+
+Every tick was caused from outside: a prompt, a tool result, a hook firing on
+someone else's action. `TriggerKind.AUTONOMOUS` had been in the enum since the
+beginning and nothing produced it. With no input, nothing in the runtime moved
+-- counts did not age, imaginings stayed pending forever, and no internal state
+could ever become the reason for anything.
+
+## What the clock does
+
+`OrganismDaemon.step` is one turn. There is no long-lived process, so it takes
+its elapsed time from the previous recorded run rather than from how long it
+slept; a scheduler may call it at any cadence, or twice in a row, and the state
+reached is the same.
+
+**Decay.** Observation counts are multiplied by `0.5 ** (elapsed_hours / 168)`,
+a one-week half-life. Rows stop at a floor of 0.05 rather than being deleted: a
+row at the floor still records that the transition was seen, it just stops
+dominating the estimate. Because the factor compounds, splitting one long
+interval into several short ones lands on the same number -- which is what makes
+the cadence a free choice.
+
+**Expiry.** An `imagined` trajectory whose deadline has passed becomes
+`expired`. The deadline is `expires_at` when a producer set one, otherwise
+creation plus 30 minutes, so trajectories written before anything populated that
+column still retire. Only `imagined` expires: one that reached `intended` was
+claimed by an intention and has to be resolved by its outcome, not by the clock.
+
+**Ignition.**
+
+```
+need    = clamp01(max_discomfort)                       from allostasis
+silence = clamp01(seconds_since_last_field / 7200)
+score   = 0.6 * need + 0.4 * silence
+ignite  = score >= 0.55  AND  seconds_since_last_field >= 900
+```
+
+Both terms are load-bearing. Need alone would fire continuously during a
+session, when the runtime is already awake and the need is being addressed;
+silence alone would fire on a schedule, which is a cron job in a costume. The
+interval is a hard floor rather than a third weighted term: a tick that just
+happened means the runtime is awake, and no amount of need justifies opening a
+second one on top of it.
+
+When it fires, `begin_tick(TriggerKind.AUTONOMOUS)` followed by
+`compete_and_commit` -- the ordinary path, with the trigger being the only
+difference. Nothing about what the resulting tick may then *do* is relaxed: the
+boundary gate and the one-outward-action bottleneck are untouched.
+
+Every turn writes one `organism_runs` row (migration 012) recording the inputs,
+the score, the decision and the reason -- including the reason it did not fire,
+and including a failure to open the tick.
+
+## What was measured
+
+Against a fork of the live history on 2026-07-28 (the fork machinery from PR-6,
+so the live database was never written to):
+
+| | first step | second step, +7 days |
+|---|---|---|
+| elapsed | 0 s | 604 800 s |
+| decay factor | 1.0 | 0.500 |
+| stat rows decayed | 0 | 59 |
+| protentions expired | 482 | 89 |
+| silence | 16 s | 604 816 s |
+| ignition score | 0.481 | 0.880 |
+| ignited | no -- "a field was committed 16s ago; the floor is 900s" | yes |
+
+Total observation mass went from 427.0 to 214.5 across the week: half, plus the
+1.0 held by rows already sitting at the floor. Pending protentions went 571 → 0;
+the live history had accumulated 571 imaginings that nothing had ever retired,
+because until now nothing could.
+
+The fork ended with one `autonomous` field. The live database still has zero.
+
+## Why the flag ships off
+
+Unlike the flags in #111, the blocker here is not evidence -- the measurement
+above is the evidence. It is that the first real run against live history will
+expire 571 pending trajectories and halve week-old counts, and that is a change
+to someone's recorded history rather than a new table. It also has no scheduler
+yet, so the flag alone does nothing: something has to call `organism_step`.
+Both of those are decisions for whoever owns the history, not defaults to
+assume.
+
+## The quiet-hours gate
+
+`SleepConsolidator` defaulted to a predicate that returned `True` at every hour,
+so the gate it advertised was open all the time. The served consolidator now
+asks `BoundaryStore.get_quiet_mode_state`, which is the same `[global]
+quiet_hours` and `timezone` that already govern speaking and posting. A
+consolidator constructed without a boundary store keeps the permissive
+fallback: it has no way to know the hour, and refusing every run would be a
+silent failure rather than a safe one.
+
+## Limits
+
+The desire snapshot is still written by an external updater that stopped
+running. `project_desires` extrapolates from it, so with a snapshot months old
+every need saturates and `max_discomfort` is effectively pinned at its maximum
+(0.8 in the measurement above). The ignition mechanism works; the need term it
+reads is currently less informative than it should be. Moving the writer inside
+the kernel is the remaining half of that problem.
+
+Ignition does not consult quiet hours. Opening a tick is not an outward action,
+and a runtime should be able to think at 3am; what it may then *do* is the
+boundary gate's business. If that turns out to be wrong in practice, the place
+to fix it is `should_ignite`, which already takes its thresholds as arguments.

--- a/mcpBehavior.toml
+++ b/mcpBehavior.toml
@@ -62,3 +62,8 @@ valence_coupling = true            # affect で競合重みを変調する。既
                                    # 2026-07-28 のライブ確認でスコア差が設計式と一致した。
                                    # boundary gate は一切読まない
                                    # （docs/valence-coupling-design.md）
+organism_daemon = false            # 非LLM の内的時計。stats の減衰、protention の期限切れ、
+                                   # 需要と沈黙からの ignition（AUTONOMOUS tick の初の生成者）。
+                                   # 既定 off: tick を新たに作る唯一のフラグなので、
+                                   # ライブで前後を測ってから on にする
+                                   # （docs/organism-daemon.md）

--- a/sociality-mcp/packages/social-core/src/social_core/migrations.py
+++ b/sociality-mcp/packages/social-core/src/social_core/migrations.py
@@ -406,6 +406,31 @@ CREATE INDEX IF NOT EXISTS idx_field_transitions_action
     ON field_transitions(action_id, created_at DESC);
 """
 
+_MIGRATION_012_SQL = """
+CREATE TABLE IF NOT EXISTS organism_runs (
+    run_id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    ran_at TEXT NOT NULL,
+    elapsed_seconds REAL NOT NULL DEFAULT 0.0,
+    stats_decayed INTEGER NOT NULL DEFAULT 0,
+    decay_factor REAL NOT NULL DEFAULT 1.0,
+    protentions_expired INTEGER NOT NULL DEFAULT 0,
+    max_discomfort REAL NOT NULL DEFAULT 0.0,
+    dominant_desire TEXT,
+    seconds_since_last_field REAL NOT NULL DEFAULT 0.0,
+    ignition_score REAL NOT NULL DEFAULT 0.0,
+    ignited INTEGER NOT NULL DEFAULT 0,
+    tick_id TEXT REFERENCES tick_frames(tick_id) ON DELETE SET NULL,
+    reason TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    CHECK(elapsed_seconds >= 0.0),
+    CHECK(decay_factor > 0.0 AND decay_factor <= 1.0),
+    CHECK(ignition_score >= 0.0 AND ignition_score <= 1.0)
+);
+CREATE INDEX IF NOT EXISTS idx_organism_runs_owner_ran
+    ON organism_runs(owner_id, ran_at DESC);
+"""
+
 _MIGRATION_011_SQL = """
 CREATE TABLE IF NOT EXISTS process_meta_representations (
     process_meta_id TEXT PRIMARY KEY,
@@ -856,6 +881,10 @@ MIGRATIONS = [
     Migration(
         name="011_process_meta_representations",
         sql=_MIGRATION_011_SQL,
+    ),
+    Migration(
+        name="012_organism_runs",
+        sql=_MIGRATION_012_SQL,
     ),
 ]
 


### PR DESCRIPTION
## Summary

PR-7, the last of the roadmap. Stacked on #113; review that one first.

`TriggerKind.AUTONOMOUS` has been in the enum since the beginning and nothing
ever produced it. That is not a missing feature so much as a missing property:
with no input, **nothing in the runtime moved**. Counts did not age, imaginings
stayed pending forever, and no internal state could become the reason for
anything.

`OrganismDaemon.step` is one turn of internal time. It is deliberately not a
model -- every quantity is read from recorded state and combined
arithmetically:

```
decay     count *= 0.5 ** (elapsed_hours / 168)     floor 0.05, never deleted
expiry    imagined trajectories past their deadline -> expired
ignition  0.6 * need + 0.4 * silence >= 0.55  AND  silence >= 900s
```

Both ignition terms are load-bearing. Need alone fires continuously during a
session, when the runtime is already awake and the need is being addressed;
silence alone fires on a schedule, which is a cron job in a costume.

Design: `docs/organism-daemon.md`.

Claim policy: this is a scheduler over recorded state. Nothing here is a
phenomenal claim.

## Cadence is free

There is no long-lived process, so a step takes its elapsed time from the
previous recorded run rather than from how long it slept. The decay factor
compounds, so two short steps land exactly where one long step would -- a
scheduler can run every minute or once a week without changing where the state
ends up. A test asserts the identity.

## Measured against forked live history

Using the fork machinery from #113, so the live database was never written to:

| | first step | second step, +7 days |
|---|---|---|
| decay factor | 1.0 | 0.500 |
| stat rows decayed | 0 | 59 |
| protentions expired | 482 | 89 |
| silence | 16 s | 604 816 s |
| ignition score | 0.481 | 0.880 |
| ignited | no -- *"a field was committed 16s ago; the floor is 900s"* | **yes** |

Observation mass 427.0 → 214.5: exactly half, plus the 1.0 held by rows already
at the floor. Pending protentions 571 → 0 -- the live history had accumulated
571 imaginings nothing had ever been able to retire.

The fork ended with one `autonomous` field. The live database still has zero.

## The flag ships off, and why that is not the usual reason

Unlike #111, the blocker is not evidence; the table above is the evidence. It is
that the first real run **rewrites recorded history** -- 571 trajectories
retired, week-old counts halved -- and that nothing schedules it yet. Both are
calls for whoever owns the history, not defaults to assume. Turning it on is a
one-line change plus a cron entry.

## Also fixed: the quiet-hours gate

`SleepConsolidator`'s default predicate was `def _always_quiet(_ts): return True`
-- the gate it advertised was open at every hour. The served consolidator now
asks `BoundaryStore.get_quiet_mode_state`, the same `[global] quiet_hours` and
`timezone` that already govern speaking and posting. A consolidator built
without a boundary store keeps the permissive fallback: it cannot know the hour,
and refusing every run would be a silent failure rather than a safe one.

## Tests

436 passed (kernel + social-core), 19 new: the half-life, the compounding
identity, each ignition term failing alone and succeeding together, the deadline
fallback, elapsed derived from the previous run, the floor, dry-run writing
nothing, only-`imagined`-expires, and a committed field whose `trigger_kind` is
`autonomous`. `uv lock --check` clean, ruff clean.

## Roadmap

The desire snapshot is still written by an updater that stopped running, so
every need saturates and the need term is pinned near its maximum (0.8 above).
The mechanism works; its input does not. Moving that writer into the kernel is
the remaining half.

Ignition does not consult quiet hours -- opening a tick is not an outward
action, and what the tick may then do is the boundary gate's business. If that
proves wrong in practice, `should_ignite` already takes its thresholds as
arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
