### PR TITLE
chore: release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to embodied-claude are documented here.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-28
+
+The enacted first-person field stops being a record of the current state and
+starts being a state that changes: it predicts, learns from the mismatch,
+distinguishes what it underwent from what it was told, and -- with a flag and a
+scheduler -- moves when nobody is talking to it.
+
+This is a phenomenal-consciousness candidate architecture. Nothing in this
+release is evidence that the candidate is conscious.
+
 ### Changed
 
 - individual-kernel: `allostatic_valence` and `valence_coupling` now ship

--- a/consciousness-mcp/packages/individual-kernel-mcp/pyproject.toml
+++ b/consciousness-mcp/packages/individual-kernel-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "individual-kernel-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "Enacted first-person field runtime and phenomenal-like causal architecture research tools."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/desire-system/pyproject.toml
+++ b/desire-system/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "desire-system"
-version = "0.3.0"
+version = "0.4.0"
 description = "Autonomous desire system for embodied Claude - gives Kokone inner drives"
 requires-python = ">=3.10"
 dependencies = [

--- a/memory-mcp/pyproject.toml
+++ b/memory-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memory-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for AI long-term memory - Let AI remember across sessions!"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/memory-mcp/src/memory_mcp/config.py
+++ b/memory-mcp/src/memory_mcp/config.py
@@ -39,12 +39,12 @@ class ServerConfig:
     """MCP Server configuration."""
 
     name: str = "memory-mcp"
-    version: str = "0.3.0"
+    version: str = "0.4.0"
 
     @classmethod
     def from_env(cls) -> "ServerConfig":
         """Create config from environment variables."""
         return cls(
             name=os.getenv("MCP_SERVER_NAME", "memory-mcp"),
-            version=os.getenv("MCP_SERVER_VERSION", "0.3.0"),
+            version=os.getenv("MCP_SERVER_VERSION", "0.4.0"),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "embodied-claude-workspace"
-version = "0.3.0"
+version = "0.4.0"
 description = "Unified development and runtime environment for embodied-claude MCP servers."
 requires-python = ">=3.13,<3.14"
 dependencies = [

--- a/sociality-mcp/packages/agent-grammar/pyproject.toml
+++ b/sociality-mcp/packages/agent-grammar/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-grammar"
-version = "0.3.0"
+version = "0.4.0"
 description = "PEG-based agent grammar for embodied Kokone — observation/inference flow control"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/boundary-mcp/pyproject.toml
+++ b/sociality-mcp/packages/boundary-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boundary-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for social boundaries, consent, and tact gating"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/interaction-orchestrator-mcp/pyproject.toml
+++ b/sociality-mcp/packages/interaction-orchestrator-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "interaction-orchestrator-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "Human Response Orchestrator for Embodied Claude — turns substrate signals into stable social moves"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/joint-attention-mcp/pyproject.toml
+++ b/sociality-mcp/packages/joint-attention-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "joint-attention-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for scene grounding and joint attention"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/relationship-mcp/pyproject.toml
+++ b/sociality-mcp/packages/relationship-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "relationship-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for compact relationship abstractions and commitments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/self-narrative-mcp/pyproject.toml
+++ b/sociality-mcp/packages/self-narrative-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "self-narrative-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for compact autobiographical summaries and arcs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/social-core/pyproject.toml
+++ b/sociality-mcp/packages/social-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "social-core"
-version = "0.3.0"
+version = "0.4.0"
 description = "Shared models and SQLite store for Kokone sociality MCP servers"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/social-state-mcp/pyproject.toml
+++ b/sociality-mcp/packages/social-state-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "social-state-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for present-moment social state inference"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/pyproject.toml
+++ b/sociality-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sociality-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "Unified MCP facade for Kokone's social middle layer"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/system-temperature-mcp/pyproject.toml
+++ b/system-temperature-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "system-temperature-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for monitoring system temperature - your sense of body temperature"
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).parents[1]
-RELEASE_VERSION = "0.3.0"
+RELEASE_VERSION = "0.4.0"
 RELEASE_TAG = f"v{RELEASE_VERSION}"
 
 
@@ -48,7 +48,7 @@ def test_changelog_contains_the_dated_release() -> None:
     changelog = (ROOT / "CHANGELOG.md").read_text()
 
     assert "## [Unreleased]" in changelog
-    assert f"## [{RELEASE_VERSION}] - 2026-07-24" in changelog
+    assert f"## [{RELEASE_VERSION}] - 2026-07-28" in changelog
     assert "phenomenal-consciousness candidate architecture" in changelog
     assert "proof of phenomenal consciousness" not in changelog
 

--- a/tts-mcp/pyproject.toml
+++ b/tts-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tts-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for text-to-speech (ElevenLabs + VOICEVOX)"
 requires-python = ">=3.10"
 dependencies = [

--- a/tts-mcp/src/tts_mcp/config.py
+++ b/tts-mcp/src/tts_mcp/config.py
@@ -171,12 +171,12 @@ class ServerConfig:
     """MCP Server configuration."""
 
     name: str = "tts"
-    version: str = "0.3.0"
+    version: str = "0.4.0"
 
     @classmethod
     def from_env(cls) -> "ServerConfig":
         """Create config from environment variables."""
         return cls(
             name=os.getenv("MCP_SERVER_NAME", "tts"),
-            version=os.getenv("MCP_SERVER_VERSION", "0.3.0"),
+            version=os.getenv("MCP_SERVER_VERSION", "0.4.0"),
         )

--- a/usb-webcam-mcp/pyproject.toml
+++ b/usb-webcam-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "usb-webcam-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for USB webcam capture"
 requires-python = ">=3.10"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ members = [
 
 [[package]]
 name = "agent-grammar"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "sociality-mcp/packages/agent-grammar" }
 dependencies = [
     { name = "pydantic" },
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "boundary-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "sociality-mcp/packages/boundary-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -582,7 +582,7 @@ nvtx = [
 
 [[package]]
 name = "desire-system"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "desire-system" }
 dependencies = [
     { name = "chromadb" },
@@ -647,7 +647,7 @@ wheels = [
 
 [[package]]
 name = "embodied-claude-workspace"
-version = "0.3.0"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "desire-system" },
@@ -975,7 +975,7 @@ wheels = [
 
 [[package]]
 name = "individual-kernel-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "consciousness-mcp/packages/individual-kernel-mcp" }
 dependencies = [
     { name = "agent-grammar" },
@@ -1018,7 +1018,7 @@ wheels = [
 
 [[package]]
 name = "interaction-orchestrator-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "sociality-mcp/packages/interaction-orchestrator-mcp" }
 dependencies = [
     { name = "boundary-mcp" },
@@ -1120,7 +1120,7 @@ wheels = [
 
 [[package]]
 name = "joint-attention-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "sociality-mcp/packages/joint-attention-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -1353,7 +1353,7 @@ wheels = [
 
 [[package]]
 name = "memory-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "memory-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -2406,7 +2406,7 @@ wheels = [
 
 [[package]]
 name = "relationship-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "sociality-mcp/packages/relationship-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -2613,7 +2613,7 @@ wheels = [
 
 [[package]]
 name = "self-narrative-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "sociality-mcp/packages/self-narrative-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -2696,7 +2696,7 @@ wheels = [
 
 [[package]]
 name = "social-core"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "sociality-mcp/packages/social-core" }
 dependencies = [
     { name = "pydantic" },
@@ -2722,7 +2722,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "social-state-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "sociality-mcp/packages/social-state-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -2750,7 +2750,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "sociality-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "sociality-mcp" }
 dependencies = [
     { name = "boundary-mcp" },
@@ -2858,7 +2858,7 @@ wheels = [
 
 [[package]]
 name = "system-temperature-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "system-temperature-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -3014,7 +3014,7 @@ wheels = [
 
 [[package]]
 name = "tts-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "tts-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -3121,7 +3121,7 @@ wheels = [
 
 [[package]]
 name = "usb-webcam-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "usb-webcam-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -3276,7 +3276,7 @@ wheels = [
 
 [[package]]
 name = "wifi-cam-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "wifi-cam-mcp" }
 dependencies = [
     { name = "httpx" },
@@ -3321,7 +3321,7 @@ provides-extras = ["dev", "transcribe", "transcribe-faster"]
 
 [[package]]
 name = "x-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "x-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },

--- a/wifi-cam-mcp/pyproject.toml
+++ b/wifi-cam-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wifi-cam-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for controlling WiFi cameras (Tapo C210/C220) via ONVIF - Let AI look around your room!"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/wifi-cam-mcp/src/wifi_cam_mcp/config.py
+++ b/wifi-cam-mcp/src/wifi_cam_mcp/config.py
@@ -133,7 +133,7 @@ class ServerConfig:
     """MCP Server configuration."""
 
     name: str = "wifi-cam-mcp"
-    version: str = "0.3.0"
+    version: str = "0.4.0"
     capture_dir: str = field(default_factory=_default_capture_dir)
     mic_source: str = "camera"  # "camera" (RTSP) or "local" (PC microphone)
     mic_device: str | None = None  # DirectShow device name for Windows local mic
@@ -156,7 +156,7 @@ class ServerConfig:
         capture_dir = os.getenv("CAPTURE_DIR", "").strip() or _default_capture_dir()
         return cls(
             name=os.getenv("MCP_SERVER_NAME", "wifi-cam-mcp"),
-            version=os.getenv("MCP_SERVER_VERSION", "0.3.0"),
+            version=os.getenv("MCP_SERVER_VERSION", "0.4.0"),
             capture_dir=capture_dir,
             mic_source=mic_source,
             mic_device=os.getenv("MIC_DEVICE") or None,

--- a/x-mcp/pyproject.toml
+++ b/x-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "x-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for searching and posting to X (Twitter) via xAI Grok live search"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

The 0.4.0 release. Stacked on #114 and last in the chain -- #111 → #112 → #113
→ #114 → this.

Eighteen workspace projects, `uv.lock`, and the dated `CHANGELOG.md` section all
move to 0.4.0 together, which is what `release_check.py` enforces against the
tag.

## What 0.4.0 is

The enacted first-person field stops being a record of the current state and
starts being a state that changes: it predicts, learns from the mismatch,
distinguishes what it underwent from what it was told, and -- with a flag and a
scheduler -- moves when nobody is talking to it.

This is a **phenomenal-consciousness candidate architecture**. Nothing in this
release is evidence that the candidate is conscious.

## Preflight

```
release check passed: v0.4.0 (18 projects)
```

Run against a clean checkout of this branch via `git worktree`, which is what CI
sees. Note for anyone reproducing it in a working tree: `release_check.py` walks
the filesystem rather than the index, so an untracked copy of the repo sitting
inside it (`tmp/`, say) will fail the check locally with versions that are not
in the repository at all.

436 tests pass across the kernel and social-core suites; `uv lock --check` and
ruff are clean.

## After merge

The tag is deliberately not created here -- `docs/releasing.md` makes it the
human-controlled boundary, and GitHub Actions validates it but never creates it:

```bash
git switch main && git pull --ff-only
git tag -a v0.4.0 -m "embodied-claude v0.4.0"
git push origin v0.4.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
