### PR TITLE
fix(individual-kernel): stop the sleep tests inheriting the runner's locale and separator

### DIFF
--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_sleep.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_sleep.py
@@ -185,10 +185,30 @@ class TestBriefingPersistence:
         )
         result = consolidator.run()
         assert path.exists()
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         assert "summary_line" in data
         assert "counterfactual_count" in data
         assert result.briefing_path == str(path)
+
+    def test_briefing_is_written_as_utf8(self, social_db, tmp_path):
+        """summary_line is always Japanese, so the file is never pure ASCII.
+
+        SleepConsolidator pins encoding="utf-8" on the write; nothing asserted it.
+        Reading the raw bytes keeps the on-disk encoding independent of the
+        locale of whoever runs the suite.
+        """
+        path = tmp_path / "morning_briefing.json"
+        store = CounterfactualStore(social_db)
+        consolidator = SleepConsolidator(
+            db=social_db,
+            counterfactual_store=store,
+            briefing_path=path,
+            is_quiet_hours=_quiet_yes,
+            clock=_fixed_clock(),
+        )
+        consolidator.run()
+        data = json.loads(path.read_bytes().decode("utf-8"))
+        assert not data["summary_line"].isascii()
 
     def test_dry_run_does_not_write(self, social_db, tmp_path):
         path = tmp_path / "morning_briefing.json"
@@ -232,7 +252,7 @@ class TestMorningBriefingShape:
             clock=_fixed_clock(),
         )
         consolidator.run()
-        data = json.loads(Path(path).read_text())
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
         # MorningBriefing must be re-constructible from disk JSON
         briefing = MorningBriefing(**data)
         assert briefing.summary_line == data["summary_line"]
@@ -242,4 +262,7 @@ def test_default_briefing_path_is_under_claude_dir():
     """The shipping default lives under ~/.claude/ so autonomous-action.sh can find it."""
     from individual_kernel_mcp.sleep import DEFAULT_BRIEFING_PATH
 
-    assert str(DEFAULT_BRIEFING_PATH).endswith(".claude/morning_briefing.json")
+    assert Path(DEFAULT_BRIEFING_PATH).parts[-2:] == (
+        ".claude",
+        "morning_briefing.json",
+    )


### PR DESCRIPTION
## Problem

`test_sleep.py` fails on Windows with a Japanese locale (`ACP=932`), on code that
is correct.

```
FAILED tests/test_sleep.py::TestBriefingPersistence::test_briefing_written_to_path
FAILED tests/test_sleep.py::TestMorningBriefingShape::test_briefing_serializes_round_trip
FAILED tests/test_sleep.py::test_default_briefing_path_is_under_claude_dir
3 failed, 422 passed
```

The first two raise `UnicodeDecodeError: 'cp932' codec can't decode byte 0x81`.
The third is an `AssertionError`.

`SleepConsolidator` itself is fine — `sleep.py:163-166` already pins
`encoding="utf-8"` on the write. Only the tests are platform-bound.

## Cause

Two separate assumptions, both about the machine rather than about the code
under test.

**1. The reads inherit the locale.** `Path.read_text()` with no `encoding=`
uses `locale.getencoding()`, which is `cp932` here and `utf-8` on the CI runners.

```python
data = json.loads(path.read_text())            # :188
data = json.loads(Path(path).read_text())      # :235
```

The file is never pure ASCII, so this is not an edge case. `_build_summary_line()`
returns a Japanese sentence unconditionally (`sleep.py:183-186`), and the write
uses `ensure_ascii=False`, so every briefing this suite produces contains
multi-byte characters:

```python
return f"前夜の振り返り：拒否した選択肢 {cf_count} 件、解釈の更新 {shift_count} 件"
```

**2. The path assertion hard-codes the POSIX separator.**

```python
assert str(DEFAULT_BRIEFING_PATH).endswith(".claude/morning_briefing.json")   # :245
```

`DEFAULT_BRIEFING_PATH` is a `Path` (`sleep.py:34`), so on Windows `str()` renders
it as `C:\Users\...\.claude\morning_briefing.json` and the suffix never matches.
The path is correct; only the way the test looks at it is not.

## Why CI does not catch it

Two independent reasons, so neither job is at fault.

- The Ubuntu job **does** run this package (`ci.yml:45`), but its locale is UTF-8,
  so `read_text()` happens to agree with the writer and the tests pass for the
  wrong reason — they are not actually asserting anything about encoding.
- The Windows job runs a fixed list of six files (`ci.yml:86-94`), and
  `test_sleep.py` is not among them.

So the locale-dependent path is never exercised anywhere.

## Fix

Same shape as #107, which already forced UTF-8 on the hook's stdin/stdout for
this reason.

- pass `encoding="utf-8"` explicitly at both read sites
- compare `Path.parts[-2:]` instead of a separator-bearing string, which is what
  the docstring means (`~/.claude/`) and is true on every platform

No production code is touched, and no behaviour changes on a UTF-8 locale.

## Tests

The three repaired assertions are strictly stronger than what they replace, and
one test is added.

**`test_briefing_is_written_as_utf8`** (new) reads the raw bytes and decodes them
as UTF-8, so the on-disk encoding no longer depends on who runs the suite. It
pins the `encoding="utf-8"` that `sleep.py` deliberately sets and that nothing
asserted until now.

```python
data = json.loads(path.read_bytes().decode("utf-8"))
assert not data["summary_line"].isascii()
```

Verified by reverting the production code, on this machine:

| Reverted | Result |
|---|---|
| drop `encoding="utf-8"` from `sleep.py:165` | `3 failed, 10 passed` — including the new test |
| drop `".claude"` from `DEFAULT_BRIEFING_PATH` | `test_default_briefing_path_is_under_claude_dir` red |

Before this change the first revert stayed **green**, because the reader and the
writer both followed the same locale. That is the regression this closes.

- `consciousness-mcp/packages/individual-kernel-mcp`: **426 passed** (was 3 failed
  / 422 passed)
- `ruff check .`: **All checks passed**

### Where the new test has no teeth

On a UTF-8 locale, dropping `encoding="utf-8"` from `sleep.py` still produces a
UTF-8 file, so `test_briefing_is_written_as_utf8` stays green there. It only
fails where the contract actually matters. I could not find a way to force a
non-UTF-8 locale from inside pytest — `Path.write_text` resolves the default
encoding below the Python level, so monkeypatching `locale` does not reach it.
If you would rather not carry a test that is inert on your machine, I am happy to
drop it and keep only the three repairs.

## Not included here

Scope is limited to `test_sleep.py`. Two related things are deliberately left out:

- **The same omission in production code.** `scripts/doctor.py:393`,
  `scripts/setup_io.py:64` and `memory-mcp/src/memory_mcp/metacognition.py:83,97`
  read or write text without an explicit encoding, and the failures there are
  worse than a red test — `setup_io.py` corrupts silently rather than raising.
  I will send that separately with its own reproduction, since it is a behaviour
  change rather than a test repair.
- **CI locale coverage.** Adding a `ja-JP` (or any non-UTF-8) locale to the matrix
  would catch this class of bug, but that is a cost decision about your CI budget,
  so I would rather raise it than slip it into this PR.

## Environment

- Windows 10 Pro, build 19045 (x64), Japanese locale (`ACP=932`, `locale.getencoding()` → `cp932`)
- Python 3.13.15 (uv-managed), uv 0.12.4
- `origin/main` @ `5177184`

---

## 日本語

### 症状

**Windows の日本語ロケール（`ACP=932`）で `test_sleep.py` が 3 件落ちます。**
落ちているのはテストだけで、対象のコードは正しい状態です。

```
3 failed, 422 passed
```

前 2 件は `UnicodeDecodeError: 'cp932' codec can't decode byte 0x81`、
残り 1 件は `AssertionError` です。

`SleepConsolidator` 自体は問題ありません。`sleep.py:163-166` は書き込み時に
`encoding="utf-8"` を明示しています。環境に縛られているのはテスト側だけです。

### 原因

「テスト対象」ではなく「実行マシン」に依存した仮定が 2 つあります。

**1. 読み出しがロケールを継いでいる。** `encoding=` 無しの `Path.read_text()` は
`locale.getencoding()` を使います。手元では `cp932`、CI ランナーでは `utf-8` です。

```python
data = json.loads(path.read_text())            # :188
data = json.loads(Path(path).read_text())      # :235
```

**このファイルが純 ASCII になることはありません。** 稀な入力の話ではなく、
`_build_summary_line()` が無条件に日本語の文を返し（`sleep.py:183-186`）、
書き込みが `ensure_ascii=False` なので、このスイートが生成する briefing には
必ずマルチバイト文字が入ります。

**2. パスの assert が POSIX 区切りを決め打ちしている。**

```python
assert str(DEFAULT_BRIEFING_PATH).endswith(".claude/morning_briefing.json")   # :245
```

`DEFAULT_BRIEFING_PATH` は `Path` です（`sleep.py:34`）。Windows では `str()` が
`C:\Users\...\.claude\morning_briefing.json` を返すため、suffix は一致しません。
**パスは正しく、見方だけが正しくありません。**

### なぜ CI で出ないか

独立した理由が 2 つあるので、どちらのジョブの不備でもありません。

- Ubuntu ジョブはこのパッケージを**実行しています**（`ci.yml:45`）が、ロケールが
  UTF-8 なので、読み手と書き手がたまたま一致して緑になります。つまり
  **エンコーディングについては何も検証できていません。**
- Windows ジョブは 6 ファイル固定で実行しており（`ci.yml:86-94`）、
  `test_sleep.py` は含まれていません。

結果として、ロケール依存の経路がどこでも通っていません。

### 修正内容

同じ理由で hook の stdin/stdout を UTF-8 に固定した #107 と同じ形にしました。

- 読み出し 2 箇所に `encoding="utf-8"` を明示
- 区切り文字を含む文字列比較をやめ、`Path.parts[-2:]` で比較。docstring が言っている
  `~/.claude/` の意味そのままで、どのプラットフォームでも成立します

**製品コードには触れていません。** UTF-8 ロケールでの挙動も変わりません。

### テスト

修正した 3 つの assert は、元より強くなっています。加えて 1 本追加しました。

**`test_briefing_is_written_as_utf8`**（新規）は生バイト列を読んで UTF-8 として
デコードします。これによりディスク上のエンコーディングが実行者のロケールから
独立します。`sleep.py` が意図して置いている `encoding="utf-8"` を、
**これまで誰も assert していませんでした。**

製品コードを戻して確認した結果（手元の環境）:

| 戻した箇所 | 結果 |
|---|---|
| `sleep.py:165` の `encoding="utf-8"` を削除 | `3 failed, 10 passed`（新規テストを含む） |
| `DEFAULT_BRIEFING_PATH` から `".claude"` を削除 | `test_default_briefing_path_is_under_claude_dir` が赤 |

**この修正前は、1 つ目を戻しても緑のままでした。** 読み手と書き手が同じロケールに
従っていたためです。今回塞ぐのはこの穴です。

- `consciousness-mcp/packages/individual-kernel-mcp`: **426 passed**（修正前は
  3 failed / 422 passed）
- `ruff check .`: **All checks passed**

#### 新規テストが効かない環境について

UTF-8 ロケールでは、`sleep.py` から `encoding="utf-8"` を外しても UTF-8 で書かれる
ので、`test_briefing_is_written_as_utf8` は緑のままです。**契約が実際に効く環境で
しか落ちません。** pytest の中から非 UTF-8 ロケールを強制する方法は見つけられません
でした（`Path.write_text` は既定エンコーディングを Python より下の層で解決するため、
`locale` を monkeypatch しても届きません）。そちらの環境で常に無反応なテストを
抱えるのが好ましくなければ、これは落として 3 件の修正だけにします。

### このPRに含めていないもの

範囲は `test_sleep.py` のみです。関連する 2 件は意図的に外しました。

- **製品コード側の同じ欠落。** `scripts/doctor.py:393` /
  `scripts/setup_io.py:64` / `memory-mcp/src/memory_mcp/metacognition.py:83,97`
  も encoding を明示せずにテキストを読み書きしており、そちらは赤いテストより
  厄介です。**`setup_io.py` は例外を出さずに文字化けします。** 挙動の変更を伴う
  ので、再現手順を付けて別途出します。
- **CI のロケール網羅。** マトリクスに `ja-JP`（あるいは非 UTF-8 なロケール）を
  足せばこの種のバグは捕まりますが、CI のコストに関わる判断なので、このPRに
  紛れ込ませず提起だけにとどめます。

### 環境

- Windows 10 Pro build 19045 (x64)、日本語ロケール（`ACP=932`、`locale.getencoding()` → `cp932`）
- Python 3.13.15（uv 管理）、uv 0.12.4
- `origin/main` @ `5177184`

---

## DIFF（参考）

```diff
@@ -185,11 +185,31 @@ class TestBriefingPersistence:
         result = consolidator.run()
         assert path.exists()
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         assert "summary_line" in data
         assert "counterfactual_count" in data
         assert result.briefing_path == str(path)
 
+    def test_briefing_is_written_as_utf8(self, social_db, tmp_path):
+        """summary_line is always Japanese, so the file is never pure ASCII.
+
+        SleepConsolidator pins encoding="utf-8" on the write; nothing asserted it.
+        Reading the raw bytes keeps the on-disk encoding independent of the
+        locale of whoever runs the suite.
+        """
+        path = tmp_path / "morning_briefing.json"
+        store = CounterfactualStore(social_db)
+        consolidator = SleepConsolidator(
+            db=social_db,
+            counterfactual_store=store,
+            briefing_path=path,
+            is_quiet_hours=_quiet_yes,
+            clock=_fixed_clock(),
+        )
+        consolidator.run()
+        data = json.loads(path.read_bytes().decode("utf-8"))
+        assert not data["summary_line"].isascii()
+
     def test_dry_run_does_not_write(self, social_db, tmp_path):

@@ -232,7 +252,7 @@ class TestMorningBriefingShape:
         consolidator.run()
-        data = json.loads(Path(path).read_text())
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
         # MorningBriefing must be re-constructible from disk JSON

@@ -242,4 +262,7 @@ def test_default_briefing_path_is_under_claude_dir():
-    assert str(DEFAULT_BRIEFING_PATH).endswith(".claude/morning_briefing.json")
+    assert Path(DEFAULT_BRIEFING_PATH).parts[-2:] == (
+        ".claude",
+        "morning_briefing.json",
+    )
```
