### PR TITLE
feat(individual-kernel): give each agent its own field and intention slot

### DIFF
--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/enacted_field.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/enacted_field.py
@@ -180,6 +180,14 @@ class RuntimeState(BaseModel):
     last_trigger_kind: str | None = None
     last_recovery_at: str | None = None
     updated_at: str
+    # The Claude Code session that speaks for this owner, claimed at its
+    # SessionStart. `runtime_state` builds this model straight from the row and
+    # the config forbids extras, so this field has to land BEFORE the migration
+    # that adds the column -- otherwise every path that reads runtime state
+    # raises at once, the gate fails closed, and the runtime can no longer be
+    # repaired from inside. That is not hypothetical; it happened while writing
+    # this change in the other order.
+    session_id: str | None = None
 
 
 class EnactedFieldStore:

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/enacted_field.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/enacted_field.py
@@ -439,6 +439,35 @@ class EnactedFieldStore:
             return None
         return RuntimeState(**dict(row))
 
+    def claim_session(
+        self,
+        *,
+        owner_id: str,
+        continuity_token: str,
+        session_id: str,
+        current_field_id: str | None = None,
+        open_tick_id: str | None = None,
+        state: str = "ACTIVE",
+    ) -> RuntimeState:
+        """Record the Claude Code session that speaks for this owner.
+
+        Deliberately last-write-wins: a genuinely new top-level session must be
+        able to take over `self` from the one before it, or every restart would
+        strand the agent under a derived owner. Only SessionStart calls this, and
+        subagents do not fire SessionStart, so the takeover cannot happen mid-run.
+        """
+        self._upsert_runtime(
+            owner_id=owner_id,
+            continuity_token=continuity_token,
+            current_field_id=current_field_id,
+            open_tick_id=open_tick_id,
+            state=state,
+            session_id=session_id,
+        )
+        claimed = self.runtime_state(owner_id)
+        assert claimed is not None
+        return claimed
+
     def pause(self, owner_id: str = "self") -> RuntimeState:
         state = self.runtime_state(owner_id)
         token = state.continuity_token if state else f"cont_{secrets.token_urlsafe(16)}"
@@ -527,19 +556,24 @@ class EnactedFieldStore:
         open_tick_id: str | None,
         state: str = "ACTIVE",
         last_trigger_kind: str | None = None,
+        session_id: str | None = None,
     ) -> None:
         self._db.execute(
             """
             INSERT INTO field_runtime_state(
                 owner_id, continuity_token, current_field_id, open_tick_id,
-                state, last_trigger_kind, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                state, last_trigger_kind, session_id, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(owner_id) DO UPDATE SET
                 continuity_token = excluded.continuity_token,
                 current_field_id = excluded.current_field_id,
                 open_tick_id = excluded.open_tick_id,
                 state = excluded.state,
                 last_trigger_kind = COALESCE(excluded.last_trigger_kind, last_trigger_kind),
+                -- COALESCE, so only a caller that actually knows the session
+                -- writes it. Every other upsert (commit, pause, resume) passes
+                -- None and must leave the claim standing.
+                session_id = COALESCE(excluded.session_id, session_id),
                 updated_at = excluded.updated_at
             """,
             (
@@ -549,6 +583,7 @@ class EnactedFieldStore:
                 open_tick_id,
                 state,
                 last_trigger_kind,
+                session_id,
                 utc_now(),
             ),
         )

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/hook_cli.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/hook_cli.py
@@ -78,6 +78,29 @@ def _surface_context(field) -> str:
     return FIELD_PROTOCOL + "\n\n" + field.phenomenal_surface
 
 
+def _owner_id(payload: dict[str, Any], producer: TickProducer) -> str:
+    """Which individual this hook invocation acts as.
+
+    Every call site used to hardcode `"self"`, so a subagent's hooks arrived as
+    the parent: same committed field, same single pending-intention slot. Only
+    one COMMITTED field is allowed per owner, so sharing an owner means two
+    concurrent agents fighting over one. Resolving from the session gives each
+    its own, which is what lets a subagent take an outward action on its own
+    account instead of taking the parent's turn.
+
+    An explicit `owner_id` in the payload still wins: that is how tests and
+    deliberate cross-owner calls address a specific individual.
+
+    Note for the next caller: `pre_tool_use`, `post_tool_use` and
+    `post_tool_use_failure` receive a `FieldRuntime`, not a producer, so they
+    must pass `runtime.producer` here.
+    """
+    explicit = payload.get("owner_id")
+    if explicit:
+        return str(explicit)
+    return producer.resolve_owner_id(payload.get("session_id"))
+
+
 def _summary(value: Any, *, limit: int = 1800) -> str:
     if isinstance(value, str):
         text = value
@@ -90,7 +113,7 @@ def _summary(value: Any, *, limit: int = 1800) -> str:
 
 
 def session_start(payload: dict[str, Any], producer: TickProducer) -> dict[str, Any]:
-    owner_id = str(payload.get("owner_id") or "self")
+    owner_id = _owner_id(payload, producer)
     recovery = producer.recover_stale_runtime(owner_id)
     field = producer.get_current_field(owner_id)
     if field is None:
@@ -113,7 +136,7 @@ def user_prompt_submit(
     payload: dict[str, Any],
     producer: TickProducer,
 ) -> dict[str, Any]:
-    owner_id = str(payload.get("owner_id") or "self")
+    owner_id = _owner_id(payload, producer)
     prompt = str(payload.get("prompt") or "")
     is_heartbeat = os.getenv("HEARTBEAT") == "1"
     field = producer.begin_tick(
@@ -131,7 +154,7 @@ def pre_tool_use(payload: dict[str, Any], runtime: FieldRuntime) -> dict[str, An
     decision = runtime.gate_tool(
         tool_name=str(payload.get("tool_name") or ""),
         tool_input=_dict(payload.get("tool_input")),
-        owner_id=str(payload.get("owner_id") or "self"),
+        owner_id=_owner_id(payload, runtime.producer),
     )
     return {
         "hookSpecificOutput": {
@@ -147,7 +170,7 @@ def post_tool_use(payload: dict[str, Any], runtime: FieldRuntime) -> dict[str, A
     tool_input = _dict(payload.get("tool_input"))
     if not is_external_tool(tool_name, tool_input):
         current = runtime.producer.get_current_field(
-            str(payload.get("owner_id") or "self")
+            _owner_id(payload, runtime.producer)
         )
         context = (
             "Internal tool result queued for the single PostToolBatch field refresh. "
@@ -159,7 +182,7 @@ def post_tool_use(payload: dict[str, Any], runtime: FieldRuntime) -> dict[str, A
         tool_input=tool_input,
         actual_result_summary=_summary(payload.get("tool_response")),
         success=True,
-        owner_id=str(payload.get("owner_id") or "self"),
+        owner_id=_owner_id(payload, runtime.producer),
         actual_result_ref=str(payload.get("tool_use_id") or "") or None,
         latency_ms=_optional_int(payload.get("duration_ms")),
         session_id=payload.get("session_id"),
@@ -187,7 +210,7 @@ def post_tool_use_failure(
     tool_input = _dict(payload.get("tool_input"))
     if not is_external_tool(tool_name, tool_input):
         current = runtime.producer.get_current_field(
-            str(payload.get("owner_id") or "self")
+            _owner_id(payload, runtime.producer)
         )
         context = (
             "Internal tool failure queued for the single PostToolBatch field refresh. "
@@ -199,7 +222,7 @@ def post_tool_use_failure(
         tool_input=tool_input,
         actual_result_summary=str(payload.get("error") or "tool execution failed"),
         success=False,
-        owner_id=str(payload.get("owner_id") or "self"),
+        owner_id=_owner_id(payload, runtime.producer),
         actual_result_ref=str(payload.get("tool_use_id") or "") or None,
         latency_ms=_optional_int(payload.get("duration_ms")),
         session_id=payload.get("session_id"),
@@ -229,12 +252,12 @@ def post_tool_batch(payload: dict[str, Any], producer: TickProducer) -> dict[str
     ]
     if not refreshing:
         current = producer.get_current_field(
-            str(payload.get("owner_id") or "self")
+            _owner_id(payload, producer)
         )
         context = current.phenomenal_surface if current else "No committed field is available."
         return _hook_context("PostToolBatch", context)
 
-    owner_id = str(payload.get("owner_id") or "self")
+    owner_id = _owner_id(payload, producer)
     current = producer.get_current_field(owner_id)
     if current is not None:
         producer.invalidate_field(
@@ -269,7 +292,7 @@ def post_tool_batch(payload: dict[str, Any], producer: TickProducer) -> dict[str
 
 
 def stop(payload: dict[str, Any], producer: TickProducer) -> dict[str, Any]:
-    field = producer.get_current_field(str(payload.get("owner_id") or "self"))
+    field = producer.get_current_field(_owner_id(payload, producer))
     if field is not None:
         producer.close_tick(
             field.tick_id,
@@ -279,7 +302,7 @@ def stop(payload: dict[str, Any], producer: TickProducer) -> dict[str, Any]:
 
 
 def stop_failure(payload: dict[str, Any], producer: TickProducer) -> dict[str, Any]:
-    field = producer.get_current_field(str(payload.get("owner_id") or "self"))
+    field = producer.get_current_field(_owner_id(payload, producer))
     if field is not None:
         producer.close_tick(
             field.tick_id,
@@ -289,7 +312,7 @@ def stop_failure(payload: dict[str, Any], producer: TickProducer) -> dict[str, A
 
 
 def diagnostics(payload: dict[str, Any], producer: TickProducer) -> dict[str, Any]:
-    owner_id = str(payload.get("owner_id") or "self")
+    owner_id = _owner_id(payload, producer)
     current = producer.get_current_field(owner_id)
     runtime = producer.fields.runtime_state(owner_id)
     return {

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/tick.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/tick.py
@@ -735,6 +735,60 @@ class TickProducer:
             resumed_field_id=current.field_id if current else None,
         )
 
+    def claim_primary_session(self, owner_id: str, session_id: str | None) -> None:
+        """Record that this Claude Code session speaks for `owner_id`.
+
+        Called from the SessionStart hook, which only a top-level session fires.
+        Subagents reach the kernel through PreToolUse alone -- measured against a
+        run where eight of them made 419 tool calls and produced no session_start
+        tick at all -- so the primary slot cannot be taken from underneath a
+        parent that is merely idle while its subagents work.
+        """
+        if not session_id:
+            return
+        state = self.fields.runtime_state(owner_id)
+        token = (
+            state.continuity_token
+            if state is not None
+            else f"cont_{secrets.token_urlsafe(16)}"
+        )
+        self.fields.claim_session(
+            owner_id=owner_id,
+            continuity_token=token,
+            session_id=session_id,
+            current_field_id=state.current_field_id if state else None,
+            open_tick_id=state.open_tick_id if state else None,
+            state=state.state if state else "ACTIVE",
+        )
+
+    def resolve_owner_id(
+        self,
+        session_id: str | None,
+        *,
+        primary_owner_id: str = "self",
+    ) -> str:
+        """Return the owner a hook from `session_id` should act as.
+
+        The primary session keeps `self` and its continuity. Any other session is
+        a subagent, and gets an owner of its own so that it can hold a field and
+        a pending intention without competing for the parent's single slot --
+        `enacted_fields` allows one COMMITTED field per owner, so sharing an owner
+        means sharing one field between concurrent agents.
+
+        Falls back to the primary when there is nothing to tell them apart: no
+        session in the payload, or no claim recorded yet. That keeps tests and
+        manual calls behaving exactly as before.
+        """
+        if not session_id:
+            return primary_owner_id
+        state = self.fields.runtime_state(primary_owner_id)
+        if state is None or not state.session_id:
+            return primary_owner_id
+        if state.session_id == session_id:
+            return primary_owner_id
+        digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:12]
+        return f"{primary_owner_id}:agent:{digest}"
+
     def pause_field_runtime(self, owner_id: str = "self"):
         return self.fields.pause(owner_id)
 

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_efpf_causal.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_efpf_causal.py
@@ -525,6 +525,77 @@ def test_recovery_leaves_a_live_intention_and_its_field_alone(
     ).allow
 
 
+def test_a_subagent_session_gets_its_own_owner(social_db, tmp_path: Path) -> None:
+    """A second session must not share the parent's field or intention slot.
+
+    `enacted_fields` permits one COMMITTED field per owner and `propose` permits
+    one pending intention per owner, so two concurrent agents under the same
+    owner fight over both. Splitting the owner is what lets a subagent act with
+    its own agency instead of taking the parent's turn.
+    """
+    producer = _producer(social_db, tmp_path)
+    producer.claim_primary_session("self", "parent-session")
+
+    assert producer.resolve_owner_id("parent-session") == "self"
+
+    child = producer.resolve_owner_id("child-session")
+    assert child != "self"
+    assert child.startswith("self:agent:")
+    # Stable across calls, so a subagent keeps one identity for its whole run.
+    assert producer.resolve_owner_id("child-session") == child
+    assert producer.resolve_owner_id("other-child") != child
+
+
+def test_owner_resolution_falls_back_to_self_without_a_claim(
+    social_db, tmp_path: Path
+) -> None:
+    """No session in the payload, or no claim yet, must behave exactly as before.
+
+    Tests and manual tool calls pass no session at all; if those silently became
+    derived owners they would stop seeing the field they just committed.
+    """
+    producer = _producer(social_db, tmp_path)
+
+    assert producer.resolve_owner_id(None) == "self"
+    assert producer.resolve_owner_id("") == "self"
+    # Claim not recorded yet: anything is potentially the primary.
+    assert producer.resolve_owner_id("unknown-session") == "self"
+
+
+def test_a_new_top_level_session_takes_over_the_primary_slot(
+    social_db, tmp_path: Path
+) -> None:
+    """Restarting Claude Code must return the agent to `self`, not strand it.
+
+    Only SessionStart claims, and subagents do not fire SessionStart, so
+    last-write-wins cannot be triggered mid-run by a subagent.
+    """
+    producer = _producer(social_db, tmp_path)
+    producer.claim_primary_session("self", "first-session")
+    producer.claim_primary_session("self", "second-session")
+
+    assert producer.resolve_owner_id("second-session") == "self"
+    assert producer.resolve_owner_id("first-session").startswith("self:agent:")
+
+
+def test_committing_a_field_does_not_erase_the_session_claim(
+    social_db, tmp_path: Path
+) -> None:
+    """Regression: every tick upserts the runtime row.
+
+    Without COALESCE on session_id, the first commit after SessionStart would
+    blank the claim and every later hook -- including the parent's own -- would
+    resolve to `self` again, silently undoing the split.
+    """
+    producer = _producer(social_db, tmp_path)
+    producer.claim_primary_session("self", "parent-session")
+    _commit(producer)
+
+    state = producer.fields.runtime_state("self")
+    assert state is not None and state.session_id == "parent-session"
+    assert producer.resolve_owner_id("child-session").startswith("self:agent:")
+
+
 def test_provenance_is_preserved_in_surface() -> None:
     field = EnactedField(
         tick_id="tick",

--- a/sociality-mcp/packages/social-core/src/social_core/migrations.py
+++ b/sociality-mcp/packages/social-core/src/social_core/migrations.py
@@ -431,6 +431,21 @@ CREATE INDEX IF NOT EXISTS idx_organism_runs_owner_ran
     ON organism_runs(owner_id, ran_at DESC);
 """
 
+# Which Claude Code session speaks for an owner. Claimed when that session's
+# SessionStart hook fires. Subagents never fire SessionStart -- verified against
+# a run where eight of them made 419 tool calls and produced zero session_start
+# ticks -- so they can never take the primary slot, and a hook arriving under a
+# different session is given its own derived owner instead of sharing the
+# parent's field and single pending-intention slot.
+#
+# `RuntimeState` must already accept this column before the migration lands; it
+# forbids extra keys, so the reverse order takes the whole runtime down.
+# ALTER TABLE ADD COLUMN has no IF NOT EXISTS in SQLite, and `apply_migrations`
+# is what guarantees this runs exactly once.
+_MIGRATION_013_SQL = """
+ALTER TABLE field_runtime_state ADD COLUMN session_id TEXT;
+"""
+
 _MIGRATION_011_SQL = """
 CREATE TABLE IF NOT EXISTS process_meta_representations (
     process_meta_id TEXT PRIMARY KEY,
@@ -885,6 +900,10 @@ MIGRATIONS = [
     Migration(
         name="012_organism_runs",
         sql=_MIGRATION_012_SQL,
+    ),
+    Migration(
+        name="013_runtime_primary_session",
+        sql=_MIGRATION_013_SQL,
     ),
 ]
 


### PR DESCRIPTION
Follow-up to #126. A subagent could not act on its own account, because it reached
the kernel as its parent.

## What was wrong

Every hook call site in `hook_cli` read `payload.get("owner_id") or "self"` -- all
twelve of them -- and the payload never carries an `owner_id`. So a subagent's
PreToolUse, PostToolUse and PostToolUseFailure all arrived as `self`.

That matters because ownership is exclusive on both sides:

- `idx_enacted_fields_one_committed_owner` allows **one COMMITTED field per owner**
- `AgencyStore.propose` allows **one pending intention per owner**

Two agents under one owner therefore share a single field and a single intention
slot. A subagent taking an outward action would have had to take the parent's turn.

## What it does now

`SessionStart` records the session that speaks for an owner. Every other hook
resolves from the payload session:

| session | owner |
|---|---|
| matches the recorded claim | `self` (unchanged continuity) |
| anything else | `self:agent:<sha256[:12]>` |
| absent, or no claim recorded yet | `self` |

The last row is what keeps tests and manual tool calls behaving exactly as before.

**Why claiming at SessionStart is safe.** Only a top-level session fires it. I
checked rather than assumed: during a run where eight subagents made 419 tool
calls over 49 minutes, `enacted_fields` recorded **zero** `session_start` ticks,
and `field_runtime_state.last_recovery_at` never moved. So a subagent cannot take
the primary slot from a parent that is idle while its subagents work -- which
rules out the time-based heuristic I first considered, since the parent can be
idle for the whole run.

The claim is last-write-wins, so restarting Claude Code returns the agent to
`self` instead of stranding it under a derived owner.

## Commits, in dependency order

1. **`RuntimeState` accepts `session_id`** -- model only, column does not exist yet
2. **migration 013 adds the column** -- nothing writes it yet
3. **the hooks resolve and claim** -- behaviour change

This order is not cosmetic. `RuntimeState` forbids extra keys, so adding the
column first makes every path that reads runtime state raise at once; the gate
fails closed and the runtime can no longer be repaired from inside. I did that
earlier today and needed help from outside the session to recover.

## Tests

Four new, in `test_efpf_causal.py`:

- a second session gets its own stable owner, and different sessions do not collide
- no session, or no claim yet, still resolves to `self`
- a new top-level session takes over the primary slot
- **committing a field does not erase the claim** -- every tick upserts the runtime
  row, so without `COALESCE` on `session_id` the first commit after SessionStart
  would blank it and the split would silently stop engaging

```
ruff              All checks passed!
pytest kernel     423 passed
pytest social-core 55 passed
uv lock --check   Resolved 191 packages
```

## Note on the hook wiring

The twelve call sites were converted one handler at a time, and the diff looks
more laborious than it needs to. It is deliberate. `pre_tool_use`, `post_tool_use`
and `post_tool_use_failure` receive a `FieldRuntime`, not a `TickProducer`; a
single blanket replace across all twelve left those five referencing an undefined
name, the hook failed closed, and every tool -- including the ones needed to fix
it -- was blocked. Converting the five runtime-scoped sites first, verifying none
remained, and only then replacing the rest keeps every intermediate state valid.

## Not in this PR

No unit test drives `hook_cli` end to end, so the resolver is covered at the
`TickProducer` level and the wiring is covered only by the whole thing continuing
to work while it was edited. A hook-level test with a synthetic subagent payload
would be the honest next step.
