### PR TITLE
fix(individual-kernel): read the bash command instead of a string that resembles one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to embodied-claude are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- individual-kernel: the bash gate read the command as a string rather than as
+  a command. It split the raw text on `|` and `;`, so an operator inside quotes
+  ended the command and left an unbalanced quote -- `grep "alpha\|beta"` parsed
+  as a write and was refused. The same applied to `>` inside quotes. Commands
+  are now tokenized with `shlex(punctuation_chars=True)`, which yields
+  operators as their own tokens and leaves quoted text alone. Detection of real
+  writes is unchanged: redirection, `tee`, a writing command after a separator,
+  and command substitution are all still refused, and a test pins each one.
+- individual-kernel: `git -C <path> status` was refused because the scan for
+  the subcommand returned the first non-flag token, which is the path. Global
+  options that take a value are now skipped before the subcommand is read.
+
 ## [0.4.0] - 2026-07-28
 
 The enacted first-person field stops being a record of the current state and

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/agency.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/agency.py
@@ -676,14 +676,68 @@ def is_external_tool(tool_name: str, tool_input: dict[str, Any] | None = None) -
     return False
 
 
+_SHELL_SEPARATORS = frozenset({"|", "||", "&&", ";", ";;", "&"})
+_DISCARD_TARGETS = frozenset({"/dev/null"})
+
+
+def _is_redirection(token: str) -> bool:
+    return bool(token) and set(token) <= {"<", ">", "&"} and ">" in token
+
+
+def _shell_segments(command: str) -> list[list[str]] | None:
+    """Split into command segments at unquoted operators, or None if unsafe.
+
+    `shlex` with `punctuation_chars` yields operators as their own tokens and
+    leaves quoted text alone. Splitting the raw string could not tell the two
+    apart: a pipe inside a regex ended the command and left an unbalanced
+    quote, so an ordinary `grep` read as a write and was refused.
+
+    Returns None when the command redirects anywhere but /dev/null, which is
+    the write this whole function exists to catch.
+    """
+
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    try:
+        tokens = list(lexer)
+    except ValueError:
+        return None
+
+    segments: list[list[str]] = []
+    current: list[str] = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        index += 1
+        if token in _SHELL_SEPARATORS:
+            segments.append(current)
+            current = []
+            continue
+        if _is_redirection(token):
+            if current and re.fullmatch(r"\d+", current[-1]):
+                current.pop()  # the file descriptor, e.g. the 2 of `2>`
+            if token.endswith("&"):
+                # Duplicating onto another descriptor writes nowhere new.
+                if index < len(tokens) and re.fullmatch(r"\d+", tokens[index]):
+                    index += 1
+                    continue
+                return None
+            if index < len(tokens) and tokens[index] in _DISCARD_TARGETS:
+                index += 1
+                continue
+            return None
+        current.append(token)
+    segments.append(current)
+    return segments
+
+
 def _bash_is_read_only(command: str) -> bool:
     """Conservatively recognize terminal-only inspection commands."""
 
     if not command.strip() or "$(" in command or "`" in command:
         return False
-    sanitized = re.sub(r"\d*>\s*/dev/null", "", command)
-    sanitized = re.sub(r"\d*>&\d+", "", sanitized)
-    if re.search(r"(^|[^<])>{1,2}", sanitized):
+    segments = _shell_segments(command)
+    if segments is None:
         return False
     read_only = {
         "[",
@@ -732,11 +786,7 @@ def _bash_is_read_only(command: str) -> bool:
         "which",
         "whoami",
     }
-    for segment in re.split(r"\|\||&&|[;|]", sanitized):
-        try:
-            tokens = shlex.split(segment)
-        except ValueError:
-            return False
+    for tokens in segments:
         while tokens and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", tokens[0]):
             tokens.pop(0)
         if not tokens:
@@ -760,10 +810,35 @@ def _bash_is_read_only(command: str) -> bool:
     return True
 
 
+# Global git options that consume the token after them. Without this the scan
+# for the first non-flag token returns the option's value -- `git -C <path>
+# status` read as the unknown subcommand `<path>` and was refused.
+_GIT_VALUE_OPTIONS = frozenset(
+    {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path", "--super-prefix"}
+)
+
+
+def _git_from_subcommand(arguments: list[str]) -> list[str]:
+    """Drop leading global options and return the subcommand with its own arguments."""
+
+    index = 0
+    while index < len(arguments):
+        token = arguments[index]
+        if token in _GIT_VALUE_OPTIONS:
+            index += 2  # the option and the value it takes
+            continue
+        if token.startswith("-"):
+            index += 1  # a flag, or --option=value carrying its own value
+            continue
+        return arguments[index:]
+    return []
+
+
 def _git_is_read_only(arguments: list[str]) -> bool:
     if not arguments:
         return True
-    command = next((item for item in arguments if not item.startswith("-")), "")
+    arguments = _git_from_subcommand(arguments)
+    command = arguments[0] if arguments else ""
     if command in {
         "diff",
         "grep",

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_bash_gate.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_bash_gate.py
@@ -1,0 +1,79 @@
+"""The bash gate has to read the command, not a string that resembles one.
+
+The gate decides whether a shell command is inspection or a side effect, and it
+fails closed. That makes a false positive expensive in a specific way: an
+ordinary read is refused, and the refusal looks like a policy decision rather
+than a parsing accident. Every case here is a command that was actually issued.
+"""
+
+from __future__ import annotations
+
+from individual_kernel_mcp.agency import _bash_is_read_only, is_external_tool
+
+
+class TestQuotedOperators:
+    """An operator inside quotes is an argument, not shell syntax."""
+
+    def test_a_pipe_inside_a_quoted_regex_is_not_a_pipeline(self) -> None:
+        # grep alternation. Splitting the raw string cut the command in half and
+        # left an unbalanced quote, which the gate then read as a write.
+        assert _bash_is_read_only('grep -n "alpha\\|beta" file.txt')
+
+    def test_a_semicolon_inside_a_quoted_argument_is_not_a_separator(self) -> None:
+        assert _bash_is_read_only('grep -n "alpha;beta" file.txt')
+
+    def test_an_arrow_inside_quotes_is_not_a_redirection(self) -> None:
+        assert _bash_is_read_only('grep -n "alpha > beta" file.txt')
+
+    def test_an_ampersand_inside_quotes_is_not_a_background_job(self) -> None:
+        assert _bash_is_read_only('grep -n "alpha && beta" file.txt')
+
+
+class TestRealOperatorsStillCount:
+    """Quote awareness must not become permissiveness."""
+
+    def test_every_stage_of_a_real_pipeline_is_checked(self) -> None:
+        assert _bash_is_read_only("cat file.txt | wc -l")
+        assert not _bash_is_read_only("cat file.txt | tee copy.txt")
+
+    def test_a_real_redirection_is_a_write(self) -> None:
+        assert not _bash_is_read_only("echo hi > out.txt")
+        assert not _bash_is_read_only("echo hi >> out.txt")
+
+    def test_a_writing_command_after_a_separator_is_a_write(self) -> None:
+        assert not _bash_is_read_only("ls /tmp; rm -rf /tmp/x")
+
+    def test_command_substitution_is_still_refused(self) -> None:
+        assert not _bash_is_read_only("echo $(rm -rf /tmp/x)")
+        assert not _bash_is_read_only("echo `rm -rf /tmp/x`")
+
+    def test_discarding_output_stays_allowed(self) -> None:
+        assert _bash_is_read_only("ls /tmp > /dev/null")
+        assert _bash_is_read_only("ls /tmp 2>/dev/null")
+        assert _bash_is_read_only("ls /tmp > /dev/null 2>&1")
+
+
+class TestGitGlobalOptions:
+    """A global option must not be mistaken for the subcommand."""
+
+    def test_a_path_option_does_not_hide_the_subcommand(self) -> None:
+        # `-C` takes a value, so the first non-flag token is the path.
+        assert _bash_is_read_only("git -C /tmp/repo status")
+
+    def test_a_config_option_does_not_hide_the_subcommand(self) -> None:
+        assert _bash_is_read_only("git -c core.pager=cat log -1")
+
+    def test_an_attached_value_option_does_not_hide_the_subcommand(self) -> None:
+        assert _bash_is_read_only("git --git-dir=/tmp/repo/.git rev-parse HEAD")
+
+    def test_a_writing_subcommand_behind_an_option_is_still_refused(self) -> None:
+        assert not _bash_is_read_only("git -C /tmp/repo commit -m x")
+        assert not _bash_is_read_only("git -C /tmp/repo push")
+
+
+class TestGateIntegration:
+    def test_the_gate_calls_a_quoted_pipe_internal(self) -> None:
+        assert not is_external_tool("Bash", {"command": 'grep "alpha\\|beta" x'})
+
+    def test_the_gate_still_calls_a_write_external(self) -> None:
+        assert is_external_tool("Bash", {"command": "echo hi > out.txt"})


### PR DESCRIPTION
## Summary

The bash gate decides whether a shell command is inspection or a side effect,
and it fails closed. It was reading the command as a *string* rather than as a
command, which made ordinary reads look like writes.

```python
re.split(r"\|\||&&|[;|]", sanitized)     # splits the raw text
```

So `grep -n "alpha\|beta" file` was cut at the pipe inside the regex, leaving
`grep -n "alpha\` — an unbalanced quote that `shlex.split` rejects, which the
gate then read as a write and refused. The redirection check had the same
blind spot: `grep "a > b"` counted as a redirection.

Commands are now tokenized once with `shlex(punctuation_chars=True)`, which
yields operators as their own tokens and leaves quoted text alone.

## Not a loosening

The point of the gate is catching writes, so the change had to be shown not to
weaken that. Eight cases in the new file were **already passing before this
change and still pass**: `> out.txt`, `>> out.txt`, `| tee`, `; rm -rf`,
`$(...)`, backticks, `git ... commit`, `git ... push`. Discarding to
`/dev/null` and `2>&1` stay allowed, as before.

The seven that were failing are the misjudgments: a pipe, semicolon, arrow or
ampersand inside quotes, and the two git cases below.

## Also: `git -C <path> status`

`_git_is_read_only` took the first non-flag token as the subcommand. For
`git -C /tmp/repo status` that is `/tmp/repo`, so the command read as an
unknown subcommand and was refused. Global options that take a value (`-C`,
`-c`, `--git-dir`, `--work-tree`, and friends) are now skipped before the
subcommand is read. `git -C x commit` is still refused.

## Evidence

Every case in `test_bash_gate.py` is a command that was actually issued during
the 0.4.0 work; the quoted-alternation one was hit three times in a single
session, each time reading as a policy refusal rather than a parsing accident.

15 new tests; 451 passed across the kernel and social-core suites; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
