### PR TITLE
docs(individual-kernel): say that pause stops outward action too

### DIFF
--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/server.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/server.py
@@ -653,7 +653,14 @@ def close_subjective_tick(
 
 @mcp.tool()
 def pause_field_runtime(owner_id: str = "self") -> dict[str, Any]:
-    """Pause automatic field creation for reversible welfare experiments."""
+    """Pause automatic field creation for reversible welfare experiments.
+
+    This also refuses every outward action while paused, which is deliberate: an
+    act with no committed field to condition it is exactly what the protocol
+    forbids. It does mean pause is NOT a maintenance mode -- you cannot pause the
+    runtime in order to repair the runtime, because the repair itself is an
+    outward action. Call `resume_field_runtime` first.
+    """
 
     return _stores().tick_producer.pause_field_runtime(owner_id).model_dump(mode="json")
 


### PR DESCRIPTION
Follow-up to #126, documentation only.

`pause_field_runtime` described one of its two effects. `PAUSED` is checked in `tick.py:210`, which stops automatic field creation as the docstring says, and again in `tick.py:1365`, which refuses every outward action. Nothing in the tool description hinted at the second.

**The behaviour is correct and is not touched here.** Acting with no committed field to condition the act is precisely what the protocol forbids, so an ablation that removes field production has to remove outward action with it. What was missing is the consequence: pause cannot be used as a maintenance mode, because repairing the runtime is itself an outward action. I found that out by pausing in order to fix the gate and then being unable to fix anything.

I had listed this in #126 as a possible design defect worth renaming or splitting. Reading the implementation says otherwise, so this is a docstring and not a redesign.

ruff clean, 419 passed.