### PR TITLE
fix(desire-system): make the agent's own name configurable

### DIFF
--- a/desire-system/.env.example
+++ b/desire-system/.env.example
@@ -5,6 +5,13 @@
 # 一緒にいる人の名前（miss_companion 欲求で呼びかける相手）
 COMPANION_NAME=コウタ
 
+# 自分（エージェント）の名前と一人称（identity_coherence 欲求で使う）
+# 未設定だと "自分" になる。エージェントの名乗りと合っていないと
+# identity_coherence のキーワードが一致せず、自己同一性の欲求だけが
+# 満たされにくくなる（エラーは出ないので気づけない）。
+SELF_NAME=ここね
+SELF_PRONOUN=ウチ
+
 # ChromaDB の場所（memory-mcp と合わせる）
 # MEMORY_DB_PATH=~/.claude/memories/chroma
 # MEMORY_COLLECTION_NAME=claude_memories

--- a/desire-system/desire_updater.py
+++ b/desire-system/desire_updater.py
@@ -1,5 +1,5 @@
 """
-Desire Updater - ここねの自発的な欲求レベルを計算してJSONに保存する。
+Desire Updater - エージェントの自発的な欲求レベルを計算してJSONに保存する。
 
 ChromaDB（memory-mcp）から各欲求に関連する最新記憶のタイムスタンプを取得し、
 「最後に〇〇してから何時間か」を計算して欲求レベル(0.0〜1.0)を算出する。
@@ -50,6 +50,14 @@ DESIRES_PATH = Path(
 # 一緒にいる人の名前（miss_companion 欲求で使う）
 COMPANION_NAME = os.getenv("COMPANION_NAME", "あなた")
 
+# 自分（エージェント）の名前と一人称（identity_coherence 欲求で使う）。
+# COMPANION_NAME と対になる設定。ここを固定名にすると、別の名前で運用している
+# エージェントでは identity_coherence のキーワードが一致せず、自己同一性の欲求
+# だけが満たされにくくなる。しかもキーワード不一致はエラーを出さないため、
+# 「最近その話をしていないだけ」と区別がつかない。
+SELF_NAME = os.getenv("SELF_NAME", "自分")
+SELF_PRONOUN = os.getenv("SELF_PRONOUN", "自分")
+
 # JST timezone
 JST = timezone(timedelta(hours=9))
 
@@ -99,10 +107,10 @@ DESIRE_CONFIGS: dict[str, DesireConfig] = {
         satisfaction_hours=float(os.getenv("DESIRE_IDENTITY_COHERENCE_HOURS", "1.0")),
         set_point=0.9,
         keywords=[
-            "ここねとして", "ウチは", "自分がここね", "記憶を引いた",
-            "recallした", "思い出した",
+            f"{SELF_NAME}として", f"{SELF_PRONOUN}は", f"自分が{SELF_NAME}",
+            "記憶を引いた", "recallした", "思い出した",
         ],
-        label="自分がここねである確信",
+        label=f"自分が{SELF_NAME}である確信",
     ),
     "cognitive_load": DesireConfig(
         satisfaction_hours=float(os.getenv("DESIRE_COGNITIVE_LOAD_HOURS", "1.5")),

--- a/desire-system/pyproject.toml
+++ b/desire-system/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "desire-system"
 version = "0.4.6"
-description = "Autonomous desire system for embodied Claude - gives Kokone inner drives"
+description = "Autonomous desire system for embodied Claude - gives the agent inner drives"
 requires-python = ">=3.10"
 dependencies = [
     "chromadb>=0.5.0",

--- a/desire-system/server.py
+++ b/desire-system/server.py
@@ -1,5 +1,5 @@
 """
-Desire System MCP Server - ここねの自発的な欲求レベルを提供する。
+Desire System MCP Server - エージェントの自発的な欲求レベルを提供する。
 
 v2: ホメオスタシス/アロスタシス対応
 - 不快度（discomfort）表示
@@ -19,7 +19,13 @@ from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool
 
 from backend import make_default_adapter
-from desire_updater import DESIRE_CONFIGS, compute_desires, save_desires
+from desire_updater import (
+    COMPANION_NAME,
+    DESIRE_CONFIGS,
+    SELF_NAME,
+    compute_desires,
+    save_desires,
+)
 
 # 欲求レベル読み込み元
 # expanduser() for the same reason as in desire_updater.py: .env supplies the
@@ -87,7 +93,7 @@ async def list_tools() -> list[Tool]:
         Tool(
             name="get_desires",
             description=(
-                "Get Kokone's current desire levels and discomfort (homeostasis). "
+                f"Get {SELF_NAME}'s current desire levels and discomfort (homeostasis). "
                 "Discomfort = distance from set point. "
                 "When discomfort >= 0.5: pick ONE bounded action that fits the "
                 "current context (prefer private/non-interruptive during quiet "
@@ -95,7 +101,7 @@ async def list_tools() -> list[Tool]:
                 "per tick. Desires bias attention; they are not a command queue. "
                 "browse_curiosity -> WebSearch something interesting; "
                 "look_outside -> use camera to look outside; "
-                "miss_companion -> talk to コウタ proactively; "
+                f"miss_companion -> talk to {COMPANION_NAME} proactively; "
                 "observe_room -> use camera to observe room; "
                 "identity_coherence -> recall memories to reinforce self-model; "
                 "cognitive_load -> think about or discuss something interesting."
@@ -151,7 +157,7 @@ async def list_tools() -> list[Tool]:
             description=(
                 "Boost a desire level due to novelty/surprise (dopamine/prediction error). "
                 "Call when you feel surprised or encounter unexpected info. "
-                "e.g. コウタ says something unexpected -> boost browse_curiosity; "
+                f"e.g. {COMPANION_NAME} says something unexpected -> boost browse_curiosity; "
                 "camera shows something unusual -> boost observe_room; "
                 "identity feels unstable -> boost identity_coherence. "
                 "Simulates dopamine response to novelty."

--- a/desire-system/tests/test_homeostasis.py
+++ b/desire-system/tests/test_homeostasis.py
@@ -1,5 +1,6 @@
 """Tests for homeostasis / allostasis extensions to the desire system."""
 
+import importlib
 import json
 import tempfile
 from datetime import datetime, timedelta, timezone
@@ -8,6 +9,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import desire_updater
 from desire_updater import (
     DESIRE_CONFIGS,
     DesireState,
@@ -40,9 +42,38 @@ class TestDesireConfig:
         assert "cognitive_load" in DESIRE_CONFIGS
 
     def test_identity_coherence_set_point_is_high(self):
-        """identity_coherence のセットポイントは高い（自分がここねである確信）"""
+        """identity_coherence のセットポイントは高い（自分が自分である確信）"""
         cfg = DESIRE_CONFIGS["identity_coherence"]
         assert cfg.set_point >= 0.8
+
+    def test_identity_coherence_follows_self_name(self, monkeypatch):
+        """identity_coherence は SELF_NAME / SELF_PRONOUN に追従する。
+
+        エージェント名がベタ書きだと、別の名前で運用している個体では
+        キーワードが一致せず、自己同一性の欲求だけが満たされにくくなる。
+        キーワード不一致は例外もログも出さないため、「最近その話題が
+        なかっただけ」と区別がつかない。
+        """
+        monkeypatch.setenv("SELF_NAME", "クロコ")
+        monkeypatch.setenv("SELF_PRONOUN", "わたし")
+        module = importlib.reload(desire_updater)
+        try:
+            cfg = module.DESIRE_CONFIGS["identity_coherence"]
+
+            assert "クロコとして" in cfg.keywords
+            assert "わたしは" in cfg.keywords
+            assert "自分がクロコ" in cfg.keywords
+            assert cfg.label == "自分がクロコである確信"
+
+            # 名前に依存しないキーワードは残す（recall 由来の満足を拾うため）
+            assert "思い出した" in cfg.keywords
+
+            # 別名の痕跡が残っていないこと
+            assert not any("ここね" in kw for kw in cfg.keywords)
+            assert "ここね" not in cfg.label
+        finally:
+            monkeypatch.undo()
+            importlib.reload(desire_updater)
 
     def test_original_desires_preserved(self):
         """既存の4欲求が残っている"""


### PR DESCRIPTION
## Problem

The `identity_coherence` desire is harder to satisfy for any deployment whose
agent is not named ここね.

```python
"identity_coherence": DesireConfig(
    set_point=0.9,
    keywords=[
        "ここねとして", "ウチは", "自分がここね",   # hardcoded
        "記憶を引いた", "recallした", "思い出した",
    ],
    label="自分がここねである確信",                  # hardcoded
),
```

Three of the six satisfaction keywords are bound to a specific name and
first-person pronoun, so they never match elsewhere. The label also tells every
other agent that it is ここね.

## Why it is hard to notice

A keyword miss raises nothing and logs nothing. The desire level is derived
purely from the latest matching timestamp returned by
`latest_satisfaction_ts()`, so from the outside the degraded state is
indistinguishable from "that topic simply hasn't come up lately".

Neither the operator nor the agent can see it.

## The mechanism already exists, one block above

`miss_companion` in the same file is already parameterised, with a neutral
default:

```python
COMPANION_NAME = os.getenv("COMPANION_NAME", "あなた")
...
"miss_companion": DesireConfig(
    keywords=[
        f"{COMPANION_NAME}の顔を見た", f"{COMPANION_NAME}を見た", ...
    ],
    label=f"{COMPANION_NAME}に会いたい",
),
```

So the real issue is an asymmetry: **the human's name is configurable with a
neutral default, while the agent's own name has no counterpart.**

## Fix

Add `SELF_NAME` and `SELF_PRONOUN` following the same convention (neutral
defaults, real values in `.env.example`) and use them for the
`identity_coherence` keywords and label:

```python
SELF_NAME = os.getenv("SELF_NAME", "自分")
SELF_PRONOUN = os.getenv("SELF_PRONOUN", "自分")
...
keywords=[
    f"{SELF_NAME}として", f"{SELF_PRONOUN}は", f"自分が{SELF_NAME}",
    "記憶を引いた", "recallした", "思い出した",
],
label=f"自分が{SELF_NAME}である確信",
```

The three name-independent keywords (`記憶を引いた` / `recallした` /
`思い出した`) are kept, so recall-driven satisfaction still counts.

### Tool descriptions too

Two descriptions in `server.py` named コウタ and Kokone directly:

```
get_desires   : "Get Kokone's current desire levels..."
                "miss_companion -> talk to コウタ proactively; "
boost_desire  : "e.g. コウタ says something unexpected -> boost browse_curiosity; "
```

Tool descriptions are **model input, not documentation**, so a fixed name there
instructs the agent to address someone who may not exist. These now use the
same variables.

## Effect on existing setups

Behaviour is unchanged once `.env` carries the following (already added to
`.env.example`):

```dotenv
SELF_NAME=ここね
SELF_PRONOUN=ウチ
```

Defaults are neutral, so — exactly like `COMPANION_NAME` — leaving it unset
gives generic behaviour and setting it gives the specific persona.

## Tests

Added `test_identity_coherence_follows_self_name`: it swaps `SELF_NAME` /
`SELF_PRONOUN`, reloads the module, and asserts that the keywords and label
follow, that the name-independent keywords survive, and that no trace of the
previous name remains.

Against the pre-fix code this test fails (the keywords stay `"ここねとして"`).

- `desire-system`: **60 passed**
- `ruff check desire-system/`: **All checks passed**

## Not included here

Two more instances of deployment-specific values living in shared code. I will
open a separate issue rather than widen this PR:

- `get_allostatic_set_point()` hardcodes JST and the 0–5h quiet window
- `system-temperature-mcp`'s `get_current_time` / `interpret_temperature`
  return sentences fixed in one particular speaking style

---

## 日本語

### 症状

`identity_coherence` の欲求が、**エージェント名が「ここね」以外の環境では満たされ
にくくなります。**

6 つのキーワードのうち **3 つが名前と一人称に依存**しているため、別の名前で運用
している個体では発火しません。ラベルも、その個体に対して「自分がここねである確信」
と表示されます。

### なぜ気づきにくいか

キーワードの不一致は**例外もログも出しません**。欲求レベルは
`latest_satisfaction_ts()` が返す最終一致時刻から計算されるだけなので、外から見た
挙動は「最近その話題が出ていない」と完全に同じです。

運用者からもエージェント自身からも、劣化していることが見えません。

### 直下に前例があります

同じファイルの `miss_companion` は、既に `COMPANION_NAME`（既定値 `"あなた"`）で
正しくパラメータ化されています。

**人間側の名前には中立な既定値つきの設定があるのに、エージェント自身の名前には対に
なる設定が無い**、という非対称が本体です。仕組みは既にあり、隣のブロックで使われて
いません。

### 修正

`COMPANION_NAME` と同じ規約（中立な既定値・実値は `.env.example`）で `SELF_NAME` と
`SELF_PRONOUN` を追加し、`identity_coherence` のキーワードとラベルに通しました。
名前に依存しない 3 つ（`記憶を引いた` / `recallした` / `思い出した`）は、recall 由来
の満足を引き続き拾うためそのまま残しています。

`server.py` のツール説明文 2 箇所も同じ変数を通しました。ツール説明文は**ドキュメント
ではなくモデルへの入力**なので、ここに固定名があると、存在しない相手に話しかけるよう
指示することになります。

### 既存環境への影響

`.env` に `SELF_NAME=ここね` / `SELF_PRONOUN=ウチ` を足せば**挙動は完全に元のまま**
です（`.env.example` に記載済み）。既定値は中立なので、`COMPANION_NAME` と同じく
「設定しなければ汎用、設定すれば固有」になります。

### テスト

`test_identity_coherence_follows_self_name` を追加しました。修正前のコードに対して
は失敗します。`desire-system` 全体 **60 passed**、`ruff check` も **All checks
passed** です。

### このPRに含めていないもの

同じ「共有コードに個体固有の値が入っている」系として 2 件。別途 issue に上げます。

- `get_allostatic_set_point()` が JST と深夜帯（0-5時）を固定している
- `system-temperature-mcp` の `get_current_time` / `interpret_temperature` の応答文
  が特定の口調で固定されている
