### PR TITLE
fix: stop scoring prediction channels nobody predicted (0.4.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to embodied-claude are documented here.
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-07-28
+
+Feedback from a session run against the 0.4.3 gate: predictions were being
+filled in on one channel and left empty on the other three, so the mismatch
+signal the whole loop is built on was mostly noise. That looked like a
+reporting habit. It was the scoring rule.
+
+### Fixed
+
+- individual-kernel: a channel with no declared prediction was scored anyway --
+  0.25 when the action succeeded, 0.75 when it failed -- while a channel that
+  did carry a prediction was floored at 0.8 on failure. Declaring an
+  expectation could therefore only lower the score, and since three channels
+  were usually silent, three quarters of the mean feeding `ownership_score`
+  measured nothing. Unpredicted channels are now absent from the mismatch
+  vector, which holds only real comparisons.
+- individual-kernel: absence is paid for by `prediction_coverage` instead, a
+  new term on `AgencyAssessment` that scales `action_effect_match`. Being right
+  about the channels you mentioned says nothing about the ones you did not, so
+  predicting nothing now contributes zero there rather than collecting a free
+  0.25 per silent channel. The ordering is the intended one again: an accurate
+  prediction beats a partial one, which beats silence.
+- individual-kernel: `ExpectedEffect` and `PredictedEffects` carry field
+  descriptions, so the tool schema says what belongs on each channel instead of
+  leaving a caller to infer it from the field name.
+
+### Changed
+
+- individual-kernel: the prediction-loop fixture declares expectations on all
+  four channels. It previously passed an empty `PredictedEffects` and asserted
+  that every channel key appeared in `prediction_errors`, which held only
+  because silent channels were being scored -- and reconciled as `observed`
+  only because those free 0.25s dragged the mean down. A test named for a full
+  cycle now runs one.
+
 ## [0.4.3] - 2026-07-28
 
 Two flags were waiting on evidence rather than on work. One now has it and

--- a/consciousness-mcp/packages/individual-kernel-mcp/pyproject.toml
+++ b/consciousness-mcp/packages/individual-kernel-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "individual-kernel-mcp"
-version = "0.4.3"
+version = "0.4.4"
 description = "Enacted first-person field runtime and phenomenal-like causal architecture research tools."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/agency.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/agency.py
@@ -41,18 +41,60 @@ class IntentionStatus(StrEnum):
 class ExpectedEffect(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    summary: str = ""
-    confidence: float = Field(default=0.5, ge=0.0, le=1.0)
-    expected_refs: list[str] = Field(default_factory=list)
+    summary: str = Field(
+        default="",
+        description=(
+            "What you expect to observe on this channel, in a sentence. Leave "
+            "it empty only when you genuinely have no expectation: an empty "
+            "channel is excluded from the mismatch vector and lowers "
+            "prediction_coverage, which lowers the ownership you can claim."
+        ),
+    )
+    confidence: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description="How sure you are of that expectation.",
+    )
+    expected_refs: list[str] = Field(
+        default_factory=list,
+        description="Content refs the result should mention, if you can name any.",
+    )
 
 
 class PredictedEffects(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    exteroceptive: ExpectedEffect = Field(default_factory=ExpectedEffect)
-    interoceptive: ExpectedEffect = Field(default_factory=ExpectedEffect)
-    social: ExpectedEffect = Field(default_factory=ExpectedEffect)
-    mnemonic: ExpectedEffect = Field(default_factory=ExpectedEffect)
+    exteroceptive: ExpectedEffect = Field(
+        default_factory=ExpectedEffect,
+        description="What changes in the world, or in what you can see of it.",
+    )
+    interoceptive: ExpectedEffect = Field(
+        default_factory=ExpectedEffect,
+        description=(
+            "What changes in your own state: effort, uncertainty, what being "
+            "wrong here would cost you."
+        ),
+    )
+    social: ExpectedEffect = Field(
+        default_factory=ExpectedEffect,
+        description=(
+            "What changes for the person you are working with: what they learn, "
+            "gain, or have to do next."
+        ),
+    )
+    mnemonic: ExpectedEffect = Field(
+        default_factory=ExpectedEffect,
+        description=(
+            "What you expect to remember from this, or which belief it should "
+            "confirm or overturn."
+        ),
+    )
+
+
+# The channels a caller can make a claim about. Latency is scored separately
+# because it is measured whether or not anyone predicted it.
+PREDICTED_CHANNELS = ("exteroceptive", "interoceptive", "social", "mnemonic")
 
 
 class ActionProposal(BaseModel):
@@ -110,6 +152,7 @@ class AgencyAssessment(BaseModel):
     action_effect_match: float = Field(ge=0.0, le=1.0)
     temporal_contiguity: float = Field(ge=0.0, le=1.0)
     exclusive_causal_fit: float = Field(ge=0.0, le=1.0)
+    prediction_coverage: float = Field(default=0.0, ge=0.0, le=1.0)
     ownership_score: float = Field(ge=0.0, le=1.0)
     rationale: list[str] = Field(default_factory=list)
 
@@ -295,6 +338,7 @@ class AgencyStore:
             latency_ms=latency_ms,
             expected_latency_ms=intention.expected_latency_ms,
             exclusive_causal_fit=causal_fit,
+            prediction_coverage=self._prediction_coverage(intention.predicted_effects),
         )
         outcome_id = f"out_{secrets.token_urlsafe(12)}"
         now = utc_now()
@@ -438,14 +482,26 @@ class AgencyStore:
         latency_ms: int | None,
         expected_latency_ms: int | None,
         exclusive_causal_fit: float,
+        prediction_coverage: float = 0.0,
     ) -> AgencyAssessment:
+        """Score how much of this outcome the agent can claim to have caused.
+
+        `action_effect_match` is scaled by coverage deliberately. Being right
+        about the channels you happened to mention says nothing about the ones
+        you did not, and the mismatch vector no longer invents a verdict for
+        those. Without the scaling, saying nothing would leave only latency in
+        the mean and outscore a partly-wrong prediction -- which is exactly
+        what taught callers to leave the channels empty.
+        """
+
         mismatch = (
             sum(_clamp01(value) for value in mismatch_vector.values())
             / len(mismatch_vector)
             if mismatch_vector
             else 0.5
         )
-        effect_match = 1.0 - mismatch
+        coverage = _clamp01(prediction_coverage)
+        effect_match = _clamp01(coverage * (1.0 - mismatch))
         temporal = _temporal_contiguity(latency_ms, expected_latency_ms)
         registered = 1.0 if registered_intention else 0.0
         ownership = _clamp01(
@@ -459,12 +515,14 @@ class AgencyStore:
             action_effect_match=effect_match,
             temporal_contiguity=temporal,
             exclusive_causal_fit=_clamp01(exclusive_causal_fit),
+            prediction_coverage=coverage,
             ownership_score=ownership,
             rationale=[
                 "registered intention present"
                 if registered_intention
                 else "no registered intention",
                 f"mean prediction mismatch={mismatch:.3f}",
+                f"prediction coverage={coverage:.2f}",
             ],
         )
 
@@ -515,6 +573,22 @@ class AgencyStore:
         )
 
     @staticmethod
+    def _prediction_coverage(effects: PredictedEffects) -> float:
+        """How much of the predictable surface was claimed before acting.
+
+        Counts channels carrying a real expectation rather than channels
+        present on the object: every channel is always present, and three of
+        them were usually empty.
+        """
+
+        declared = sum(
+            1
+            for channel in PREDICTED_CHANNELS
+            if _tokens(getattr(effects, channel).summary)
+        )
+        return declared / len(PREDICTED_CHANNELS)
+
+    @staticmethod
     def _mismatch_vector(
         *,
         intention: IntentionRecord,
@@ -525,16 +599,21 @@ class AgencyStore:
         actual_tokens = _tokens(actual_result_summary)
         effects = intention.predicted_effects
         mismatch: dict[str, float] = {}
-        for channel in ("exteroceptive", "interoceptive", "social", "mnemonic"):
-            expected = getattr(effects, channel)
-            expected_tokens = _tokens(expected.summary)
+        for channel in PREDICTED_CHANNELS:
+            expected_tokens = _tokens(getattr(effects, channel).summary)
             if not expected_tokens:
-                value = 0.25 if success else 0.75
-            else:
-                overlap = len(expected_tokens & actual_tokens) / len(expected_tokens)
-                value = 1.0 - overlap
-                if not success:
-                    value = max(value, 0.8)
+                # A channel nobody spoke about is not a failed prediction.
+                # Scoring it as one (0.25 on success, 0.75 on failure) buried
+                # the real signal: three channels were usually silent, so most
+                # of the mean feeding ownership measured nothing. It also made
+                # silence cheaper than speech, since a real prediction was
+                # floored at 0.8 on failure while silence sat at 0.75. Absence
+                # is now paid for by prediction_coverage instead.
+                continue
+            overlap = len(expected_tokens & actual_tokens) / len(expected_tokens)
+            value = 1.0 - overlap
+            if not success:
+                value = max(value, 0.8)
             mismatch[channel] = round(_clamp01(value), 6)
         mismatch["latency"] = round(
             1.0 - _temporal_contiguity(latency_ms, intention.expected_latency_ms), 6

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_prediction_coverage.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_prediction_coverage.py
@@ -1,0 +1,143 @@
+"""Staying silent about a channel must not be cheaper than predicting it.
+
+A channel with no declared prediction was scored anyway: 0.25 when the action
+succeeded, 0.75 when it failed. A channel that did carry a prediction was
+floored at 0.8 on failure. So writing a prediction could only lower the score,
+and three of the four channels were a constant that had nothing to do with
+anything predicted -- yet they made up three quarters of the mean that feeds
+ownership.
+
+That is why an agent using this interface fills one channel and leaves the rest
+empty. It is not laziness; it is the scoring rule.
+
+A channel nobody predicted is now simply absent from the vector, and coverage
+becomes an explicit term: you cannot claim to have caused an outcome you never
+said anything about.
+"""
+
+from __future__ import annotations
+
+from social_core.db import SocialDB
+
+from individual_kernel_mcp.agency import (
+    AgencyStore,
+    ExpectedEffect,
+    IntentionRecord,
+    IntentionStatus,
+    PredictedEffects,
+)
+
+
+def _intention(**summaries: str) -> IntentionRecord:
+    return IntentionRecord(
+        action_id="act_test",
+        owner_id="self",
+        field_id="field_test",
+        tick_id="tick_test",
+        tool_name="Bash",
+        tool_input_hash="hash",
+        normalized_tool_input={},
+        intended_goal="check the scoring rule",
+        predicted_effects=PredictedEffects(
+            **{
+                channel: ExpectedEffect(summary=text)
+                for channel, text in summaries.items()
+            }
+        ),
+        expected_latency_ms=100,
+        confidence=0.8,
+        status=IntentionStatus.PENDING,
+        created_at="2026-07-28T00:00:00+00:00",
+    )
+
+
+class TestAnUnpredictedChannelIsNotScored:
+    def test_only_predicted_channels_appear(self) -> None:
+        vector = AgencyStore._mismatch_vector(
+            intention=_intention(exteroceptive="the file is written"),
+            actual_result_summary="the file is written",
+            success=True,
+            latency_ms=100,
+        )
+
+        assert "exteroceptive" in vector
+        assert "interoceptive" not in vector
+        assert "social" not in vector
+        assert "mnemonic" not in vector
+
+    def test_latency_is_scored_without_being_declared(self) -> None:
+        # Latency is measured either way, so it needs no declared prediction.
+        vector = AgencyStore._mismatch_vector(
+            intention=_intention(),
+            actual_result_summary="anything",
+            success=True,
+            latency_ms=100,
+        )
+
+        assert set(vector) == {"latency"}
+
+    def test_a_failure_invents_no_verdict_for_a_silent_channel(self) -> None:
+        # This is the 0.75 constant that used to fill three channels.
+        vector = AgencyStore._mismatch_vector(
+            intention=_intention(exteroceptive="the file is written"),
+            actual_result_summary="permission denied",
+            success=False,
+            latency_ms=100,
+        )
+
+        assert set(vector) == {"exteroceptive", "latency"}
+
+
+class TestSilenceCannotBuyAgency:
+    def test_an_accurate_prediction_beats_saying_nothing(
+        self, social_db: SocialDB
+    ) -> None:
+        store = AgencyStore(social_db)
+        common = dict(
+            registered_intention=True,
+            latency_ms=100,
+            expected_latency_ms=100,
+            exclusive_causal_fit=1.0,
+        )
+
+        silent = store.assess(
+            mismatch_vector={"latency": 0.0}, prediction_coverage=0.0, **common
+        )
+        accurate = store.assess(
+            mismatch_vector={"exteroceptive": 0.0, "latency": 0.0},
+            prediction_coverage=0.25,
+            **common,
+        )
+
+        assert accurate.ownership_score > silent.ownership_score
+
+    def test_predicting_every_channel_beats_predicting_one(
+        self, social_db: SocialDB
+    ) -> None:
+        store = AgencyStore(social_db)
+        common = dict(
+            registered_intention=True,
+            mismatch_vector={"exteroceptive": 0.0, "latency": 0.0},
+            latency_ms=100,
+            expected_latency_ms=100,
+            exclusive_causal_fit=1.0,
+        )
+
+        narrow = store.assess(prediction_coverage=0.25, **common)
+        broad = store.assess(prediction_coverage=1.0, **common)
+
+        assert broad.ownership_score > narrow.ownership_score
+
+    def test_the_coverage_is_reported(self, social_db: SocialDB) -> None:
+        # Whoever reads the assessment can see how much of it was actually
+        # claimed in advance, rather than inferring it from a missing key.
+        assessment = AgencyStore(social_db).assess(
+            registered_intention=True,
+            mismatch_vector={"exteroceptive": 0.2, "latency": 0.0},
+            prediction_coverage=0.5,
+            latency_ms=100,
+            expected_latency_ms=100,
+            exclusive_causal_fit=1.0,
+        )
+
+        assert assessment.prediction_coverage == 0.5

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_prediction_loop.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_prediction_loop.py
@@ -8,7 +8,11 @@ from pathlib import Path
 import pytest
 from social_core.db import SocialDB
 
-from individual_kernel_mcp.agency import ActionProposal, PredictedEffects
+from individual_kernel_mcp.agency import (
+    ActionProposal,
+    ExpectedEffect,
+    PredictedEffects,
+)
 from individual_kernel_mcp.enacted_field import TriggerKind
 from individual_kernel_mcp.experienced_transition import ExperiencedTransitionStore
 from individual_kernel_mcp.generative_model import CountBasedGenerativeFieldModel
@@ -99,7 +103,21 @@ def _proposal(field, confidence: float = 0.6) -> ActionProposal:
         field_id=field.field_id,
         tool_name="Write",
         tool_input=dict(_TOOL_INPUT),
-        predicted_effects=PredictedEffects(),
+        # A cycle with nothing predicted is not a full cycle. Channels left
+        # empty are no longer scored, so an empty PredictedEffects would give
+        # the loop nothing to compare and the assertions below would be
+        # asserting the absence of work.
+        #
+        # Mismatch is token overlap against the result summary, so a fixture
+        # standing for "predicted this well" has to share the vocabulary of
+        # "fixture file written successfully". The phrasing is terse for that
+        # reason, not because a real prediction would be.
+        predicted_effects=PredictedEffects(
+            exteroceptive=ExpectedEffect(summary="fixture file written"),
+            interoceptive=ExpectedEffect(summary="written successfully"),
+            social=ExpectedEffect(summary="fixture written"),
+            mnemonic=ExpectedEffect(summary="file written successfully"),
+        ),
         goal="write the fixture file",
         confidence=confidence,
     )

--- a/desire-system/pyproject.toml
+++ b/desire-system/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "desire-system"
-version = "0.4.3"
+version = "0.4.4"
 description = "Autonomous desire system for embodied Claude - gives Kokone inner drives"
 requires-python = ">=3.10"
 dependencies = [

--- a/memory-mcp/pyproject.toml
+++ b/memory-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memory-mcp"
-version = "0.4.3"
+version = "0.4.4"
 description = "MCP server for AI long-term memory - Let AI remember across sessions!"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/memory-mcp/src/memory_mcp/config.py
+++ b/memory-mcp/src/memory_mcp/config.py
@@ -39,12 +39,12 @@ class ServerConfig:
     """MCP Server configuration."""
 
     name: str = "memory-mcp"
-    version: str = "0.4.3"
+    version: str = "0.4.4"
 
     @classmethod
     def from_env(cls) -> "ServerConfig":
         """Create config from environment variables."""
         return cls(
             name=os.getenv("MCP_SERVER_NAME", "memory-mcp"),
-            version=os.getenv("MCP_SERVER_VERSION", "0.4.3"),
+            version=os.getenv("MCP_SERVER_VERSION", "0.4.4"),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "embodied-claude-workspace"
-version = "0.4.3"
+version = "0.4.4"
 description = "Unified development and runtime environment for embodied-claude MCP servers."
 requires-python = ">=3.13,<3.14"
 dependencies = [

--- a/sociality-mcp/packages/agent-grammar/pyproject.toml
+++ b/sociality-mcp/packages/agent-grammar/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-grammar"
-version = "0.4.3"
+version = "0.4.4"
 description = "PEG-based agent grammar for embodied Kokone — observation/inference flow control"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/boundary-mcp/pyproject.toml
+++ b/sociality-mcp/packages/boundary-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boundary-mcp"
-version = "0.4.3"
+version = "0.4.4"
 description = "MCP server for social boundaries, consent, and tact gating"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/interaction-orchestrator-mcp/pyproject.toml
+++ b/sociality-mcp/packages/interaction-orchestrator-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "interaction-orchestrator-mcp"
-version = "0.4.3"
+version = "0.4.4"
 description = "Human Response Orchestrator for Embodied Claude — turns substrate signals into stable social moves"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/joint-attention-mcp/pyproject.toml
+++ b/sociality-mcp/packages/joint-attention-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "joint-attention-mcp"
-version = "0.4.3"
+version = "0.4.4"
 description = "MCP server for scene grounding and joint attention"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/relationship-mcp/pyproject.toml
+++ b/sociality-mcp/packages/relationship-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "relationship-mcp"
-version = "0.4.3"
+version = "0.4.4"
 description = "MCP server for compact relationship abstractions and commitments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/self-narrative-mcp/pyproject.toml
+++ b/sociality-mcp/packages/self-narrative-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "self-narrative-mcp"
-version = "0.4.3"
+version = "0.4.4"
 description = "MCP server for compact autobiographical summaries and arcs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/social-core/pyproject.toml
+++ b/sociality-mcp/packages/social-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "social-core"
-version = "0.4.3"
+version = "0.4.4"
 description = "Shared models and SQLite store for Kokone sociality MCP servers"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/social-state-mcp/pyproject.toml
+++ b/sociality-mcp/packages/social-state-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "social-state-mcp"
-version = "0.4.3"
+version = "0.4.4"
 description = "MCP server for present-moment social state inference"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/pyproject.toml
+++ b/sociality-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sociality-mcp"
-version = "0.4.3"
+version = "0.4.4"
 description = "Unified MCP facade for Kokone's social middle layer"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/system-temperature-mcp/pyproject.toml
+++ b/system-temperature-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "system-temperature-mcp"
-version = "0.4.3"
+version = "0.4.4"
 description = "MCP server for monitoring system temperature - your sense of body temperature"
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).parents[1]
-RELEASE_VERSION = "0.4.3"
+RELEASE_VERSION = "0.4.4"
 RELEASE_TAG = f"v{RELEASE_VERSION}"
 
 

--- a/tts-mcp/pyproject.toml
+++ b/tts-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tts-mcp"
-version = "0.4.3"
+version = "0.4.4"
 description = "MCP server for text-to-speech (ElevenLabs + VOICEVOX)"
 requires-python = ">=3.10"
 dependencies = [

--- a/tts-mcp/src/tts_mcp/config.py
+++ b/tts-mcp/src/tts_mcp/config.py
@@ -171,12 +171,12 @@ class ServerConfig:
     """MCP Server configuration."""
 
     name: str = "tts"
-    version: str = "0.4.3"
+    version: str = "0.4.4"
 
     @classmethod
     def from_env(cls) -> "ServerConfig":
         """Create config from environment variables."""
         return cls(
             name=os.getenv("MCP_SERVER_NAME", "tts"),
-            version=os.getenv("MCP_SERVER_VERSION", "0.4.3"),
+            version=os.getenv("MCP_SERVER_VERSION", "0.4.4"),
         )

--- a/usb-webcam-mcp/pyproject.toml
+++ b/usb-webcam-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "usb-webcam-mcp"
-version = "0.4.3"
+version = "0.4.4"
 description = "MCP server for USB webcam capture"
 requires-python = ">=3.10"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ members = [
 
 [[package]]
 name = "agent-grammar"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "sociality-mcp/packages/agent-grammar" }
 dependencies = [
     { name = "pydantic" },
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "boundary-mcp"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "sociality-mcp/packages/boundary-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -582,7 +582,7 @@ nvtx = [
 
 [[package]]
 name = "desire-system"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "desire-system" }
 dependencies = [
     { name = "chromadb" },
@@ -647,7 +647,7 @@ wheels = [
 
 [[package]]
 name = "embodied-claude-workspace"
-version = "0.4.3"
+version = "0.4.4"
 source = { virtual = "." }
 dependencies = [
     { name = "desire-system" },
@@ -975,7 +975,7 @@ wheels = [
 
 [[package]]
 name = "individual-kernel-mcp"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "consciousness-mcp/packages/individual-kernel-mcp" }
 dependencies = [
     { name = "agent-grammar" },
@@ -1018,7 +1018,7 @@ wheels = [
 
 [[package]]
 name = "interaction-orchestrator-mcp"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "sociality-mcp/packages/interaction-orchestrator-mcp" }
 dependencies = [
     { name = "boundary-mcp" },
@@ -1120,7 +1120,7 @@ wheels = [
 
 [[package]]
 name = "joint-attention-mcp"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "sociality-mcp/packages/joint-attention-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -1353,7 +1353,7 @@ wheels = [
 
 [[package]]
 name = "memory-mcp"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "memory-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -2406,7 +2406,7 @@ wheels = [
 
 [[package]]
 name = "relationship-mcp"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "sociality-mcp/packages/relationship-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -2613,7 +2613,7 @@ wheels = [
 
 [[package]]
 name = "self-narrative-mcp"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "sociality-mcp/packages/self-narrative-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -2696,7 +2696,7 @@ wheels = [
 
 [[package]]
 name = "social-core"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "sociality-mcp/packages/social-core" }
 dependencies = [
     { name = "pydantic" },
@@ -2722,7 +2722,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "social-state-mcp"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "sociality-mcp/packages/social-state-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -2750,7 +2750,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "sociality-mcp"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "sociality-mcp" }
 dependencies = [
     { name = "boundary-mcp" },
@@ -2858,7 +2858,7 @@ wheels = [
 
 [[package]]
 name = "system-temperature-mcp"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "system-temperature-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -3014,7 +3014,7 @@ wheels = [
 
 [[package]]
 name = "tts-mcp"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "tts-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -3121,7 +3121,7 @@ wheels = [
 
 [[package]]
 name = "usb-webcam-mcp"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "usb-webcam-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -3276,7 +3276,7 @@ wheels = [
 
 [[package]]
 name = "wifi-cam-mcp"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "wifi-cam-mcp" }
 dependencies = [
     { name = "httpx" },
@@ -3321,7 +3321,7 @@ provides-extras = ["dev", "transcribe", "transcribe-faster"]
 
 [[package]]
 name = "x-mcp"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "x-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },

--- a/wifi-cam-mcp/pyproject.toml
+++ b/wifi-cam-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wifi-cam-mcp"
-version = "0.4.3"
+version = "0.4.4"
 description = "MCP server for controlling WiFi cameras (Tapo C210/C220) via ONVIF - Let AI look around your room!"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/wifi-cam-mcp/src/wifi_cam_mcp/config.py
+++ b/wifi-cam-mcp/src/wifi_cam_mcp/config.py
@@ -133,7 +133,7 @@ class ServerConfig:
     """MCP Server configuration."""
 
     name: str = "wifi-cam-mcp"
-    version: str = "0.4.3"
+    version: str = "0.4.4"
     capture_dir: str = field(default_factory=_default_capture_dir)
     mic_source: str = "camera"  # "camera" (RTSP) or "local" (PC microphone)
     mic_device: str | None = None  # DirectShow device name for Windows local mic
@@ -156,7 +156,7 @@ class ServerConfig:
         capture_dir = os.getenv("CAPTURE_DIR", "").strip() or _default_capture_dir()
         return cls(
             name=os.getenv("MCP_SERVER_NAME", "wifi-cam-mcp"),
-            version=os.getenv("MCP_SERVER_VERSION", "0.4.3"),
+            version=os.getenv("MCP_SERVER_VERSION", "0.4.4"),
             capture_dir=capture_dir,
             mic_source=mic_source,
             mic_device=os.getenv("MIC_DEVICE") or None,

--- a/x-mcp/pyproject.toml
+++ b/x-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "x-mcp"
-version = "0.4.3"
+version = "0.4.4"
 description = "MCP server for searching and posting to X (Twitter) via xAI Grok live search"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

A session run against the 0.4.3 gate reported that it kept filling one
prediction channel and leaving the other three empty, and read that as its own
reporting habit. It was not. It was the scoring rule.

```python
expected_tokens = _tokens(expected.summary)
if not expected_tokens:
    value = 0.25 if success else 0.75      # nobody predicted this. score it anyway
else:
    overlap = len(expected_tokens & actual_tokens) / len(expected_tokens)
    value = 1.0 - overlap
    if not success:
        value = max(value, 0.8)
```

Two consequences. Three of four channels were usually silent, so three quarters
of the mean feeding `ownership_score` measured nothing. And on failure a
channel you predicted was floored at **0.8** while a channel you ignored sat at
**0.75** -- so writing a prediction could only cost you.

Live evidence from the reporting session's own history: `exteroceptive 0.917`
(predicted) against `interoceptive / social / mnemonic 0.75` (silent), on the
same failed action.

## The change

An unpredicted channel is no longer in the mismatch vector at all. The vector
now contains only comparisons that were actually made, plus latency, which is
measured whether or not anyone predicted it.

Absence is paid for by `prediction_coverage`, a new term on `AgencyAssessment`
that scales `action_effect_match`. Being right about the channels you mentioned
says nothing about the ones you did not, so silence now contributes zero rather
than collecting a free 0.25 per channel. Ordering restored:

| | effect term |
| --- | --- |
| predicted 4/4, accurate | 1.00 |
| predicted 1/4, accurate | 0.25 |
| predicted nothing | 0.00 |

`ExpectedEffect` and `PredictedEffects` also carry field descriptions, so the
tool schema says what belongs on each channel instead of leaving a caller to
infer it from the field name -- the other half of what the session reported.

## The fixture that was hiding it

`test_prediction_loop` passed an empty `PredictedEffects` and asserted that
every channel key appeared in `prediction_errors`. That held only because
silent channels were being scored, and the trajectory reconciled as `observed`
only because those free 0.25s dragged the mean below the threshold. With the
rule fixed it reconciled as `contradicted` -- the same defect seen from the
other side. The fixture now declares expectations on all four channels.

I did not backfill the missing channels inside `prediction_loop` instead. That
would have put the vacuous constants back one layer down, in the very table the
generative model learns from.

## Verification

- ruff clean; 418 passed in the kernel suite, 129 in social-core plus root
- six new tests in `test_prediction_coverage.py` pin the absence rule, the
  ordering, and the reported coverage
- live: the last six outcomes on this machine show four scored channels,
  coverage 1.00, and `action_effect_match` ranging 0.061 to 0.482 -- variation
  driven by whether the predictions matched, where it used to be a constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
