### PR TITLE
feat: ship higher-order precision feedback and a schedulable clock (0.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to embodied-claude are documented here.
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-07-28
+
+Two flags were waiting on evidence rather than on work. One now has it and
+ships on; the other has everything except a decision that is not the code's to
+make.
+
+### Changed
+
+- individual-kernel: `hor_precision_feedback` ships **on**. It was held back
+  pending a live before-and-after, which ran on 2026-07-28 against two forks of
+  the real history differing only in the flag: `self_model` precision moved
+  0.538 to 0.668, the other four channels were bit-identical, and the winning
+  candidate was the same in both arms. The 0.130 bump sits below the 0.20 cap,
+  so it is what the records say rather than a saturated constant, and the
+  channel feeds only the indicator profile and its own carry-forward -- the
+  boundary gate reads none of it. A flag that ships off indefinitely is dead
+  code; this one now has the same standard of evidence the previous two were
+  held to.
+
+### Added
+
+- individual-kernel: `efpf-hook organism-step`. The organism daemon is the only
+  producer of an autonomous tick and exists to move when nobody is talking, but
+  it was reachable only through an MCP tool -- so the non-verbal clock could be
+  wound only by a language model. The command is the same step, callable by a
+  scheduler, and it honours the flag: with `organism_daemon = false` it returns
+  `{"ran": false}` and touches nothing, so a crontab entry can be installed
+  before the flag is flipped. `docs/organism-daemon.md` carries the entry and
+  the two mistakes that make such an entry fail silently.
+
+### Docs
+
+- `phenomenal-architecture-current-state.md`: the frozen candidate score is
+  recorded as a deliberate decision rather than an open hazard. A score is the
+  record of a decision taken under the weights in force at the time;
+  re-deriving it would make the audit trail describe a competition that never
+  happened. The cost is one tick of latency.
+- `phenomenal-architecture-current-state.md`: the desire-staleness entry
+  carried a root cause that turned out to be wrong twice over. It now records
+  the measured one, and the general lesson: a component reporting success
+  proves it ran, not that its output arrived.
+
 ## [0.4.2] - 2026-07-28
 
 The body state had been reporting every need maximal since May. The composition

--- a/consciousness-mcp/packages/individual-kernel-mcp/pyproject.toml
+++ b/consciousness-mcp/packages/individual-kernel-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "individual-kernel-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "Enacted first-person field runtime and phenomenal-like causal architecture research tools."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/hook_cli.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/hook_cli.py
@@ -17,6 +17,7 @@ from social_core import SocialDB
 
 from individual_kernel_mcp.agency import is_external_tool
 from individual_kernel_mcp.boundary_adapter import BoundaryPolicyAdapter
+from individual_kernel_mcp.organism import OrganismDaemon, organism_enabled
 from individual_kernel_mcp.tick import (
     FieldRuntime,
     TickProducer,
@@ -341,26 +342,49 @@ def _heartbeat_continuation(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+COMMANDS = (
+    "session-start",
+    "user-prompt-submit",
+    "pre-tool-use",
+    "post-tool-use",
+    "post-tool-use-failure",
+    "post-tool-batch",
+    "stop",
+    "stop-failure",
+    "diagnostics",
+    "organism-step",
+)
+
+
+def organism_step(
+    db: SocialDB,
+    producer: TickProducer,
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Turn the internal clock once, for a scheduler rather than a caller.
+
+    The daemon is what makes an autonomous tick possible, and its point is to
+    move when nobody is talking to the agent. Reaching it only through an MCP
+    tool meant the non-verbal clock could be wound only by a language model,
+    which is the one thing it was supposed to be independent of. This is the
+    same step that tool takes, callable from cron.
+    """
+
+    if not organism_enabled():
+        return {"ran": False, "reason": "organism_daemon is off in mcpBehavior.toml"}
+    step = OrganismDaemon(db, producer).step(force=force, dry_run=dry_run)
+    return {"ran": True, **step.model_dump(mode="json")}
+
+
 def main() -> None:
     if hasattr(sys.stdin, "reconfigure"):
         sys.stdin.reconfigure(encoding="utf-8")
     if hasattr(sys.stdout, "reconfigure"):
         sys.stdout.reconfigure(encoding="utf-8")
     parser = argparse.ArgumentParser(prog="efpf-hook")
-    parser.add_argument(
-        "command",
-        choices=(
-            "session-start",
-            "user-prompt-submit",
-            "pre-tool-use",
-            "post-tool-use",
-            "post-tool-use-failure",
-            "post-tool-batch",
-            "stop",
-            "stop-failure",
-            "diagnostics",
-        ),
-    )
+    parser.add_argument("command", choices=COMMANDS)
     args = parser.parse_args()
     payload = _read_input()
     db = SocialDB()
@@ -381,6 +405,7 @@ def main() -> None:
         "stop": lambda: stop(payload, producer),
         "stop-failure": lambda: stop_failure(payload, producer),
         "diagnostics": lambda: diagnostics(payload, producer),
+        "organism-step": lambda: organism_step(db, producer),
     }
     try:
         _emit(handlers[args.command]())

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_organism_cli.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_organism_cli.py
@@ -1,0 +1,57 @@
+"""The clock has to be runnable without a conversation.
+
+The organism daemon is the only producer of an autonomous tick, and its whole
+point is to move when nobody is talking to the agent. Until now it was reachable
+only through the `organism_step` MCP tool, which needs a language model to call
+it -- so the non-verbal clock could only be wound by the very thing it was
+supposed to be independent of. A scheduler needs a command it can run.
+"""
+
+from __future__ import annotations
+
+from social_core.db import SocialDB
+
+from individual_kernel_mcp import hook_cli
+from individual_kernel_mcp.tick import TickProducer
+
+
+class TestTheCommandExists:
+    def test_the_cli_accepts_it(self) -> None:
+        # cron invokes `efpf-hook organism-step`; if the command is not in the
+        # accepted set the entry point rejects it before anything runs.
+        assert "organism-step" in hook_cli.COMMANDS
+
+
+class TestTheFlagGovernsIt:
+    def test_it_declines_while_the_flag_is_off(
+        self, social_db: SocialDB, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(hook_cli, "organism_enabled", lambda: False)
+
+        result = hook_cli.organism_step(social_db, TickProducer(social_db))
+
+        assert result["ran"] is False
+        assert "organism_daemon" in result["reason"]
+
+    def test_it_turns_the_clock_while_the_flag_is_on(
+        self, social_db: SocialDB, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(hook_cli, "organism_enabled", lambda: True)
+
+        result = hook_cli.organism_step(social_db, TickProducer(social_db))
+
+        # The daemon decides for itself whether to ignite; what matters here is
+        # that the turn happened and reported its reasoning.
+        assert result["ran"] is True
+        assert "ignited" in result
+
+
+class TestItIsSafeToRunFromCron:
+    def test_a_dry_run_changes_nothing(self, social_db: SocialDB, monkeypatch) -> None:
+        monkeypatch.setattr(hook_cli, "organism_enabled", lambda: True)
+        before = social_db.fetchone("SELECT COUNT(*) AS n FROM organism_runs")["n"]
+
+        hook_cli.organism_step(social_db, TickProducer(social_db), dry_run=True)
+
+        after = social_db.fetchone("SELECT COUNT(*) AS n FROM organism_runs")["n"]
+        assert after == before

--- a/desire-system/pyproject.toml
+++ b/desire-system/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "desire-system"
-version = "0.4.2"
+version = "0.4.3"
 description = "Autonomous desire system for embodied Claude - gives Kokone inner drives"
 requires-python = ">=3.10"
 dependencies = [

--- a/docs/hor-ablation.md
+++ b/docs/hor-ablation.md
@@ -71,7 +71,39 @@ without it, such a report has no referent inside the system.
 The write is wrapped: a storage fault must not roll back a field that has
 already been committed.
 
-## Why the flag ships off
+## The live measurement, and why the flag now ships on
+
+Run 2026-07-28 against the live history. Two arms, each a fresh copy of
+`~/.claude/sociality/social.db` taken through the sqlite backup API, differing
+only in `hor_precision_feedback`. Same candidate, same interoception and desire
+inputs, one committed tick each.
+
+| channel | off | on | delta |
+| --- | --- | --- | --- |
+| extero | 0.307692 | 0.307692 | +0.000000 |
+| intero | 0.307692 | 0.307692 | +0.000000 |
+| mnemonic | 0.307692 | 0.307692 | +0.000000 |
+| self_model | 0.538208 | 0.668208 | **+0.130000** |
+| social | 0.307692 | 0.307692 | +0.000000 |
+
+The winner was `desire:identity_coherence` in both arms.
+
+Three things make this the measurement the flag was waiting for. The live
+history's higher-order records all assert modes that map to `self_model`, so
+exactly one channel moves and the other four are bit-identical. The bump is
+0.130, below the 0.20 cap, so the value is what the records actually say rather
+than a saturated constant. And the selection is unchanged, which is expected
+rather than lucky: competition scores read the candidate's own precision, not
+the field's `PrecisionState`.
+
+The blast radius is therefore the `self_model` channel, its own carry-forward
+(`0.65 * previous + 0.25 * attention_intensity`, so a per-tick bias of 0.130
+settles around +0.24 rather than accumulating), and `IndicatorProfile`
+`self_model_feedback`, which is a mean over that channel. The boundary gate
+reads none of it. In short, the flag changes a measured quantity and nothing
+that acts, which is exactly what it was designed to do.
+
+## Why the flag shipped off until then
 
 The two flags shipped in the previous PR were switched on only after a live
 check showed what they did to the running system. The same standard applies

--- a/docs/organism-daemon.md
+++ b/docs/organism-daemon.md
@@ -84,7 +84,31 @@ because until now nothing could.
 
 The fork ended with one `autonomous` field. The live database still has zero.
 
-## Why the flag ships off
+## Running it without a conversation
+
+Until 0.4.3 the daemon was reachable only through the `organism_step` MCP tool,
+which means a language model had to call it. A clock whose entire purpose is to
+move when nobody is talking could therefore only be wound by the one thing it
+was supposed to be independent of. `efpf-hook organism-step` is the same step,
+callable by a scheduler:
+
+```
+*/15 * * * * /path/to/uv run --directory /path/to/embodied-claude \
+  efpf-hook organism-step < /dev/null >> ~/.claude/autonomous-logs/organism.log 2>&1
+```
+
+Two details that a crontab entry gets wrong easily, both learned from the
+`desire-updater` entry that sat broken for months: give `uv` an absolute path,
+because cron's PATH does not include `~/.local/bin`, and use `--directory`
+rather than `cd`, because a `cd` to a path that stops existing makes the whole
+line fail silently -- `&&` short-circuits before the redirect, so not even the
+log records that nothing ran.
+
+The command respects the flag: with `organism_daemon = false` it returns
+`{"ran": false}` and touches nothing, so the entry can be installed before the
+flag is flipped and will simply idle until it is.
+
+## Why the flag still ships off
 
 Unlike the flags in #111, the blocker here is not evidence -- the measurement
 above is the evidence. It is that the first real run against live history will

--- a/docs/phenomenal-architecture-current-state.md
+++ b/docs/phenomenal-architecture-current-state.md
@@ -70,12 +70,21 @@ flowchart TD
 
 ## Known hazards recorded at survey time
 
-- `predicted_next_focus` is written twice per commit from two different
-  predictors (protention at tick.py commit, then the attention schema).
-  Unchanged in this work; canonicalization is scheduled with the fork
-  experiments.
+- ~~`predicted_next_focus` is written twice per commit from two different
+  predictors~~ Resolved 2026-07-28 (0.4.2), and the original entry overstated
+  it: the two predictors applied the same rule to the same `CompetitionResult`,
+  so they could not disagree. It was duplication, not divergence. The rule now
+  lives on `CompetitionResult.next_focus_candidate`. Note that `enacted_fields`
+  has no column of that name; the value round-trips through the epistemic trace.
 - Workspace candidate scores are frozen at insert time, so learned weight
-  changes can only affect future ticks.
+  changes can only affect future ticks. **Kept deliberately.** A score is the
+  record of a decision that was actually taken under the weights in force at
+  the time; re-deriving it later would make the audit trail describe a
+  competition that never happened, and `deterministic_order` would no longer
+  reproduce the commit it belongs to. The cost is only latency -- a weight
+  change reaches the next tick rather than the current one -- and a tick is
+  short. Revisit only if within-tick reweighting becomes necessary, and then by
+  storing both scores rather than replacing one.
 - Valence was causally inert on the live path: computed only from the desire
   file as an EMA of `-0.6 * max(discomforts)` (structurally never positive),
   absent from competition weights and memory recall. The live
@@ -91,6 +100,20 @@ flowchart TD
   present but dead is the worse failure, because nothing reports its absence.
   The durable fix moves the clock into the kernel, so a stalled writer costs
   corrections rather than motion.
+
+  Second correction (2026-07-28, 0.4.2): the account above was still wrong
+  about the cause. Both crontab faults were real, but the snapshot had already
+  stopped reaching the kernel before either could matter. `DESIRES_PATH` was
+  read from the environment without `expanduser()`, and `.env` supplies
+  `~/.claude/desires.json` as a plain string, so the updater created a
+  directory literally named `~` under its working directory and wrote there --
+  since at least 2026-04-08, printing a success line each run. `.gitignore`
+  covers `desires.json`, so the stray tree was invisible; the same tree exists
+  in each sibling checkout. The lesson generalises past this bug: a component
+  that reports success proves it ran, not that its output arrived. Moving the
+  clock into the kernel does not help when the clock is reading a file nobody
+  writes, which is why `project_desires` now also bounds how far it will
+  extrapolate.
 - `InteroceptionState.controllability` was derived from discomfort and not
   wired to the measured `ownership_score`.
 - `SleepConsolidator` was constructed without a quiet-hours predicate, so its

--- a/mcpBehavior.toml
+++ b/mcpBehavior.toml
@@ -54,9 +54,12 @@ allostatic_valence = true          # valence/needs/controllability の再定義�
                                    # 2026-07-28 のライブ確認で control が実測 ownership に
                                    # 追従し valence が tick ごとに動くことを確認した
                                    # （docs/allostatic-valence-design.md）
-hor_precision_feedback = false     # HOR がそのチャネルの precision を上げる。既定 off:
-                                   # 全 tick の初期 precision を変えるので、他の2つと
-                                   # 同じようにライブで前後を測ってから on にする
+hor_precision_feedback = true      # HOR がそのチャネルの precision を上げる。既定 on:
+                                   # 2026-07-28 のライブ履歴で前後を測った。同じ
+                                   # フォーク2本で self_model だけが +0.130 動き、
+                                   # 他の4チャネルと勝者は不変。上限 0.20 にも
+                                   # 達してないのでデータ由来の値。self_model は
+                                   # 指標と自分の EMA にしか流れん
                                    # （docs/hor-ablation.md）
 valence_coupling = true            # affect で競合重みを変調する。既定 on:
                                    # 2026-07-28 のライブ確認でスコア差が設計式と一致した。
@@ -64,6 +67,9 @@ valence_coupling = true            # affect で競合重みを変調する。既
                                    # （docs/valence-coupling-design.md）
 organism_daemon = false            # 非LLM の内的時計。stats の減衰、protention の期限切れ、
                                    # 需要と沈黙からの ignition（AUTONOMOUS tick の初の生成者）。
-                                   # 既定 off: tick を新たに作る唯一のフラグなので、
-                                   # ライブで前後を測ってから on にする
+                                   # 既定 off。測定も scheduler も揃った
+                                   # （`efpf-hook organism-step`、cron 行は
+                                   # docs/organism-daemon.md）。残ってるのは
+                                   # 判断だけ：on にすると話しかけられてない
+                                   # 間も tick が開く。これはコウタの決めること
                                    # （docs/organism-daemon.md）

--- a/memory-mcp/pyproject.toml
+++ b/memory-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memory-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "MCP server for AI long-term memory - Let AI remember across sessions!"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/memory-mcp/src/memory_mcp/config.py
+++ b/memory-mcp/src/memory_mcp/config.py
@@ -39,12 +39,12 @@ class ServerConfig:
     """MCP Server configuration."""
 
     name: str = "memory-mcp"
-    version: str = "0.4.2"
+    version: str = "0.4.3"
 
     @classmethod
     def from_env(cls) -> "ServerConfig":
         """Create config from environment variables."""
         return cls(
             name=os.getenv("MCP_SERVER_NAME", "memory-mcp"),
-            version=os.getenv("MCP_SERVER_VERSION", "0.4.2"),
+            version=os.getenv("MCP_SERVER_VERSION", "0.4.3"),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "embodied-claude-workspace"
-version = "0.4.2"
+version = "0.4.3"
 description = "Unified development and runtime environment for embodied-claude MCP servers."
 requires-python = ">=3.13,<3.14"
 dependencies = [

--- a/sociality-mcp/packages/agent-grammar/pyproject.toml
+++ b/sociality-mcp/packages/agent-grammar/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-grammar"
-version = "0.4.2"
+version = "0.4.3"
 description = "PEG-based agent grammar for embodied Kokone — observation/inference flow control"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/boundary-mcp/pyproject.toml
+++ b/sociality-mcp/packages/boundary-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boundary-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "MCP server for social boundaries, consent, and tact gating"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/interaction-orchestrator-mcp/pyproject.toml
+++ b/sociality-mcp/packages/interaction-orchestrator-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "interaction-orchestrator-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "Human Response Orchestrator for Embodied Claude — turns substrate signals into stable social moves"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/joint-attention-mcp/pyproject.toml
+++ b/sociality-mcp/packages/joint-attention-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "joint-attention-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "MCP server for scene grounding and joint attention"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/relationship-mcp/pyproject.toml
+++ b/sociality-mcp/packages/relationship-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "relationship-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "MCP server for compact relationship abstractions and commitments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/self-narrative-mcp/pyproject.toml
+++ b/sociality-mcp/packages/self-narrative-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "self-narrative-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "MCP server for compact autobiographical summaries and arcs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/social-core/pyproject.toml
+++ b/sociality-mcp/packages/social-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "social-core"
-version = "0.4.2"
+version = "0.4.3"
 description = "Shared models and SQLite store for Kokone sociality MCP servers"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/social-state-mcp/pyproject.toml
+++ b/sociality-mcp/packages/social-state-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "social-state-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "MCP server for present-moment social state inference"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/pyproject.toml
+++ b/sociality-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sociality-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "Unified MCP facade for Kokone's social middle layer"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/system-temperature-mcp/pyproject.toml
+++ b/system-temperature-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "system-temperature-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "MCP server for monitoring system temperature - your sense of body temperature"
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).parents[1]
-RELEASE_VERSION = "0.4.2"
+RELEASE_VERSION = "0.4.3"
 RELEASE_TAG = f"v{RELEASE_VERSION}"
 
 

--- a/tts-mcp/pyproject.toml
+++ b/tts-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tts-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "MCP server for text-to-speech (ElevenLabs + VOICEVOX)"
 requires-python = ">=3.10"
 dependencies = [

--- a/tts-mcp/src/tts_mcp/config.py
+++ b/tts-mcp/src/tts_mcp/config.py
@@ -171,12 +171,12 @@ class ServerConfig:
     """MCP Server configuration."""
 
     name: str = "tts"
-    version: str = "0.4.2"
+    version: str = "0.4.3"
 
     @classmethod
     def from_env(cls) -> "ServerConfig":
         """Create config from environment variables."""
         return cls(
             name=os.getenv("MCP_SERVER_NAME", "tts"),
-            version=os.getenv("MCP_SERVER_VERSION", "0.4.2"),
+            version=os.getenv("MCP_SERVER_VERSION", "0.4.3"),
         )

--- a/usb-webcam-mcp/pyproject.toml
+++ b/usb-webcam-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "usb-webcam-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "MCP server for USB webcam capture"
 requires-python = ">=3.10"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ members = [
 
 [[package]]
 name = "agent-grammar"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "sociality-mcp/packages/agent-grammar" }
 dependencies = [
     { name = "pydantic" },
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "boundary-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "sociality-mcp/packages/boundary-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -582,7 +582,7 @@ nvtx = [
 
 [[package]]
 name = "desire-system"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "desire-system" }
 dependencies = [
     { name = "chromadb" },
@@ -647,7 +647,7 @@ wheels = [
 
 [[package]]
 name = "embodied-claude-workspace"
-version = "0.4.2"
+version = "0.4.3"
 source = { virtual = "." }
 dependencies = [
     { name = "desire-system" },
@@ -975,7 +975,7 @@ wheels = [
 
 [[package]]
 name = "individual-kernel-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "consciousness-mcp/packages/individual-kernel-mcp" }
 dependencies = [
     { name = "agent-grammar" },
@@ -1018,7 +1018,7 @@ wheels = [
 
 [[package]]
 name = "interaction-orchestrator-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "sociality-mcp/packages/interaction-orchestrator-mcp" }
 dependencies = [
     { name = "boundary-mcp" },
@@ -1120,7 +1120,7 @@ wheels = [
 
 [[package]]
 name = "joint-attention-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "sociality-mcp/packages/joint-attention-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -1353,7 +1353,7 @@ wheels = [
 
 [[package]]
 name = "memory-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "memory-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -2406,7 +2406,7 @@ wheels = [
 
 [[package]]
 name = "relationship-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "sociality-mcp/packages/relationship-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -2613,7 +2613,7 @@ wheels = [
 
 [[package]]
 name = "self-narrative-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "sociality-mcp/packages/self-narrative-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -2696,7 +2696,7 @@ wheels = [
 
 [[package]]
 name = "social-core"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "sociality-mcp/packages/social-core" }
 dependencies = [
     { name = "pydantic" },
@@ -2722,7 +2722,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "social-state-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "sociality-mcp/packages/social-state-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -2750,7 +2750,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "sociality-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "sociality-mcp" }
 dependencies = [
     { name = "boundary-mcp" },
@@ -2858,7 +2858,7 @@ wheels = [
 
 [[package]]
 name = "system-temperature-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "system-temperature-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -3014,7 +3014,7 @@ wheels = [
 
 [[package]]
 name = "tts-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "tts-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -3121,7 +3121,7 @@ wheels = [
 
 [[package]]
 name = "usb-webcam-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "usb-webcam-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -3276,7 +3276,7 @@ wheels = [
 
 [[package]]
 name = "wifi-cam-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "wifi-cam-mcp" }
 dependencies = [
     { name = "httpx" },
@@ -3321,7 +3321,7 @@ provides-extras = ["dev", "transcribe", "transcribe-faster"]
 
 [[package]]
 name = "x-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "x-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },

--- a/wifi-cam-mcp/pyproject.toml
+++ b/wifi-cam-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wifi-cam-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "MCP server for controlling WiFi cameras (Tapo C210/C220) via ONVIF - Let AI look around your room!"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/wifi-cam-mcp/src/wifi_cam_mcp/config.py
+++ b/wifi-cam-mcp/src/wifi_cam_mcp/config.py
@@ -133,7 +133,7 @@ class ServerConfig:
     """MCP Server configuration."""
 
     name: str = "wifi-cam-mcp"
-    version: str = "0.4.2"
+    version: str = "0.4.3"
     capture_dir: str = field(default_factory=_default_capture_dir)
     mic_source: str = "camera"  # "camera" (RTSP) or "local" (PC microphone)
     mic_device: str | None = None  # DirectShow device name for Windows local mic
@@ -156,7 +156,7 @@ class ServerConfig:
         capture_dir = os.getenv("CAPTURE_DIR", "").strip() or _default_capture_dir()
         return cls(
             name=os.getenv("MCP_SERVER_NAME", "wifi-cam-mcp"),
-            version=os.getenv("MCP_SERVER_VERSION", "0.4.2"),
+            version=os.getenv("MCP_SERVER_VERSION", "0.4.3"),
             capture_dir=capture_dir,
             mic_source=mic_source,
             mic_device=os.getenv("MIC_DEVICE") or None,

--- a/x-mcp/pyproject.toml
+++ b/x-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "x-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "MCP server for searching and posting to X (Twitter) via xAI Grok live search"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Two flags were waiting on evidence rather than on work. One now has it and
ships on; the other has everything except a decision that is not the code's to
make.

## `hor_precision_feedback` ships on

Measured against two forks of the live history differing only in the flag --
same candidate, same interoception and desire inputs, one committed tick each.

| channel | off | on | delta |
| --- | --- | --- | --- |
| extero | 0.307692 | 0.307692 | +0.000000 |
| intero | 0.307692 | 0.307692 | +0.000000 |
| mnemonic | 0.307692 | 0.307692 | +0.000000 |
| self_model | 0.538208 | 0.668208 | **+0.130000** |
| social | 0.307692 | 0.307692 | +0.000000 |

The winner was `desire:identity_coherence` in both arms. Exactly one channel
moves because the live higher-order records all assert modes mapping to
`self_model`; the bump is below the 0.20 cap, so it is what the records say
rather than a saturated constant; and the selection is unchanged by
construction, since competition scores read the candidate's own precision, not
the field's `PrecisionState`. The channel feeds only the indicator profile and
its own carry-forward. The boundary gate reads none of it.

## The clock can now be wound by a scheduler

The organism daemon is the only producer of an autonomous tick and exists to
move when nobody is talking -- but it was reachable only through an MCP tool,
so the non-verbal clock could be wound only by a language model. `efpf-hook
organism-step` is the same step, callable from cron, and it honours the flag:
with `organism_daemon = false` it returns `{"ran": false}` and touches nothing.

`organism_daemon` stays off. Everything it was waiting for now exists -- the
measurement, the scheduler, and (as of 0.4.2) a desire snapshot that is not 71
days stale, which matters because its ignition term reads exactly that. What is
left is a decision about the running system, not about the code: with the flag
on, ticks open while nobody is talking. That is the owner's call to make.

## Two decisions written down

The frozen candidate score stays frozen. A score is the record of a decision
taken under the weights in force at the time; re-deriving it later would make
the audit trail describe a competition that never happened, and
`deterministic_order` would stop reproducing the commit it belongs to. The cost
is one tick of latency.

The desire-staleness hazard entry had a root cause that was wrong twice over.
It now carries the measured one, and the general lesson: a component reporting
success proves it ran, not that its output arrived.

## Verification

- ruff clean across `consciousness-mcp` and `sociality-mcp`
- 541 passed (kernel + social-core + root), including four new tests for the
  CLI command and the flag it honours
- the two failures that remain locally are the known working-tree artifacts
  (an untracked copy of the repo and a local `.mcp.json`); they passed in a
  clean worktree at the previous release commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
