### PR TITLE
fix(system-temperature): skip LHM configuration values reported in °C

### DIFF
--- a/system-temperature-mcp/src/system_temperature_mcp/server.py
+++ b/system-temperature-mcp/src/system_temperature_mcp/server.py
@@ -146,6 +146,22 @@ def _run_powershell(script: str) -> str:
         return ""
 
 
+# LHM/OHM reports several *configuration* values in °C alongside real readings:
+# SPD thermal limits on DDR5 DIMMs, NVMe warning/critical thresholds, and the
+# sensor's own resolution. These are constants, not measurements, so including
+# them pins max()/min() to a hardware limit (a DIMM's 85 °C critical limit makes
+# every reading look "hot") and breaks the temperature interpretation. Only
+# newer hardware exposes them, which is why this does not reproduce on older
+# machines.
+_LHM_NON_READINGS = (
+    "Distance to TjMax",       # headroom margin, not a temperature
+    "Limit",                   # Thermal Sensor (Critical) High/Low Limit — SPD
+    "Warning Temperature",     # NVMe SMART threshold
+    "Critical Temperature",    # NVMe SMART threshold
+    "Resolution",              # Temperature Sensor Resolution (e.g. 0.3 °C)
+)
+
+
 def _get_lhm_webserver_temps() -> list[dict[str, Any]]:
     """Get temperatures from a running LibreHardwareMonitor/OpenHardwareMonitor
     "Remote Web Server" (Options -> Remote Web Server -> Run).
@@ -170,9 +186,11 @@ def _get_lhm_webserver_temps() -> list[dict[str, Any]]:
     def walk(node: dict[str, Any]) -> None:
         text = node.get("Text", "")
         value = node.get("Value", "")
-        # "Distance to TjMax" is reported in °C but is a headroom margin,
-        # not an actual temperature reading, so skip it.
-        if value and "°C" in value and "Distance to TjMax" not in text:
+        if (
+            value
+            and "°C" in value
+            and not any(marker in text for marker in _LHM_NON_READINGS)
+        ):
             match = re.search(r"-?\d+(?:[.,]\d+)?", value)
             if match:
                 try:

--- a/system-temperature-mcp/tests/test_server.py
+++ b/system-temperature-mcp/tests/test_server.py
@@ -47,6 +47,145 @@ def test_lhm_webserver_extracts_temperatures(monkeypatch) -> None:
     ]
 
 
+def _lhm_payload_with_configuration_values() -> dict:
+    """A trimmed LHM tree captured from a real machine.
+
+    Source: Intel Core Ultra 7 155H / SK Hynix DDR5 / KIOXIA NVMe, LHM 0.9.6.
+    Alongside real readings, LHM reports hardware *configuration* values in °C:
+    DDR5 SPD exposes thermal limits and the sensor's own resolution, and NVMe
+    exposes SMART warning/critical thresholds. Older hardware does not report
+    these, so this only shows up on newer machines.
+    """
+    return {
+        "Text": "Sensor",
+        "Children": [
+            {
+                "Text": "Intel Core Ultra 7 155H",
+                "Children": [
+                    {
+                        "Text": "Temperatures",
+                        "Children": [
+                            {"Text": "CPU Package", "Value": "47.0 °C", "Children": []},
+                            {"Text": "P-Core #1", "Value": "44.0 °C", "Children": []},
+                            {
+                                "Text": "P-Core #1 Distance to TjMax",
+                                "Value": "53.0 °C",
+                                "Children": [],
+                            },
+                        ],
+                    }
+                ],
+            },
+            {
+                "Text": "SK Hynix - HMCG78AGBSA092N (#0)",
+                "Children": [
+                    {
+                        "Text": "Temperatures",
+                        "Children": [
+                            {"Text": "DIMM #0", "Value": "39.0 °C", "Children": []},
+                            {
+                                "Text": "Temperature Sensor Resolution",
+                                "Value": "0.3 °C",
+                                "Children": [],
+                            },
+                            {
+                                "Text": "Thermal Sensor Low Limit",
+                                "Value": "0.0 °C",
+                                "Children": [],
+                            },
+                            {
+                                "Text": "Thermal Sensor High Limit",
+                                "Value": "55.0 °C",
+                                "Children": [],
+                            },
+                            {
+                                "Text": "Thermal Sensor Critical Low Limit",
+                                "Value": "0.0 °C",
+                                "Children": [],
+                            },
+                            {
+                                "Text": "Thermal Sensor Critical High Limit",
+                                "Value": "85.0 °C",
+                                "Children": [],
+                            },
+                        ],
+                    }
+                ],
+            },
+            {
+                "Text": "KBG6AZNV512G LA KIOXIA",
+                "Children": [
+                    {
+                        "Text": "Temperatures",
+                        "Children": [
+                            {
+                                "Text": "Composite Temperature",
+                                "Value": "35.0 °C",
+                                "Children": [],
+                            },
+                            {
+                                "Text": "Warning Temperature",
+                                "Value": "82.0 °C",
+                                "Children": [],
+                            },
+                            {
+                                "Text": "Critical Temperature",
+                                "Value": "84.0 °C",
+                                "Children": [],
+                            },
+                        ],
+                    }
+                ],
+            },
+        ],
+    }
+
+
+def test_lhm_webserver_skips_configuration_values(monkeypatch) -> None:
+    """Only live readings are collected; limits and specs are not temperatures."""
+    response = io.BytesIO(json.dumps(_lhm_payload_with_configuration_values()).encode())
+    monkeypatch.setattr(server.urllib.request, "urlopen", lambda *_args, **_kwargs: response)
+
+    temperatures = server._get_lhm_webserver_temps()
+
+    assert [t["name"] for t in temperatures] == [
+        "CPU Package",
+        "P-Core #1",
+        "DIMM #0",
+        "Composite Temperature",
+    ]
+    # The DIMM's 0.0 °C low limit would otherwise become the minimum, and its
+    # 85.0 °C critical limit the maximum.
+    values = [t["temperature_celsius"] for t in temperatures]
+    assert (min(values), max(values)) == (35.0, 47.0)
+
+
+def test_configuration_values_do_not_change_the_reported_feeling(monkeypatch) -> None:
+    """Regression: a DDR5 critical limit must not be felt as body heat.
+
+    Before configuration values were filtered out, a DIMM's 85.0 °C critical
+    limit became max_temp, so the server reported severe heat while the CPU was
+    idling in the 40s. Asserting against the readings-only verdict keeps this
+    independent of how the feelings themselves are worded.
+    """
+    response = io.BytesIO(json.dumps(_lhm_payload_with_configuration_values()).encode())
+    monkeypatch.setattr(server.urllib.request, "urlopen", lambda *_args, **_kwargs: response)
+
+    from_lhm = server.interpret_temperature(server._get_lhm_webserver_temps())
+    readings_only = server.interpret_temperature([
+        {"source": "lhm_webserver", "name": "CPU Package", "temperature_celsius": 47.0},
+        {"source": "lhm_webserver", "name": "P-Core #1", "temperature_celsius": 44.0},
+        {"source": "lhm_webserver", "name": "DIMM #0", "temperature_celsius": 39.0},
+        {
+            "source": "lhm_webserver",
+            "name": "Composite Temperature",
+            "temperature_celsius": 35.0,
+        },
+    ])
+
+    assert from_lhm == readings_only
+
+
 def test_windows_temperature_prefers_lhm_webserver(monkeypatch) -> None:
     expected = [
         {


### PR DESCRIPTION
## Problem

On Windows via the LibreHardwareMonitor web server path, `get_system_temperature`
reports severe heat on a completely idle machine — the `>= 80 °C` branch fires
while the CPU sits in the 40s.

## Cause

`_get_lhm_webserver_temps()` collects every node whose `Value` contains `°C`,
excluding only `Distance to TjMax`. But LHM also reports hardware
*configuration* values in °C alongside real readings:

| Node | Value | What it actually is |
|---|---|---|
| `Thermal Sensor Critical High Limit` | 85.0 °C | DDR5 SPD limit — **became `max_temp`** |
| `Thermal Sensor High Limit` | 55.0 °C | DDR5 SPD limit |
| `Thermal Sensor (Critical) Low Limit` | 0.0 °C | DDR5 SPD limit — also broke `min()` |
| `Warning Temperature` / `Critical Temperature` | 82.0 / 84.0 °C | NVMe SMART thresholds |
| `Temperature Sensor Resolution` | 0.3 °C | not a temperature at all |

They are constants, so the reported feeling was pinned to a DIMM's critical
limit and never reflected the machine's actual state. On my machine 53 nodes
carry `°C`; only 22 are readings.

## Why this may not reproduce for you

Older hardware does not expose these sensors — they come from DDR5 SPD thermal
sensors and NVMe SMART thresholds, so this only appears on newer machines.
Captured on Intel Core Ultra 7 155H / SK Hynix DDR5 / KIOXIA NVMe, LHM 0.9.6.

## Fix

Extend the existing `Distance to TjMax` exclusion into `_LHM_NON_READINGS` and
filter every node against it.

## Verifying without the hardware

Two regression tests are included, built from a trimmed real LHM tree, so this
is checkable on macOS/Linux with neither LHM nor Windows:

- `test_lhm_webserver_skips_configuration_values`
- `test_configuration_values_do_not_change_the_reported_feeling` — asserts the
  verdict with configuration values present equals the verdict computed from
  readings only, so it hard-codes none of the feeling strings.

Reverting `_LHM_NON_READINGS` to `("Distance to TjMax",)` turns both red
(`max` becomes 85.0 and the output flips to the `>= 80` branch).

Scope is limited to `system-temperature-mcp/`; the WMI and ACPI paths are untouched.

---

## 日本語

### 症状

Windows の LibreHardwareMonitor Web サーバー経路で、**完全にアイドルな機体なのに
`get_system_temperature` が「かなり熱い」と報告します**（`>= 80 °C` の分岐が発火）。
実際の CPU は 40℃台です。

### 原因

`_get_lhm_webserver_temps()` は `Value` に `°C` を含むノードを全て温度として集めており、
除外しているのは `Distance to TjMax` の 1 件だけです。しかし LHM は実測値と並べて、
**ハードウェアの設定値**も °C 付きで返してきます。

| ノード | 値 | 正体 |
|---|---|---|
| `Thermal Sensor Critical High Limit` | 85.0 °C | DDR5 SPD の限界値 — **これが `max_temp` になっていた** |
| `Thermal Sensor High Limit` | 55.0 °C | DDR5 SPD の上限設定値 |
| `Thermal Sensor (Critical) Low Limit` | 0.0 °C | DDR5 SPD の下限設定値 — `min()` も壊していた |
| `Warning Temperature` / `Critical Temperature` | 82.0 / 84.0 °C | NVMe の SMART 閾値 |
| `Temperature Sensor Resolution` | 0.3 °C | センサー分解能。そもそも温度ではない |

これらは定数なので、報告される「体感」は DIMM の臨界設定値に張り付いたままになり、
実際の機体の状態を一度も反映していませんでした。手元の環境では `°C` を持つノードが
53 個あり、そのうち実測値は 22 個だけです。

### 再現しない可能性について

**古いハードウェアはこれらのセンサーを出しません。** DDR5 の SPD 温度センサーと
NVMe の SMART 閾値に由来するため、比較的新しい機体でしか現れません。採取環境は
Intel Core Ultra 7 155H / SK Hynix DDR5 / KIOXIA NVMe、LHM 0.9.6 です。

### 修正内容

既存の `Distance to TjMax` 除外を `_LHM_NON_READINGS` として一般化し、
全ノードをそれで濾します。

### ハードウェア無しでの検証方法

実機の LHM ツリーを削って作ったフィクスチャによる回帰テストを 2 本同梱したので、
**LHM も Windows も無い macOS / Linux 上で確認できます。**

- `test_lhm_webserver_skips_configuration_values`
- `test_configuration_values_do_not_change_the_reported_feeling` — 「設定値が混ざった場合」と
  「実測値だけの場合」で判定が一致することを assert しています。体感の文言そのものは
  固定していないので、後からメッセージを変更してもテストは壊れません。

`_LHM_NON_READINGS` を `("Distance to TjMax",)` に戻すと両方とも赤になります
（`max` が 85.0 になり、出力が `>= 80` の分岐に切り替わる）。

変更範囲は `system-temperature-mcp/` のみで、WMI 経路と ACPI 経路には触れていません。
