### PR TITLE
fix: make the desire snapshot reach the kernel again (0.4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to embodied-claude are documented here.
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-07-28
+
+The body state had been reporting every need maximal since May. The composition
+was not at fault; its input was. The desire snapshot the kernel reads had not
+been written for 71 days, and nothing downstream could tell that apart from an
+agent that genuinely had not looked outside since then.
+
+### Fixed
+
+- desire-system: `DESIRES_PATH` was read from the environment without
+  `expanduser()`. The default is built from `Path.home()` and was fine, but
+  `.env` supplies `~/.claude/desires.json` as a plain string, and an unexpanded
+  tilde is a relative path: the updater created a directory literally named `~`
+  under its working directory and wrote there. It had been doing so since at
+  least 2026-04-08 while reporting success every five minutes, and the same
+  stray tree exists in each sibling checkout. `server.py` read the variable the
+  same way. With the path expanded, the snapshot the kernel reads updated for
+  the first time since 2026-05-18, and the committed field's focus moved from
+  `identity_coherence` to `observe_room` on the next tick.
+- individual-kernel: `project_desires` extrapolated without bound. Levels ramp
+  to 1.0 over `satisfaction_hours`, the longest of which is three, so a snapshot
+  nobody has written reports every need maxed out however long it has been
+  abandoned -- and the organism daemon's ignition term reads exactly that. Past
+  `MAX_SNAPSHOT_AGE_HOURS` (24) the projection reports the resting state, no
+  discomfort and no dominant need, and marks itself unusable. The age is still
+  returned, because refusing to extrapolate is not the same as claiming the
+  snapshot is current. Hours of genuine neglect still saturate as before.
+- individual-kernel: the rule deciding what takes focus next was written twice,
+  once for the protention and once for the attention schema. Both derived it
+  from the same competition in the same way, so nothing disagreed; a change to
+  either would have diverged from the other silently. It now lives on
+  `CompetitionResult.next_focus_candidate` and both read it.
+
 ## [0.4.1] - 2026-07-28
 
 A patch for one defect found immediately after 0.4.0 shipped: the gate that

--- a/consciousness-mcp/packages/individual-kernel-mcp/pyproject.toml
+++ b/consciousness-mcp/packages/individual-kernel-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "individual-kernel-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "Enacted first-person field runtime and phenomenal-like causal architecture research tools."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/allostasis.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/allostasis.py
@@ -5,7 +5,10 @@ Two problems in the previous body state are addressed here.
 The desire file is written by an external updater on a timer. When that timer
 stops, every level freezes at whatever was last written. `project_desires`
 re-derives current levels from the recorded snapshot plus elapsed time, so the
-writer only supplies corrections and the kernel owns the clock.
+writer only supplies corrections and the kernel owns the clock. Owning the clock
+is not the same as owning the input: levels ramp to 1.0 within hours, so a
+snapshot the writer abandoned reports every need maxed out forever. Past
+`MAX_SNAPSHOT_AGE_HOURS` the projection says so instead of extrapolating.
 
 Valence was `-0.6 * max_discomfort`, whose upper bound is zero: no outcome could
 produce a positive state. `compose_valence` builds it from an appetitive term
@@ -55,6 +58,14 @@ DEFAULT_DESIRE_SPECS: dict[str, DesireSpec] = {
 
 FALLBACK_SPEC = DesireSpec(satisfaction_hours=2.0, set_point=0.3)
 
+# Beyond this, a snapshot is an artifact rather than a record. The longest
+# satisfaction window is three hours, so everything saturates well inside a day
+# and a further extrapolation adds no information -- it only makes an absent
+# writer look identical to a genuinely neglected agent. A day is far longer than
+# any gap a running writer produces and far shorter than the 71 days the live
+# snapshot actually sat unwritten.
+MAX_SNAPSHOT_AGE_HOURS = 24.0
+
 
 @dataclass(frozen=True)
 class DesireProjection:
@@ -64,6 +75,7 @@ class DesireProjection:
     discomforts: dict[str, float]
     dominant: str | None
     stale_seconds: float
+    usable: bool = True
 
     @property
     def mean_discomfort(self) -> float:
@@ -171,6 +183,13 @@ def project_desires(
 
     An unreadable or absent timestamp is treated as "just written": the recorded
     levels are used as-is rather than extrapolated from a guessed instant.
+
+    Past ``MAX_SNAPSHOT_AGE_HOURS`` the snapshot no longer describes anyone, and
+    extrapolating it would report every need maxed out however long the writer
+    has been gone. Such a projection is marked unusable and reports the resting
+    state: levels at their set points, no discomfort, no dominant need. The age
+    is still returned, because refusing to extrapolate is not the same as
+    claiming the snapshot is current.
     """
 
     specs = specs or DEFAULT_DESIRE_SPECS
@@ -182,6 +201,7 @@ def project_desires(
     stale_seconds = (
         max(0.0, (now - recorded_at).total_seconds()) if recorded_at else 0.0
     )
+    usable = stale_seconds <= MAX_SNAPSHOT_AGE_HOURS * 3600.0
 
     desires: dict[str, float] = {}
     discomforts: dict[str, float] = {}
@@ -191,22 +211,25 @@ def project_desires(
         except (TypeError, ValueError):
             continue
         spec = specs.get(str(name), FALLBACK_SPEC)
+        set_point = allostatic_set_point(str(name), spec, now)
+        if not usable:
+            desires[str(name)] = set_point
+            discomforts[str(name)] = 0.0
+            continue
         projected = (
             extrapolate_desire_level(level, recorded_at, spec.satisfaction_hours, now)
             if recorded_at
             else _clamp01(level)
         )
         desires[str(name)] = projected
-        discomforts[str(name)] = abs(
-            projected - allostatic_set_point(str(name), spec, now)
-        )
+        discomforts[str(name)] = abs(projected - set_point)
 
     dominant = (
         max(sorted(discomforts), key=lambda name: discomforts[name])
-        if discomforts
+        if discomforts and usable
         else None
     )
-    return DesireProjection(desires, discomforts, dominant, stale_seconds)
+    return DesireProjection(desires, discomforts, dominant, stale_seconds, usable)
 
 
 def compose_valence(

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/attention_schema.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/attention_schema.py
@@ -193,9 +193,7 @@ class AttentionSchemaTracker:
         modality = self._infer_modality_from_candidate(
             result.winner.modality, focal
         )
-        predicted_next = (
-            result.top_rejected[0].content_ref if result.top_rejected else focal
-        )
+        predicted_next = result.next_focus_candidate.content_ref
         control_handle = (
             f"shift:{result.top_rejected[0].candidate_id}"
             if result.conflicted and result.top_rejected

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/tick.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/tick.py
@@ -1165,7 +1165,7 @@ class TickProducer:
 
     @staticmethod
     def _build_protention(result: CompetitionResult) -> Protention:
-        predicted = result.top_rejected[0] if result.top_rejected else result.winner
+        predicted = result.next_focus_candidate
         confidence = _clamp01(
             0.45 * result.attention_intensity
             + 0.35 * (1.0 - result.entropy)

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/workspace.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/workspace.py
@@ -115,6 +115,18 @@ class CompetitionResult(BaseModel):
     attention_intensity: float = Field(ge=0.0, le=1.0)
     deterministic_order: list[str] = Field(default_factory=list)
 
+    @property
+    def next_focus_candidate(self) -> WorkspaceCandidate:
+        """The candidate expected to take focus next.
+
+        The runner-up when the competition rejected anything, otherwise the
+        winner: with nothing contesting it, focus stays where it is. Both the
+        protention and the attention schema answer this question, and a tick
+        that answered it twice could answer it two ways, so it is answered
+        here once.
+        """
+        return self.top_rejected[0] if self.top_rejected else self.winner
+
 
 class WorkspaceEngine:
     """SQLite-backed candidate market with deterministic tie breaking."""

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_desire_staleness.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_desire_staleness.py
@@ -1,0 +1,107 @@
+"""A snapshot old enough to say nothing must not be read as saying everything.
+
+Desire levels grow linearly toward 1.0 over `satisfaction_hours`, the longest of
+which is three. Extrapolating a snapshot therefore saturates every need within
+hours, and keeps returning the saturated answer forever. That is correct for a
+few hours of genuine neglect and wrong for a writer that stopped: the live
+snapshot went unwritten for 71 days and every field committed in that time
+carried a maximal need vector, which is indistinguishable from an agent that
+really had not looked outside since May.
+
+Past a bound, the snapshot is an artifact rather than a record, and the honest
+reading is the resting state plus a note that the input was unusable.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from individual_kernel_mcp.allostasis import (
+    DEFAULT_DESIRE_SPECS,
+    MAX_SNAPSHOT_AGE_HOURS,
+    allostatic_set_point,
+    project_desires,
+)
+
+NOW = datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc)
+
+
+def _snapshot(age: timedelta) -> dict:
+    return {
+        "updated_at": (NOW - age).isoformat(),
+        "desires": {
+            "look_outside": 0.018,
+            "browse_curiosity": 1.0,
+            "miss_kouta": 1.0,
+            "observe_room": 1.0,
+            "identity_coherence": 0.4,
+        },
+    }
+
+
+class TestAFreshSnapshotIsUnaffected:
+    def test_recent_levels_still_extrapolate(self) -> None:
+        projection = project_desires(_snapshot(timedelta(minutes=30)), now=NOW)
+
+        # 0.018 + 0.5h / 1.0h
+        assert projection.desires["look_outside"] == 0.518
+        assert projection.usable is True
+
+    def test_hours_of_real_neglect_still_saturate(self) -> None:
+        # Being genuinely unattended for a few hours is what saturation is for.
+        projection = project_desires(_snapshot(timedelta(hours=6)), now=NOW)
+
+        assert projection.desires["look_outside"] == 1.0
+        assert projection.usable is True
+        assert projection.dominant == "observe_room"
+
+
+class TestAnAbandonedSnapshotIsRefused:
+    def test_a_snapshot_older_than_the_bound_falls_back_to_rest(self) -> None:
+        projection = project_desires(_snapshot(timedelta(days=71)), now=NOW)
+
+        assert projection.usable is False
+        for name, spec in DEFAULT_DESIRE_SPECS.items():
+            if name not in projection.desires:
+                continue
+            assert projection.desires[name] == allostatic_set_point(name, spec, NOW)
+
+    def test_an_unusable_snapshot_reports_no_discomfort(self) -> None:
+        # The daemon fires on unmet need. A snapshot that cannot say what is unmet
+        # must not be able to answer that question either.
+        projection = project_desires(_snapshot(timedelta(days=71)), now=NOW)
+
+        assert projection.mean_discomfort == 0.0
+        assert projection.dominant is None
+
+    def test_the_age_is_still_reported(self) -> None:
+        # Refusing to extrapolate is not the same as pretending it is current.
+        projection = project_desires(_snapshot(timedelta(days=71)), now=NOW)
+
+        assert projection.stale_seconds == 71 * 24 * 3600
+
+
+class TestTheBoundary:
+    def test_exactly_at_the_bound_is_still_usable(self) -> None:
+        projection = project_desires(
+            _snapshot(timedelta(hours=MAX_SNAPSHOT_AGE_HOURS)), now=NOW
+        )
+
+        assert projection.usable is True
+
+    def test_just_past_the_bound_is_not(self) -> None:
+        projection = project_desires(
+            _snapshot(timedelta(hours=MAX_SNAPSHOT_AGE_HOURS, seconds=1)), now=NOW
+        )
+
+        assert projection.usable is False
+
+
+class TestASnapshotWithoutATimestamp:
+    def test_it_is_treated_as_just_written(self) -> None:
+        # Unchanged behaviour: an absent timestamp already meant "use as-is"
+        # rather than "extrapolate from a guessed instant".
+        projection = project_desires({"desires": {"look_outside": 0.4}}, now=NOW)
+
+        assert projection.desires["look_outside"] == 0.4
+        assert projection.usable is True

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_predicted_next_focus.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_predicted_next_focus.py
@@ -1,0 +1,119 @@
+"""One rule decides what comes next, and everything that stores it agrees.
+
+`predicted_next_focus` is assigned twice while a tick commits: once from the
+protention, then again from the attention schema. Both derived it from the same
+competition by the same rule -- the runner-up, or the winner when nothing was
+rejected -- so the two agreed, and these tests passed before the rule was moved
+into one place. They exist to keep it that way: if the derivation is ever split
+again, the object, the trace and the stored surface stop matching here first.
+
+The value round-trips through the epistemic trace. `enacted_fields` has no
+column of that name, and `EnactedFieldStore.update` does not write one, so the
+trace is the only home it has.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from social_core.db import SocialDB
+
+from individual_kernel_mcp.enacted_field import EnactedFieldStore, TriggerKind
+from individual_kernel_mcp.tick import TickProducer
+from individual_kernel_mcp.workspace import (
+    CandidateKind,
+    CandidateSource,
+    SourceMode,
+    WorkspaceCandidate,
+)
+
+
+def _producer(social_db: SocialDB, tmp_path: Path) -> TickProducer:
+    interoception = tmp_path / "interoception.json"
+    interoception.write_text(json.dumps({"now": {"arousal": 50.0}}), encoding="utf-8")
+    desires = tmp_path / "desires.json"
+    desires.write_text(
+        json.dumps({"desires": {"identity_coherence": 0.9}, "dominant": "identity_coherence"}),
+        encoding="utf-8",
+    )
+    return TickProducer(
+        social_db, interoception_path=interoception, desires_path=desires
+    )
+
+
+def _commit(producer: TickProducer, focus_ref: str = "desire:identity_coherence"):
+    opened = producer.begin_tick(TriggerKind.USER_PROMPT)
+    producer.workspace.add_candidate(
+        WorkspaceCandidate(
+            tick_id=opened.tick_id,
+            kind=CandidateKind.GOAL,
+            content_ref=focus_ref,
+            content_summary=f"focus {focus_ref}",
+            source=CandidateSource.DESIRE,
+            source_mode=SourceMode.INFERRED,
+            precision=1.0,
+            need_relevance=1.0,
+            goal_relevance=1.0,
+            continuity_with_previous=1.0,
+            controllability=1.0,
+        )
+    )
+    return producer.compete_and_commit(opened.tick_id).field
+
+
+class TestOneCanonicalPrediction:
+    def test_a_reloaded_field_predicts_what_the_committed_one_did(
+        self, social_db: SocialDB, tmp_path: Path
+    ) -> None:
+        committed = _commit(_producer(social_db, tmp_path))
+        reloaded = EnactedFieldStore(social_db).get(committed.field_id)
+
+        assert reloaded is not None
+        assert reloaded.predicted_next_focus == committed.predicted_next_focus
+
+    def test_the_trace_agrees_with_the_field(
+        self, social_db: SocialDB, tmp_path: Path
+    ) -> None:
+        # The trace is diagnostics for the same state, so it may not carry a
+        # second, different answer under the same name.
+        committed = _commit(_producer(social_db, tmp_path))
+        reloaded = EnactedFieldStore(social_db).get(committed.field_id)
+
+        assert reloaded is not None
+        assert (
+            reloaded.epistemic_trace.get("predicted_next_focus")
+            == reloaded.predicted_next_focus
+        )
+
+    def test_the_stored_surface_agrees_with_the_reloaded_field(
+        self, social_db: SocialDB, tmp_path: Path
+    ) -> None:
+        # The surface is what the agent reads. It is rendered before the row is
+        # written, so a prediction that does not survive persistence would make
+        # the stored string describe a state the stored row does not have.
+        committed = _commit(_producer(social_db, tmp_path))
+        reloaded = EnactedFieldStore(social_db).get(committed.field_id)
+
+        assert reloaded is not None
+        assert reloaded.predicted_next_focus is not None
+        assert f'predicted_next="{reloaded.predicted_next_focus}"' in (
+            reloaded.phenomenal_surface
+        )
+
+    def test_the_attention_schema_predicts_what_the_field_predicts(
+        self, social_db: SocialDB, tmp_path: Path
+    ) -> None:
+        # The two used to be computed independently. They are now one call, and
+        # the schema is the record a reader consults for the same question.
+        producer = _producer(social_db, tmp_path)
+        committed = _commit(producer)
+
+        assert committed.attention_schema_ref is not None
+        row = social_db.fetchone(
+            "SELECT predicted_next_focus FROM attention_schemas WHERE schema_id = ?",
+            (committed.attention_schema_ref,),
+        )
+
+        assert row is not None
+        assert row["predicted_next_focus"] == committed.predicted_next_focus

--- a/desire-system/desire_updater.py
+++ b/desire-system/desire_updater.py
@@ -37,7 +37,15 @@ from backend import (
 load_dotenv()
 
 # 欲求レベル出力先
-DESIRES_PATH = Path(os.getenv("DESIRES_PATH", str(Path.home() / ".claude" / "desires.json")))
+# expanduser() is required. The default is built from Path.home() and is fine,
+# but .env carries DESIRES_PATH=~/.claude/desires.json as a plain string, and an
+# unexpanded tilde is a relative path: the updater created a directory literally
+# named `~` under its working directory and wrote there. It had been doing so
+# since at least 2026-04-08, which is why the file the kernel reads stopped
+# changing on 2026-05-18 while the updater reported success every five minutes.
+DESIRES_PATH = Path(
+    os.getenv("DESIRES_PATH", str(Path.home() / ".claude" / "desires.json"))
+).expanduser()
 
 # 一緒にいる人の名前（miss_companion 欲求で使う）
 COMPANION_NAME = os.getenv("COMPANION_NAME", "あなた")

--- a/desire-system/pyproject.toml
+++ b/desire-system/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "desire-system"
-version = "0.4.1"
+version = "0.4.2"
 description = "Autonomous desire system for embodied Claude - gives Kokone inner drives"
 requires-python = ">=3.10"
 dependencies = [

--- a/desire-system/server.py
+++ b/desire-system/server.py
@@ -22,7 +22,11 @@ from backend import make_default_adapter
 from desire_updater import DESIRE_CONFIGS, compute_desires, save_desires
 
 # 欲求レベル読み込み元
-DESIRES_PATH = Path(os.getenv("DESIRES_PATH", str(Path.home() / ".claude" / "desires.json")))
+# expanduser() for the same reason as in desire_updater.py: .env supplies the
+# tilde as a plain string, and an unexpanded tilde is a relative path.
+DESIRES_PATH = Path(
+    os.getenv("DESIRES_PATH", str(Path.home() / ".claude" / "desires.json"))
+).expanduser()
 
 server = Server("desire-system")
 

--- a/memory-mcp/pyproject.toml
+++ b/memory-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memory-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "MCP server for AI long-term memory - Let AI remember across sessions!"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/memory-mcp/src/memory_mcp/config.py
+++ b/memory-mcp/src/memory_mcp/config.py
@@ -39,12 +39,12 @@ class ServerConfig:
     """MCP Server configuration."""
 
     name: str = "memory-mcp"
-    version: str = "0.4.1"
+    version: str = "0.4.2"
 
     @classmethod
     def from_env(cls) -> "ServerConfig":
         """Create config from environment variables."""
         return cls(
             name=os.getenv("MCP_SERVER_NAME", "memory-mcp"),
-            version=os.getenv("MCP_SERVER_VERSION", "0.4.1"),
+            version=os.getenv("MCP_SERVER_VERSION", "0.4.2"),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "embodied-claude-workspace"
-version = "0.4.1"
+version = "0.4.2"
 description = "Unified development and runtime environment for embodied-claude MCP servers."
 requires-python = ">=3.13,<3.14"
 dependencies = [

--- a/sociality-mcp/packages/agent-grammar/pyproject.toml
+++ b/sociality-mcp/packages/agent-grammar/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-grammar"
-version = "0.4.1"
+version = "0.4.2"
 description = "PEG-based agent grammar for embodied Kokone — observation/inference flow control"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/boundary-mcp/pyproject.toml
+++ b/sociality-mcp/packages/boundary-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boundary-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "MCP server for social boundaries, consent, and tact gating"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/interaction-orchestrator-mcp/pyproject.toml
+++ b/sociality-mcp/packages/interaction-orchestrator-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "interaction-orchestrator-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "Human Response Orchestrator for Embodied Claude — turns substrate signals into stable social moves"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/joint-attention-mcp/pyproject.toml
+++ b/sociality-mcp/packages/joint-attention-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "joint-attention-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "MCP server for scene grounding and joint attention"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/relationship-mcp/pyproject.toml
+++ b/sociality-mcp/packages/relationship-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "relationship-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "MCP server for compact relationship abstractions and commitments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/self-narrative-mcp/pyproject.toml
+++ b/sociality-mcp/packages/self-narrative-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "self-narrative-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "MCP server for compact autobiographical summaries and arcs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/social-core/pyproject.toml
+++ b/sociality-mcp/packages/social-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "social-core"
-version = "0.4.1"
+version = "0.4.2"
 description = "Shared models and SQLite store for Kokone sociality MCP servers"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/social-state-mcp/pyproject.toml
+++ b/sociality-mcp/packages/social-state-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "social-state-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "MCP server for present-moment social state inference"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/pyproject.toml
+++ b/sociality-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sociality-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "Unified MCP facade for Kokone's social middle layer"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/system-temperature-mcp/pyproject.toml
+++ b/system-temperature-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "system-temperature-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "MCP server for monitoring system temperature - your sense of body temperature"
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).parents[1]
-RELEASE_VERSION = "0.4.1"
+RELEASE_VERSION = "0.4.2"
 RELEASE_TAG = f"v{RELEASE_VERSION}"
 
 

--- a/tts-mcp/pyproject.toml
+++ b/tts-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tts-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "MCP server for text-to-speech (ElevenLabs + VOICEVOX)"
 requires-python = ">=3.10"
 dependencies = [

--- a/tts-mcp/src/tts_mcp/config.py
+++ b/tts-mcp/src/tts_mcp/config.py
@@ -171,12 +171,12 @@ class ServerConfig:
     """MCP Server configuration."""
 
     name: str = "tts"
-    version: str = "0.4.1"
+    version: str = "0.4.2"
 
     @classmethod
     def from_env(cls) -> "ServerConfig":
         """Create config from environment variables."""
         return cls(
             name=os.getenv("MCP_SERVER_NAME", "tts"),
-            version=os.getenv("MCP_SERVER_VERSION", "0.4.1"),
+            version=os.getenv("MCP_SERVER_VERSION", "0.4.2"),
         )

--- a/usb-webcam-mcp/pyproject.toml
+++ b/usb-webcam-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "usb-webcam-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "MCP server for USB webcam capture"
 requires-python = ">=3.10"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ members = [
 
 [[package]]
 name = "agent-grammar"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "sociality-mcp/packages/agent-grammar" }
 dependencies = [
     { name = "pydantic" },
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "boundary-mcp"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "sociality-mcp/packages/boundary-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -582,7 +582,7 @@ nvtx = [
 
 [[package]]
 name = "desire-system"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "desire-system" }
 dependencies = [
     { name = "chromadb" },
@@ -647,7 +647,7 @@ wheels = [
 
 [[package]]
 name = "embodied-claude-workspace"
-version = "0.4.1"
+version = "0.4.2"
 source = { virtual = "." }
 dependencies = [
     { name = "desire-system" },
@@ -975,7 +975,7 @@ wheels = [
 
 [[package]]
 name = "individual-kernel-mcp"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "consciousness-mcp/packages/individual-kernel-mcp" }
 dependencies = [
     { name = "agent-grammar" },
@@ -1018,7 +1018,7 @@ wheels = [
 
 [[package]]
 name = "interaction-orchestrator-mcp"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "sociality-mcp/packages/interaction-orchestrator-mcp" }
 dependencies = [
     { name = "boundary-mcp" },
@@ -1120,7 +1120,7 @@ wheels = [
 
 [[package]]
 name = "joint-attention-mcp"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "sociality-mcp/packages/joint-attention-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -1353,7 +1353,7 @@ wheels = [
 
 [[package]]
 name = "memory-mcp"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "memory-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -2406,7 +2406,7 @@ wheels = [
 
 [[package]]
 name = "relationship-mcp"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "sociality-mcp/packages/relationship-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -2613,7 +2613,7 @@ wheels = [
 
 [[package]]
 name = "self-narrative-mcp"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "sociality-mcp/packages/self-narrative-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -2696,7 +2696,7 @@ wheels = [
 
 [[package]]
 name = "social-core"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "sociality-mcp/packages/social-core" }
 dependencies = [
     { name = "pydantic" },
@@ -2722,7 +2722,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "social-state-mcp"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "sociality-mcp/packages/social-state-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -2750,7 +2750,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "sociality-mcp"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "sociality-mcp" }
 dependencies = [
     { name = "boundary-mcp" },
@@ -2858,7 +2858,7 @@ wheels = [
 
 [[package]]
 name = "system-temperature-mcp"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "system-temperature-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -3014,7 +3014,7 @@ wheels = [
 
 [[package]]
 name = "tts-mcp"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "tts-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -3121,7 +3121,7 @@ wheels = [
 
 [[package]]
 name = "usb-webcam-mcp"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "usb-webcam-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -3276,7 +3276,7 @@ wheels = [
 
 [[package]]
 name = "wifi-cam-mcp"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "wifi-cam-mcp" }
 dependencies = [
     { name = "httpx" },
@@ -3321,7 +3321,7 @@ provides-extras = ["dev", "transcribe", "transcribe-faster"]
 
 [[package]]
 name = "x-mcp"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "x-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },

--- a/wifi-cam-mcp/pyproject.toml
+++ b/wifi-cam-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wifi-cam-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "MCP server for controlling WiFi cameras (Tapo C210/C220) via ONVIF - Let AI look around your room!"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/wifi-cam-mcp/src/wifi_cam_mcp/config.py
+++ b/wifi-cam-mcp/src/wifi_cam_mcp/config.py
@@ -133,7 +133,7 @@ class ServerConfig:
     """MCP Server configuration."""
 
     name: str = "wifi-cam-mcp"
-    version: str = "0.4.1"
+    version: str = "0.4.2"
     capture_dir: str = field(default_factory=_default_capture_dir)
     mic_source: str = "camera"  # "camera" (RTSP) or "local" (PC microphone)
     mic_device: str | None = None  # DirectShow device name for Windows local mic
@@ -156,7 +156,7 @@ class ServerConfig:
         capture_dir = os.getenv("CAPTURE_DIR", "").strip() or _default_capture_dir()
         return cls(
             name=os.getenv("MCP_SERVER_NAME", "wifi-cam-mcp"),
-            version=os.getenv("MCP_SERVER_VERSION", "0.4.1"),
+            version=os.getenv("MCP_SERVER_VERSION", "0.4.2"),
             capture_dir=capture_dir,
             mic_source=mic_source,
             mic_device=os.getenv("MIC_DEVICE") or None,

--- a/x-mcp/pyproject.toml
+++ b/x-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "x-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "MCP server for searching and posting to X (Twitter) via xAI Grok live search"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

The body state had been reporting every need maximal since May. The composition
was not at fault; its input was.

`DESIRES_PATH` was read from the environment without `expanduser()`. The default
is built from `Path.home()` and was fine, but `.env` supplies
`~/.claude/desires.json` as a plain string, and an unexpanded tilde is a
relative path: the updater created a directory literally named `~` under its
working directory and wrote there. It had been doing so since at least
2026-04-08 while printing a success line every five minutes, and `.gitignore`
covers `desires.json`, so the stray tree stayed invisible. The same tree exists
in each sibling checkout.

With the path expanded, the snapshot the kernel reads updated for the first time
since 2026-05-18, and the committed field's focus moved from
`identity_coherence` to `observe_room` on the next tick.

## The second fault

A missing writer should not have been able to hide for 71 days. `project_desires`
extrapolated without bound: levels ramp to 1.0 over `satisfaction_hours`, the
longest of which is three, so an abandoned snapshot reports every need maxed out
forever -- and that is exactly the quantity the organism daemon's ignition term
reads. Past `MAX_SNAPSHOT_AGE_HOURS` (24) the projection now reports the resting
state, no discomfort and no dominant need, and marks itself unusable. The age is
still returned; refusing to extrapolate is not the same as claiming the snapshot
is current. Hours of genuine neglect still saturate exactly as before.

## Also

The rule deciding what takes focus next was written twice, once in the
protention and once in the attention schema. Both read the runner-up of the same
competition, so nothing disagreed -- but a change to either would have diverged
from the other silently. It now lives on `CompetitionResult.next_focus_candidate`
and both read it. No behaviour change; the tests pin the object, the epistemic
trace, the stored surface and the schema against each other.

## Verification

- `uv run ruff check consciousness-mcp sociality-mcp` clean
- kernel + social-core + root suites: 537 passed
- root suite in a clean `git worktree` at the release commit: 76 passed, which
  is what settles the version-consistency and CHANGELOG-date checks (they walk
  the filesystem, so an untracked copy of the repo fails them locally)
- live: the updater run by hand wrote `~/.claude/desires.json` with a current
  timestamp, and the next committed field changed focus

## Not in this PR

The crontab entry that runs the updater had two faults of its own: it `cd`s into
`~/repo/embodied-claude/desire-system`, a path that stopped existing when the
repository moved, and cron's PATH has no `uv`. That was repaired on the machine
rather than here, since it is not repository state. A separate entry still
points at `autonomous-action.sh`, which no longer exists anywhere; that one was
left alone deliberately, because deciding whether autonomous action should
resume is not a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
