### PR TITLE
fix(memory): survive losing the HTTP recall port to another process

### DIFF
--- a/memory-mcp/src/memory_mcp/server.py
+++ b/memory-mcp/src/memory_mcp/server.py
@@ -3,7 +3,8 @@
 import asyncio
 import json
 import logging
-from contextlib import asynccontextmanager
+from collections.abc import Awaitable, Callable
+from contextlib import AsyncExitStack, asynccontextmanager
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +21,30 @@ from .types import CameraPosition
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+async def _start_http_recall_server(
+    handler: Callable[[asyncio.StreamReader, asyncio.StreamWriter], Awaitable[None]],
+    port: int,
+) -> asyncio.Server | None:
+    """Bind the local HTTP recall endpoint, best effort.
+
+    The port is a shared, machine-wide resource: a second Claude Code window, or a
+    memory-mcp process that outlived its client, may already hold it. Losing that
+    race must not take down the MCP server — the stdio tools work regardless of who
+    owns the HTTP endpoint — so a bind failure is logged and reported as ``None``.
+    """
+    try:
+        server = await asyncio.start_server(handler, "127.0.0.1", port)
+    except OSError as e:
+        logger.warning(
+            f"HTTP recall endpoint unavailable on 127.0.0.1:{port} ({e}). "
+            "Another memory-mcp process is likely holding it; "
+            "MCP tools remain fully functional."
+        )
+        return None
+    logger.info(f"HTTP recall endpoint listening on 127.0.0.1:{port}")
+    return server
 
 
 class MemoryMCPServer:
@@ -1691,20 +1716,22 @@ Date Range:
     async def run(self) -> None:
         """Run the MCP server."""
         async with self.run_context():
-            # Start lightweight HTTP recall server
+            # Start the lightweight HTTP recall server. Binding is best effort;
+            # see _start_http_recall_server for why losing the port is survivable.
             http_port = int(__import__("os").environ.get("MEMORY_HTTP_PORT", "18900"))
-            http_server = await asyncio.start_server(
-                self._handle_http_recall, "127.0.0.1", http_port
+            http_server = await _start_http_recall_server(
+                self._handle_http_recall, http_port
             )
-            logger.info(f"HTTP recall endpoint listening on 127.0.0.1:{http_port}")
 
-            async with http_server:
-                async with stdio_server() as (read_stream, write_stream):
-                    await self._server.run(
-                        read_stream,
-                        write_stream,
-                        self._server.create_initialization_options(),
-                    )
+            async with AsyncExitStack() as stack:
+                if http_server is not None:
+                    await stack.enter_async_context(http_server)
+                read_stream, write_stream = await stack.enter_async_context(stdio_server())
+                await self._server.run(
+                    read_stream,
+                    write_stream,
+                    self._server.create_initialization_options(),
+                )
 
 
 def main() -> None:

--- a/memory-mcp/tests/test_http_recall_port.py
+++ b/memory-mcp/tests/test_http_recall_port.py
@@ -1,0 +1,41 @@
+"""The HTTP recall endpoint must never be able to take the MCP server down."""
+
+from __future__ import annotations
+
+import asyncio
+
+from memory_mcp.server import _start_http_recall_server
+
+
+async def _noop_handler(
+    _reader: asyncio.StreamReader, _writer: asyncio.StreamWriter
+) -> None:  # pragma: no cover - the tests never open a connection
+    return None
+
+
+async def test_binds_when_the_port_is_free() -> None:
+    server = await _start_http_recall_server(_noop_handler, 0)
+
+    assert server is not None
+    try:
+        assert server.sockets
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+async def test_returns_none_when_the_port_is_already_held() -> None:
+    """A second holder of the port must degrade to stdio-only, not crash.
+
+    The bind previously raised straight out of ``run()``, so a second Claude Code
+    window took down that window's memory-mcp entirely — even though its stdio
+    tools never needed the HTTP endpoint in the first place.
+    """
+    holder = await asyncio.start_server(_noop_handler, "127.0.0.1", 0)
+    port = holder.sockets[0].getsockname()[1]
+
+    try:
+        assert await _start_http_recall_server(_noop_handler, port) is None
+    finally:
+        holder.close()
+        await holder.wait_closed()


### PR DESCRIPTION
## Problem

Opening a second Claude Code window kills memory-mcp in that window.

The recall endpoint binds a fixed, machine-wide port (`MEMORY_HTTP_PORT`,
default `18900`). If anything already holds it — another window, or a
memory-mcp process that outlived its client — `asyncio.start_server` raises
straight out of `run()` and takes the whole MCP server down.

The stdio tools never needed that port. The window loses its memory entirely
over an endpoint it was not using.

## Reproduce

Open two Claude Code windows with memory-mcp configured. The second one's
`remember` / `recall` tools are gone, with `[Errno 48] address already in use`
(`WSAEADDRINUSE` / `[Errno 10048]` on Windows) in the log.

This is not platform specific — the port is contended the same way everywhere.

## Fix

Extract the bind into `_start_http_recall_server()`, which logs a warning and
returns `None` on `OSError`, and enter the server context conditionally through
`AsyncExitStack` so the stdio server still starts when the port is unavailable.

Losing the race now degrades to stdio-only rather than to nothing. Whoever won
the port keeps serving the HTTP endpoint, which is the behaviour the endpoint
was designed for anyway.

## Tests

`memory-mcp/tests/test_http_recall_port.py` covers both outcomes:

- `test_binds_when_the_port_is_free` — returns a live `asyncio.Server`
- `test_returns_none_when_the_port_is_already_held` — occupies a port itself,
  then asserts the helper returns `None` instead of raising

Full suite: 246 passed, `ruff check` clean.

---

## 日本語

### 症状

**Claude Code のウィンドウを 2 枚開くと、2 枚目の memory-mcp が丸ごと死にます。**

recall エンドポイントは固定のマシン共有ポート（`MEMORY_HTTP_PORT`、既定 `18900`）を
bind します。既に誰かが握っている場合——別ウィンドウ、あるいはクライアントより長生き
してしまった memory-mcp プロセス——`asyncio.start_server` の例外が `run()` の外へ
そのまま抜け、MCP サーバー全体を道連れにします。

stdio のツール群はそのポートを必要としていません。**使ってもいないエンドポイントの
せいで、そのウィンドウは記憶を丸ごと失います。**

### 再現手順

memory-mcp を設定した Claude Code を 2 枚開くだけです。2 枚目では `remember` /
`recall` が消え、ログに `[Errno 48] address already in use`（Windows なら
`WSAEADDRINUSE` / `[Errno 10048]`）が出ます。

**プラットフォーム固有の問題ではありません。** ポートの奪い合いはどの環境でも同じに
起こります。

### 修正内容

bind を `_start_http_recall_server()` に切り出し、`OSError` を捕まえて警告ログを出し
`None` を返すようにしました。`AsyncExitStack` で条件付きに context へ入れることで、
ポートが取れなくても stdio サーバーは起動します。

競争に負けた場合の結果が「全部死ぬ」から「stdio のみで動く」に変わります。ポートを
取った側は HTTP エンドポイントを提供し続けるので、そもそもこのエンドポイントが
想定していた姿に落ち着きます。

### テスト

`memory-mcp/tests/test_http_recall_port.py` に 2 ケース追加しました。

- `test_binds_when_the_port_is_free` — 生きた `asyncio.Server` が返ること
- `test_returns_none_when_the_port_is_already_held` — テスト自身がポートを占有し、
  例外ではなく `None` が返ることを確認

全体テストは 246 passed、`ruff check` もクリーンです。
