### PR TITLE
fix(individual-kernel): actually claim the primary session from the hook

### DIFF
--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/hook_cli.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/hook_cli.py
@@ -113,6 +113,14 @@ def _summary(value: Any, *, limit: int = 1800) -> str:
 
 
 def session_start(payload: dict[str, Any], producer: TickProducer) -> dict[str, Any]:
+    # Claim before resolving. `_owner_id` reads the stored session, so without
+    # this the runtime never learns which session is primary and every hook --
+    # parent and subagent alike -- resolves to "self", which is the state this
+    # whole mechanism exists to avoid. Claiming for "self" rather than for the
+    # resolved owner is deliberate: only a top-level session fires SessionStart,
+    # so this event is exactly what identifies the primary.
+    if not payload.get("owner_id"):
+        producer.claim_primary_session("self", payload.get("session_id"))
     owner_id = _owner_id(payload, producer)
     recovery = producer.recover_stale_runtime(owner_id)
     field = producer.get_current_field(owner_id)

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_hook_cli.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_hook_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -210,3 +211,149 @@ def test_heartbeat_stop_continuation_is_cross_platform(
     assert result["decision"] == "block"
     assert "finish the release check" in result["reason"]
     db.close()
+
+
+_OWNER_TOOL = "Write"
+_OWNER_INPUT = {"file_path": "/tmp/efpf-owner-fixture", "content": "parent"}
+
+
+def _field_id(result: dict) -> str:
+    context = result["hookSpecificOutput"]["additionalContext"]
+    match = re.search(r'field_id="([^"]+)"', context)
+    assert match is not None, context
+    return match.group(1)
+
+
+def _producer(tmp_path) -> tuple[SocialDB, TickProducer]:
+    db = SocialDB(tmp_path / "hook-social.db")
+    return db, TickProducer(
+        db,
+        interoception_path=tmp_path / "interoception.json",
+        desires_path=tmp_path / "desires.json",
+    )
+
+
+def _register_intention(tmp_path, field_id: str) -> None:
+    db, producer = _producer(tmp_path)
+    FieldRuntime(db, producer=producer).propose_action(
+        ActionProposal(
+            field_id=field_id,
+            tool_name=_OWNER_TOOL,
+            tool_input=_OWNER_INPUT,
+            goal="write the fixture once",
+        )
+    )
+    db.close()
+
+
+def _committed_field_id(tmp_path, owner_id: str) -> str | None:
+    db, producer = _producer(tmp_path)
+    field = producer.get_current_field(owner_id)
+    db.close()
+    return None if field is None else field.field_id
+
+
+def _start_parent_and_register(tmp_path) -> str:
+    _run_hook(
+        tmp_path,
+        "session-start",
+        {
+            "session_id": "parent-session",
+            "hook_event_name": "SessionStart",
+            "source": "startup",
+        },
+    )
+    parent = _run_hook(
+        tmp_path,
+        "user-prompt-submit",
+        {
+            "session_id": "parent-session",
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "write the fixture",
+        },
+    )
+    parent_field_id = _field_id(parent)
+    _register_intention(tmp_path, parent_field_id)
+    return parent_field_id
+
+
+def test_a_subagent_turn_leaves_the_parents_field_and_intention_alone(
+    tmp_path,
+) -> None:
+    """Drive the hooks end to end the way a subagent actually arrives.
+
+    Every hook used to act as owner "self", and only one COMMITTED field is
+    allowed per owner, so a subagent's UserPromptSubmit took the parent's
+    single slot. Resolving the owner from the session id gives the child its
+    own field and its own intention slot; the parent keeps both.
+    """
+    parent_field_id = _start_parent_and_register(tmp_path)
+
+    child = _run_hook(
+        tmp_path,
+        "user-prompt-submit",
+        {
+            "session_id": "child-session",
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "look something up for the parent",
+        },
+    )
+    assert _field_id(child) != parent_field_id
+    assert _committed_field_id(tmp_path, "self") == parent_field_id
+
+    # The child holds no intention of its own and must not spend the parent's.
+    child_gate = _run_hook(
+        tmp_path,
+        "pre-tool-use",
+        {
+            "session_id": "child-session",
+            "hook_event_name": "PreToolUse",
+            "tool_name": _OWNER_TOOL,
+            "tool_input": _OWNER_INPUT,
+            "tool_use_id": "child-write",
+        },
+    )
+    assert child_gate["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    parent_gate = _run_hook(
+        tmp_path,
+        "pre-tool-use",
+        {
+            "session_id": "parent-session",
+            "hook_event_name": "PreToolUse",
+            "tool_name": _OWNER_TOOL,
+            "tool_input": _OWNER_INPUT,
+            "tool_use_id": "parent-write",
+        },
+    )
+    assert parent_gate["hookSpecificOutput"]["permissionDecision"] == "allow", (
+        parent_gate
+    )
+
+
+def test_forcing_one_shared_owner_takes_the_parents_committed_slot(
+    tmp_path,
+) -> None:
+    """Same script, except the child is told to act as "self".
+
+    `_owner_id` honours an explicit `owner_id` in the payload, which reproduces
+    the pre-fix behaviour without editing the live hook: the child's tick
+    occupies the one COMMITTED slot and the parent's field is no longer the
+    committed one. Keeps the test above from passing vacuously.
+    """
+    parent_field_id = _start_parent_and_register(tmp_path)
+
+    child = _run_hook(
+        tmp_path,
+        "user-prompt-submit",
+        {
+            "session_id": "child-session",
+            "owner_id": "self",
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "look something up for the parent",
+        },
+    )
+    child_field_id = _field_id(child)
+
+    assert child_field_id != parent_field_id
+    assert _committed_field_id(tmp_path, "self") == child_field_id


### PR DESCRIPTION
## What

`claim_primary_session` documents itself as "Called from the SessionStart hook, which
only a top-level session fires." Nothing called it. `field_runtime_state.session_id`
stayed NULL, `resolve_owner_id` took its no-claim-recorded fallback, and every session --
the parent and each subagent alike -- resolved to owner `self`.

So per-agent field ownership (#128) shipped inert: one COMMITTED field and one
pending-intention slot shared by everyone, which is exactly the state it was written to
prevent.

`begin_tick` does pass `session_id` through, but only onto the `EnactedField`. The
runtime column is written by `claim_session` alone.

## Why the existing tests missed it

They call `claim_primary_session` directly. That exercises the mechanism and never the
wiring, so the call site could be absent and every assertion still held.

## What is here

- `session_start` claims the primary session before resolving the owner. Ordering
  matters: `_owner_id` reads the stored session, so claiming afterwards would record
  nothing on the first run.
- `test_a_subagent_turn_leaves_the_parents_field_and_intention_alone` drives `hook_cli`
  end to end through subprocess the way a subagent actually arrives: parent SessionStart,
  parent UserPromptSubmit, register an intention, then a subagent UserPromptSubmit.
  Asserts the child gets its own field, the parent's field is still the committed one for
  `self`, the child's PreToolUse is denied, and the parent's is allowed.
- `test_forcing_one_shared_owner_takes_the_parents_committed_slot` runs the same script
  with an explicit `owner_id` of `self` in the child payload. `_owner_id` honours it, so
  this reproduces the pre-fix behaviour without editing the live hook, and keeps the
  first test from passing vacuously.

## Evidence

Replaying the hook sequence against a throwaway database. Before:

```
runtime_state: [{'owner_id': 'self', 'session_id': None}]
resolve(child): self
committed:     [{'owner_id': 'self', 'field_id': 'field_CjOIzt1tyXp-4hyQ'}]
```

After:

```
runtime_state: [{'owner_id': 'self', 'session_id': 'parent-session'},
                {'owner_id': 'self:agent:3e323a7328d0', 'session_id': None}]
resolve(child): self:agent:3e323a7328d0
committed:     [{'owner_id': 'self', 'field_id': 'field_ntSkLcOamC4oZd8x'},
                {'owner_id': 'self:agent:3e323a7328d0', 'field_id': 'field_m8FSSuQUZrQB8AJK'}]
```

## Not in this PR

Whether a subagent fires SessionStart at all. The claim is deliberately scoped to `self`
on the assumption that it does not -- the same assumption `claim_primary_session`'s
docstring records from a measured run. If that turns out to be wrong, a subagent's
SessionStart would steal the primary slot, and the guard belongs here.

## Test plan

- [x] `uv run ruff check consciousness-mcp/packages/individual-kernel-mcp`
- [x] `uv run pytest consciousness-mcp/packages/individual-kernel-mcp/tests` -- 425 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
