### PR TITLE
docs: warn that plain uv sync drops optional extras like elevenlabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,26 @@ repository root:
 uv sync --locked
 ```
 
+`tts-mcp[elevenlabs]`, `wifi-cam-mcp[transcribe...]`, `usb-webcam-mcp`,
+`system-temperature-mcp`, and `x-mcp` are declared as optional extras in the
+root `pyproject.toml`, not base dependencies. A plain `uv sync` only installs
+the base workspace packages (`desire-system`, `individual-kernel-mcp`,
+`memory-mcp`, `sociality-mcp`) and will **uninstall** any of those optional
+packages that were previously installed outside the requested extras — for
+example, `python -c "import elevenlabs"` starts failing with
+`No module named 'elevenlabs'` inside a running `tts-mcp` server even though
+nothing about `tts-mcp` itself changed. If a live MCP server still holds one
+of the removed console-script `.exe` files open, `uv sync` also fails outright
+with an `os error 32` file-lock message, which looks like a process problem
+but is really this same partial-removal in progress. Sync with the extras you
+actually use instead:
+
+```bash
+uv sync --locked --extra all           # everything, including elevenlabs
+uv sync --locked --extra voice-elevenlabs
+uv sync --locked --extra camera-tapo
+```
+
 To run a package directly:
 
 ```bash


### PR DESCRIPTION
## Summary
- A bare `uv sync` only installs the base workspace packages and silently uninstalls optional extras (`tts-mcp[elevenlabs]`, `wifi-cam-mcp` transcribe, `usb-webcam-mcp`, `system-temperature-mcp`, `x-mcp`) if they aren't requested.
- This breaks a running `tts-mcp` server with `No module named 'elevenlabs'`, and can also surface as a confusing `os error 32` file-lock message if a live MCP server still holds the console-script `.exe` open while `uv sync` tries to remove it.
- Documents the fix: sync with `--extra all` or the specific extra you need (`voice-elevenlabs`, `camera-tapo`, etc).

## Test plan
- [x] Reproduced locally: plain `uv sync` broke `mcp__tts__say` with `No module named 'elevenlabs'`.
- [x] Confirmed `uv sync --extra all` reinstalls `elevenlabs` and restores `mcp__tts__say`.
- [x] Docs-only change; no code touched.