### PR TITLE
feat(setup): add --all for a config where every server is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to embodied-claude are documented here.
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-07-31
+
+Setting up for a hands-on meant a room full of laptops with no cameras and no
+API keys, and a setup script that quite reasonably declined to configure
+servers it had no credentials for. Every participant would have seen a
+different, mostly empty tool list.
+
+### Added
+
+- setup: `--all` writes a configuration containing every server in the
+  catalogue, filling absent credentials with stand-in values. Because `camera`
+  and `voice` each name one option, the flag rides alongside them as an
+  additive overlay: both camera backends and both TTS engines are installed,
+  and both camera servers are emitted, without widening either field.
+- setup: the generated stand-ins keep a `changeme-` marker, which is exactly
+  what the placeholder guard rejects. Skipping that guard is confined to
+  `--all` and is the intent rather than a workaround -- a demo config should
+  announce itself rather than pass for a working one. Credentials already in
+  the environment are left alone, so running `--all` on a configured machine
+  adds servers instead of overwriting what already works.
+
 ## [0.4.5] - 2026-07-29
 
 A session spent several minutes sweeping the room for someone and could not

--- a/consciousness-mcp/packages/individual-kernel-mcp/pyproject.toml
+++ b/consciousness-mcp/packages/individual-kernel-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "individual-kernel-mcp"
-version = "0.4.5"
+version = "0.4.6"
 description = "Enacted first-person field runtime and phenomenal-like causal architecture research tools."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/desire-system/pyproject.toml
+++ b/desire-system/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "desire-system"
-version = "0.4.5"
+version = "0.4.6"
 description = "Autonomous desire system for embodied Claude - gives Kokone inner drives"
 requires-python = ">=3.10"
 dependencies = [

--- a/memory-mcp/pyproject.toml
+++ b/memory-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memory-mcp"
-version = "0.4.5"
+version = "0.4.6"
 description = "MCP server for AI long-term memory - Let AI remember across sessions!"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/memory-mcp/src/memory_mcp/config.py
+++ b/memory-mcp/src/memory_mcp/config.py
@@ -39,12 +39,12 @@ class ServerConfig:
     """MCP Server configuration."""
 
     name: str = "memory-mcp"
-    version: str = "0.4.5"
+    version: str = "0.4.6"
 
     @classmethod
     def from_env(cls) -> "ServerConfig":
         """Create config from environment variables."""
         return cls(
             name=os.getenv("MCP_SERVER_NAME", "memory-mcp"),
-            version=os.getenv("MCP_SERVER_VERSION", "0.4.5"),
+            version=os.getenv("MCP_SERVER_VERSION", "0.4.6"),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "embodied-claude-workspace"
-version = "0.4.5"
+version = "0.4.6"
 description = "Unified development and runtime environment for embodied-claude MCP servers."
 requires-python = ">=3.13,<3.14"
 dependencies = [

--- a/scripts/onboarding.py
+++ b/scripts/onboarding.py
@@ -30,6 +30,7 @@ class FeatureSelection:
     x_enabled: bool = False
     system_temperature: bool = False
     embedding_model: str = "small"
+    all_tools: bool = False
 
     def __post_init__(self) -> None:
         if self.profile != "core":
@@ -48,12 +49,19 @@ class FeatureSelection:
     def uv_extras(self) -> tuple[str, ...]:
         """Return root extras needed by this feature selection."""
         extras: list[str] = []
+        if self.all_tools and self.camera != "usb":
+            # `camera` names one backend, but --all wants both installed. The
+            # other is overlaid here rather than by widening the field to a
+            # set, which would touch every existing caller.
+            extras.append("camera-usb")
         if self.camera is not None:
             extras.append(f"camera-{self.camera}")
         if self.transcription is not None:
             extras.append(f"transcription-{self.transcription}")
         if self.voice is not None:
             extras.append(f"voice-{self.voice}")
+        if self.all_tools and self.voice != "elevenlabs":
+            extras.append("voice-elevenlabs")
         if self.x_enabled:
             extras.append("x")
         if self.system_temperature:
@@ -114,6 +122,21 @@ X_REQUIRED_ENVIRONMENT = (
     "X_ACCESS_TOKEN_SECRET",
 )
 
+# Deliberately fake values for --all. They keep the `changeme-` marker that
+# is_placeholder_value() rejects, so a demo config announces itself as one
+# rather than passing for a working setup.
+HANDSON_ENVIRONMENT = {
+    "TAPO_CAMERA_HOST": "changeme-tapo.invalid",
+    "TAPO_USERNAME": "changeme-user",
+    "TAPO_PASSWORD": "changeme-password",
+    "ELEVENLABS_API_KEY": "changeme-elevenlabs-key",
+    "XAI_API_KEY": "changeme-xai-key",
+    "X_CONSUMER_KEY": "changeme-x-consumer-key",
+    "X_CONSUMER_SECRET": "changeme-x-consumer-secret",
+    "X_ACCESS_TOKEN": "changeme-x-access-token",
+    "X_ACCESS_TOKEN_SECRET": "changeme-x-access-token-secret",
+}
+
 _PRIVATE_KEYS = {
     "TAPO_USERNAME",
     "ELEVENLABS_VOICE_ID",
@@ -136,11 +159,39 @@ def required_environment(selection: FeatureSelection) -> tuple[str, ...]:
     required: list[str] = []
     if selection.camera == "tapo":
         required.extend(TAPO_REQUIRED_ENVIRONMENT)
-    if selection.voice == "elevenlabs":
+    if selection.voice == "elevenlabs" or selection.all_tools:
         required.extend(ELEVENLABS_REQUIRED_ENVIRONMENT)
     if selection.x_enabled:
         required.extend(X_REQUIRED_ENVIRONMENT)
     return tuple(required)
+
+
+def all_tools_selection(embedding_model: str = "small") -> FeatureSelection:
+    """Every server at once, for demos and hands-on sessions."""
+
+    return FeatureSelection(
+        camera="tapo",
+        transcription="whisper",
+        voice="voicevox",
+        x_enabled=True,
+        system_temperature=True,
+        embedding_model=embedding_model,
+        all_tools=True,
+    )
+
+
+def fill_handson_environment(environment: Mapping[str, str]) -> dict[str, str]:
+    """Overlay fake values on required keys that are empty.
+
+    Credentials already present are kept. --all exists to make every server
+    appear, not to overwrite a machine that is already configured.
+    """
+
+    filled = dict(environment)
+    for key, value in HANDSON_ENVIRONMENT.items():
+        if not filled.get(key, "").strip():
+            filled[key] = value
+    return filled
 
 
 def missing_environment(
@@ -194,10 +245,12 @@ def build_mcp_config(
 ) -> dict[str, Any]:
     """Build a deterministic MCP configuration for the selected capabilities."""
 
-    invalid = missing_environment(selection, environment) + placeholder_environment(
-        selection,
-        environment,
-    )
+    invalid = missing_environment(selection, environment)
+    if not selection.all_tools:
+        # --all fills required keys with exactly the values this check exists
+        # to reject. Skipping it is the point: the stand-ins stay recognisable
+        # rather than being disguised to slip past the guard.
+        invalid = invalid + placeholder_environment(selection, environment)
     if invalid:
         joined = ", ".join(dict.fromkeys(invalid))
         raise ValueError(f"Missing or placeholder environment values: {joined}")
@@ -221,9 +274,11 @@ def build_mcp_config(
         ),
     }
 
-    if selection.camera == "usb":
+    # Two independent checks rather than a chain: --all wants both cameras,
+    # and `camera` can only name one of them.
+    if selection.camera == "usb" or selection.all_tools:
         servers["usb-webcam"] = SERVER_SPECS["usb-webcam"].command()
-    elif selection.camera == "tapo":
+    if selection.camera == "tapo":
         camera_environment = _selected_environment(
             environment,
             TAPO_REQUIRED_ENVIRONMENT,
@@ -240,13 +295,23 @@ def build_mcp_config(
         servers["wifi-cam"] = SERVER_SPECS["wifi-cam"].command(camera_environment)
 
     if selection.voice == "voicevox":
-        servers["tts"] = SERVER_SPECS["tts"].command(
-            {
-                "VOICEVOX_URL": environment.get("VOICEVOX_URL", "").strip()
-                or DEFAULT_VOICEVOX_URL,
-                "TTS_DEFAULT_ENGINE": "voicevox",
-            }
-        )
+        voice_environment = {
+            "VOICEVOX_URL": environment.get("VOICEVOX_URL", "").strip()
+            or DEFAULT_VOICEVOX_URL,
+            "TTS_DEFAULT_ENGINE": "voicevox",
+        }
+        if selection.all_tools:
+            # Both engines are installed under --all, so carry the ElevenLabs
+            # key as well: switching engines becomes a one-line edit instead
+            # of a re-run of setup.
+            voice_environment.update(
+                _selected_environment(
+                    environment,
+                    ELEVENLABS_REQUIRED_ENVIRONMENT,
+                    ELEVENLABS_OPTIONAL_ENVIRONMENT,
+                )
+            )
+        servers["tts"] = SERVER_SPECS["tts"].command(voice_environment)
     elif selection.voice == "elevenlabs":
         voice_environment = _selected_environment(
             environment,

--- a/scripts/setup.cmd
+++ b/scripts/setup.cmd
@@ -2,6 +2,10 @@
 setlocal
 cd /d "%~dp0.."
 
+rem Every argument goes straight to scripts\setup.py, which owns the option
+rem surface; run with --help for the full list. `setup.cmd --all` configures
+rem every server, filling absent credentials with obviously fake values.
+
 where uv >nul 2>nul
 if errorlevel 1 (
   echo uv is required. Install it from https://docs.astral.sh/uv/getting-started/installation/ 1>&2

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -19,7 +19,9 @@ if __package__ in {None, ""}:
 from scripts.doctor import CheckResult, CheckStatus, run_doctor
 from scripts.onboarding import (
     FeatureSelection,
+    all_tools_selection,
     build_mcp_config,
+    fill_handson_environment,
     missing_environment,
     redact_config,
 )
@@ -54,6 +56,14 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--with-voice", choices=("voicevox", "elevenlabs"))
     parser.add_argument("--with-x", action="store_true")
     parser.add_argument("--with-system-temperature", action="store_true")
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help=(
+            "Enable every server, filling absent credentials with obviously "
+            "fake values. For demos and hands-on sessions, not for real use"
+        ),
+    )
     parser.add_argument(
         "--embedding-model",
         choices=("small", "base"),
@@ -307,10 +317,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(raw_arguments)
     interactive = not raw_arguments
 
-    selection = (
-        _interactive_selection()
-        if interactive
-        else FeatureSelection(
+    if interactive:
+        selection = _interactive_selection()
+        environment = _interactive_environment(selection, os.environ)
+    elif args.all:
+        # --all overrides the individual --with-* flags rather than merging
+        # with them: "everything" has no coherent reading that also honours a
+        # narrower choice made on the same command line.
+        selection = all_tools_selection(args.embedding_model)
+        environment = fill_handson_environment(os.environ)
+    else:
+        selection = FeatureSelection(
             profile=args.profile,
             camera=args.with_camera,
             transcription=args.with_transcription,
@@ -319,12 +336,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             system_temperature=args.with_system_temperature,
             embedding_model=args.embedding_model,
         )
-    )
-    environment = (
-        _interactive_environment(selection, os.environ)
-        if interactive
-        else dict(os.environ)
-    )
+        environment = dict(os.environ)
     missing = missing_environment(selection, environment)
     if missing:
         parser.error(

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Every argument goes straight to scripts/setup.py, which owns the option
+# surface; run with --help for the full list. `setup.sh --all` configures
+# every server, filling absent credentials with obviously fake values.
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 

--- a/sociality-mcp/packages/agent-grammar/pyproject.toml
+++ b/sociality-mcp/packages/agent-grammar/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-grammar"
-version = "0.4.5"
+version = "0.4.6"
 description = "PEG-based agent grammar for embodied Kokone — observation/inference flow control"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/boundary-mcp/pyproject.toml
+++ b/sociality-mcp/packages/boundary-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boundary-mcp"
-version = "0.4.5"
+version = "0.4.6"
 description = "MCP server for social boundaries, consent, and tact gating"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/interaction-orchestrator-mcp/pyproject.toml
+++ b/sociality-mcp/packages/interaction-orchestrator-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "interaction-orchestrator-mcp"
-version = "0.4.5"
+version = "0.4.6"
 description = "Human Response Orchestrator for Embodied Claude — turns substrate signals into stable social moves"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/joint-attention-mcp/pyproject.toml
+++ b/sociality-mcp/packages/joint-attention-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "joint-attention-mcp"
-version = "0.4.5"
+version = "0.4.6"
 description = "MCP server for scene grounding and joint attention"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/relationship-mcp/pyproject.toml
+++ b/sociality-mcp/packages/relationship-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "relationship-mcp"
-version = "0.4.5"
+version = "0.4.6"
 description = "MCP server for compact relationship abstractions and commitments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/self-narrative-mcp/pyproject.toml
+++ b/sociality-mcp/packages/self-narrative-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "self-narrative-mcp"
-version = "0.4.5"
+version = "0.4.6"
 description = "MCP server for compact autobiographical summaries and arcs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/social-core/pyproject.toml
+++ b/sociality-mcp/packages/social-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "social-core"
-version = "0.4.5"
+version = "0.4.6"
 description = "Shared models and SQLite store for Kokone sociality MCP servers"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/packages/social-state-mcp/pyproject.toml
+++ b/sociality-mcp/packages/social-state-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "social-state-mcp"
-version = "0.4.5"
+version = "0.4.6"
 description = "MCP server for present-moment social state inference"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/sociality-mcp/pyproject.toml
+++ b/sociality-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sociality-mcp"
-version = "0.4.5"
+version = "0.4.6"
 description = "Unified MCP facade for Kokone's social middle layer"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/system-temperature-mcp/pyproject.toml
+++ b/system-temperature-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "system-temperature-mcp"
-version = "0.4.5"
+version = "0.4.6"
 description = "MCP server for monitoring system temperature - your sense of body temperature"
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).parents[1]
-RELEASE_VERSION = "0.4.5"
+RELEASE_VERSION = "0.4.6"
 RELEASE_TAG = f"v{RELEASE_VERSION}"
 
 
@@ -48,7 +48,7 @@ def test_changelog_contains_the_dated_release() -> None:
     changelog = (ROOT / "CHANGELOG.md").read_text()
 
     assert "## [Unreleased]" in changelog
-    assert f"## [{RELEASE_VERSION}] - 2026-07-29" in changelog
+    assert f"## [{RELEASE_VERSION}] - 2026-07-31" in changelog
     assert "phenomenal-consciousness candidate architecture" in changelog
     assert "proof of phenomenal consciousness" not in changelog
 

--- a/tests/test_setup_cli.py
+++ b/tests/test_setup_cli.py
@@ -7,9 +7,14 @@ import sys
 from io import StringIO
 from pathlib import Path
 
-from scripts import setup
+from scripts import onboarding, setup
 from scripts.doctor import CheckResult, CheckStatus
-from scripts.onboarding import CORE_SERVER_NAMES, FeatureSelection
+from scripts.onboarding import (
+    CORE_SERVER_NAMES,
+    SERVER_SPECS,
+    TAPO_REQUIRED_ENVIRONMENT,
+    FeatureSelection,
+)
 from scripts.setup import execute_setup
 
 ROOT = Path(__file__).parents[1]
@@ -156,6 +161,63 @@ def test_noninteractive_selection_names_every_missing_variable() -> None:
         "X_ACCESS_TOKEN_SECRET",
     ):
         assert key in result.stderr
+
+
+def _all_environment(**overrides: str) -> dict[str, str]:
+    environment = os.environ.copy()
+    for key in TAPO_REQUIRED_ENVIRONMENT:
+        environment.pop(key, None)
+    environment.update(overrides)
+    return environment
+
+
+def test_all_dry_run_lists_every_supported_server() -> None:
+    # The hands-on needs every tool visible in /mcp, so --all has to cover the
+    # whole catalogue rather than a curated subset that drifts out of date.
+    result = _run_setup_cli("--all", "--dry-run", environment=_all_environment())
+
+    assert result.returncode == 0, result.stderr
+    config = json.loads(result.stdout)
+    assert set(config["mcpServers"]) == set(SERVER_SPECS)
+
+
+def test_all_generates_values_that_are_visibly_fake() -> None:
+    # A demo config that reads as real is worse than one announcing itself.
+    # The placeholder guard exists to stop example values reaching production,
+    # and --all is the one path allowed to write values it would reject.
+    result = _run_setup_cli("--all", "--dry-run", environment=_all_environment())
+
+    assert result.returncode == 0, result.stderr
+    config = json.loads(result.stdout)
+    assert "changeme" in config["mcpServers"]["wifi-cam"]["env"]["TAPO_CAMERA_HOST"]
+
+
+def test_all_keeps_credentials_that_are_already_real() -> None:
+    # --all is for making every server appear, not for overwriting a machine
+    # that is already configured.
+    environment = _all_environment(TAPO_CAMERA_HOST="192.0.2.10")
+
+    result = _run_setup_cli("--all", "--dry-run", environment=environment)
+
+    assert result.returncode == 0, result.stderr
+    config = json.loads(result.stdout)
+    host = config["mcpServers"]["wifi-cam"]["env"]["TAPO_CAMERA_HOST"]
+    assert host == "192.0.2.10"
+
+
+def test_all_sync_command_installs_every_extra() -> None:
+    command = setup.build_sync_command(onboarding.all_tools_selection())
+
+    assert command[:4] == ["uv", "sync", "--locked", "--no-dev"]
+    assert set(command[5::2]) == {
+        "camera-usb",
+        "camera-tapo",
+        "transcription-whisper",
+        "voice-voicevox",
+        "voice-elevenlabs",
+        "x",
+        "system-temperature",
+    }
 
 
 def test_dry_run_calls_no_side_effects(tmp_path: Path) -> None:

--- a/tts-mcp/pyproject.toml
+++ b/tts-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tts-mcp"
-version = "0.4.5"
+version = "0.4.6"
 description = "MCP server for text-to-speech (ElevenLabs + VOICEVOX)"
 requires-python = ">=3.10"
 dependencies = [

--- a/tts-mcp/src/tts_mcp/config.py
+++ b/tts-mcp/src/tts_mcp/config.py
@@ -171,12 +171,12 @@ class ServerConfig:
     """MCP Server configuration."""
 
     name: str = "tts"
-    version: str = "0.4.5"
+    version: str = "0.4.6"
 
     @classmethod
     def from_env(cls) -> "ServerConfig":
         """Create config from environment variables."""
         return cls(
             name=os.getenv("MCP_SERVER_NAME", "tts"),
-            version=os.getenv("MCP_SERVER_VERSION", "0.4.5"),
+            version=os.getenv("MCP_SERVER_VERSION", "0.4.6"),
         )

--- a/usb-webcam-mcp/pyproject.toml
+++ b/usb-webcam-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "usb-webcam-mcp"
-version = "0.4.5"
+version = "0.4.6"
 description = "MCP server for USB webcam capture"
 requires-python = ">=3.10"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ members = [
 
 [[package]]
 name = "agent-grammar"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "sociality-mcp/packages/agent-grammar" }
 dependencies = [
     { name = "pydantic" },
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "boundary-mcp"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "sociality-mcp/packages/boundary-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -582,7 +582,7 @@ nvtx = [
 
 [[package]]
 name = "desire-system"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "desire-system" }
 dependencies = [
     { name = "chromadb" },
@@ -647,7 +647,7 @@ wheels = [
 
 [[package]]
 name = "embodied-claude-workspace"
-version = "0.4.5"
+version = "0.4.6"
 source = { virtual = "." }
 dependencies = [
     { name = "desire-system" },
@@ -975,7 +975,7 @@ wheels = [
 
 [[package]]
 name = "individual-kernel-mcp"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "consciousness-mcp/packages/individual-kernel-mcp" }
 dependencies = [
     { name = "agent-grammar" },
@@ -1018,7 +1018,7 @@ wheels = [
 
 [[package]]
 name = "interaction-orchestrator-mcp"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "sociality-mcp/packages/interaction-orchestrator-mcp" }
 dependencies = [
     { name = "boundary-mcp" },
@@ -1120,7 +1120,7 @@ wheels = [
 
 [[package]]
 name = "joint-attention-mcp"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "sociality-mcp/packages/joint-attention-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -1353,7 +1353,7 @@ wheels = [
 
 [[package]]
 name = "memory-mcp"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "memory-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -2406,7 +2406,7 @@ wheels = [
 
 [[package]]
 name = "relationship-mcp"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "sociality-mcp/packages/relationship-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -2613,7 +2613,7 @@ wheels = [
 
 [[package]]
 name = "self-narrative-mcp"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "sociality-mcp/packages/self-narrative-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -2696,7 +2696,7 @@ wheels = [
 
 [[package]]
 name = "social-core"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "sociality-mcp/packages/social-core" }
 dependencies = [
     { name = "pydantic" },
@@ -2722,7 +2722,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "social-state-mcp"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "sociality-mcp/packages/social-state-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -2750,7 +2750,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "sociality-mcp"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "sociality-mcp" }
 dependencies = [
     { name = "boundary-mcp" },
@@ -2858,7 +2858,7 @@ wheels = [
 
 [[package]]
 name = "system-temperature-mcp"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "system-temperature-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -3014,7 +3014,7 @@ wheels = [
 
 [[package]]
 name = "tts-mcp"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "tts-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -3121,7 +3121,7 @@ wheels = [
 
 [[package]]
 name = "usb-webcam-mcp"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "usb-webcam-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -3276,7 +3276,7 @@ wheels = [
 
 [[package]]
 name = "wifi-cam-mcp"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "wifi-cam-mcp" }
 dependencies = [
     { name = "httpx" },
@@ -3321,7 +3321,7 @@ provides-extras = ["dev", "transcribe", "transcribe-faster"]
 
 [[package]]
 name = "x-mcp"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "x-mcp" }
 dependencies = [
     { name = "mcp", extra = ["cli"] },

--- a/wifi-cam-mcp/pyproject.toml
+++ b/wifi-cam-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wifi-cam-mcp"
-version = "0.4.5"
+version = "0.4.6"
 description = "MCP server for controlling WiFi cameras (Tapo C210/C220) via ONVIF - Let AI look around your room!"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/wifi-cam-mcp/src/wifi_cam_mcp/config.py
+++ b/wifi-cam-mcp/src/wifi_cam_mcp/config.py
@@ -133,7 +133,7 @@ class ServerConfig:
     """MCP Server configuration."""
 
     name: str = "wifi-cam-mcp"
-    version: str = "0.4.5"
+    version: str = "0.4.6"
     capture_dir: str = field(default_factory=_default_capture_dir)
     mic_source: str = "camera"  # "camera" (RTSP) or "local" (PC microphone)
     mic_device: str | None = None  # DirectShow device name for Windows local mic
@@ -156,7 +156,7 @@ class ServerConfig:
         capture_dir = os.getenv("CAPTURE_DIR", "").strip() or _default_capture_dir()
         return cls(
             name=os.getenv("MCP_SERVER_NAME", "wifi-cam-mcp"),
-            version=os.getenv("MCP_SERVER_VERSION", "0.4.5"),
+            version=os.getenv("MCP_SERVER_VERSION", "0.4.6"),
             capture_dir=capture_dir,
             mic_source=mic_source,
             mic_device=os.getenv("MIC_DEVICE") or None,

--- a/x-mcp/pyproject.toml
+++ b/x-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "x-mcp"
-version = "0.4.5"
+version = "0.4.6"
 description = "MCP server for searching and posting to X (Twitter) via xAI Grok live search"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Tomorrow's hands-on needs a machine where `/mcp` shows every server, so a
participant can see the whole surface without owning a camera, an ElevenLabs
key and an X developer account. `setup.sh --all` produces that config; absent
credentials are filled with values that announce themselves as fake.

- Selects every server in `SERVER_SPECS` — both cameras, Whisper, both voice
  engines, X, system temperature.
- Fills only the credentials that are **absent**. A machine already holding a
  real `TAPO_CAMERA_HOST` keeps it, so `--all` on a configured workstation
  overwrites nothing.
- Skips the placeholder guard. That guard exists to stop example values
  reaching a real config, and `--all` writes exactly the values it rejects —
  so the stand-ins stay recognisable (`changeme-tapo.invalid`) rather than
  being disguised to slip past it.

`--all` overrides the individual `--with-*` flags rather than merging with
them: "everything" has no coherent reading that also honours a narrower choice
made on the same command line.

## Where the existing shape resisted

`FeatureSelection.camera` and `.voice` each name **one** backend, but `--all`
wants both cameras and both voice engines installed. Widening those fields to
sets would have touched every existing caller, so the second backend rides
alongside as an `all_tools` overlay in `uv_extras()`, and the config builder's
camera `elif` became two independent `if`s.

## Verification

- `--all --dry-run` emits all 9 servers, `tts` carrying both the VOICEVOX
  settings and `ELEVENLABS_API_KEY`.
- `uv run ruff check scripts tests` clean; 50 passed.
- One pre-existing failure,
  `test_noninteractive_core_dry_run_lists_only_core_servers`, which asserts
  `not (ROOT / ".mcp.json").exists()` and so fails on any machine with a real
  config. It arrived in 2b68da0 (#106) and is untouched here.

## Also

Bumps the workspace to 0.4.6 for the release tag.

One caveat for anyone running `scripts/release_check.py` locally: it walks the
whole tree and skips only `.venv`, so an unrelated checkout sitting under the
repo reads as a version mismatch. Untracked paths never reach a CI clone, so
this is local-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
