### PR TITLE
fix(individual-kernel): let the Windows shell reach the outward-action gate

### DIFF
--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -62,7 +62,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|NotebookEdit|Bash|mcp__.*",
+        "matcher": "Write|Edit|NotebookEdit|Bash|PowerShell|mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -83,7 +83,7 @@
     ],
     "PostToolUseFailure": [
       {
-        "matcher": "Write|Edit|NotebookEdit|Bash|mcp__.*",
+        "matcher": "Write|Edit|NotebookEdit|Bash|PowerShell|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -62,7 +62,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|NotebookEdit|Bash|mcp__.*",
+        "matcher": "Write|Edit|NotebookEdit|Bash|PowerShell|mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -83,7 +83,7 @@
     ],
     "PostToolUseFailure": [
       {
-        "matcher": "Write|Edit|NotebookEdit|Bash|mcp__.*",
+        "matcher": "Write|Edit|NotebookEdit|Bash|PowerShell|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/agency.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/agency.py
@@ -784,6 +784,12 @@ def is_external_tool(tool_name: str, tool_input: dict[str, Any] | None = None) -
         return True
     if tool_name in {"Write", "Edit", "NotebookEdit"}:
         return True
+    # Claude Code exposes PowerShell as a tool of its own on Windows, where it is
+    # the primary shell. There is no _powershell_is_read_only() counterpart yet,
+    # and a wrong read-only verdict would reopen the bypass this branch closes,
+    # so every PowerShell call counts as outward.
+    if tool_name == "PowerShell":
+        return True
     if tool_name == "Bash":
         command = str((tool_input or {}).get("command", ""))
         return not _bash_is_read_only(command)

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_powershell_gate.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_powershell_gate.py
@@ -1,0 +1,47 @@
+"""The Windows shell has to reach the same gate as the POSIX one.
+
+Claude Code exposes PowerShell as a tool of its own on Windows, where it is the
+primary shell. `is_external_tool` named Bash and not PowerShell, so a command the
+Bash branch refuses was allowed verbatim through the PowerShell one -- the two
+shells disagreed about the same effect.
+"""
+
+from __future__ import annotations
+
+from individual_kernel_mcp.agency import is_external_tool
+
+
+class TestPowerShellReachesTheGate:
+    def test_a_recursive_delete_is_outward(self) -> None:
+        assert is_external_tool(
+            "PowerShell", {"command": "Remove-Item -Recurse -Force ./tmp"}
+        )
+
+    def test_the_two_shells_agree_about_the_same_effect(self) -> None:
+        delete = {
+            "Bash": "rm -rf ./tmp",
+            "PowerShell": "Remove-Item -Recurse -Force ./tmp",
+        }
+        assert {tool: is_external_tool(tool, {"command": cmd}) for tool, cmd in delete.items()} == {
+            "Bash": True,
+            "PowerShell": True,
+        }
+
+    def test_a_missing_command_is_still_outward(self) -> None:
+        # The Bash branch reads the command to classify it; this one does not, so
+        # an absent or malformed input cannot soften the verdict.
+        assert is_external_tool("PowerShell", {})
+
+    def test_an_inspection_command_is_outward_too(self) -> None:
+        # Deliberate. There is no _powershell_is_read_only() counterpart, and a
+        # wrong read-only verdict would reopen the bypass, so reads cost an
+        # intention on Windows. Remove this test when that counterpart lands.
+        assert is_external_tool("PowerShell", {"command": "Get-ChildItem"})
+
+
+class TestBashClassificationIsUnchanged:
+    def test_read_only_bash_is_still_internal(self) -> None:
+        assert not is_external_tool("Bash", {"command": "ls -la"})
+
+    def test_writing_bash_is_still_outward(self) -> None:
+        assert is_external_tool("Bash", {"command": "echo hi > out.txt"})

--- a/tests/test_uv_workspace.py
+++ b/tests/test_uv_workspace.py
@@ -187,6 +187,21 @@ def test_core_hook_settings_do_not_require_posix_shell_scripts() -> None:
     assert all(".sh" not in json.dumps(hook) for hook in hooks)
 
 
+def test_post_tool_hooks_match_every_shell_the_gate_can_refuse() -> None:
+    """PreToolUse carries no matcher, so it gates every tool. PostToolUse does.
+
+    A tool the gate can refuse but the post hooks never see would leave its
+    intention pending, and the one-outward-action bottleneck then blocks the
+    next one. The two lists have to name the same tools.
+    """
+    for name in (".claude/settings.json", ".claude/settings.example.json"):
+        config = json.loads((ROOT / name).read_text(encoding="utf-8"))
+        for event in ("PostToolUse", "PostToolUseFailure"):
+            for entry in config["hooks"][event]:
+                for tool in ("Write", "Edit", "Bash", "PowerShell"):
+                    assert tool in entry["matcher"], (name, event, tool)
+
+
 def test_ci_uses_the_locked_root_workspace() -> None:
     workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
     assert 'python-version: "3.13"' in workflow


### PR DESCRIPTION

## Problem

`is_external_tool` names `Bash` but not `PowerShell`. On Windows, Claude Code
exposes PowerShell as a tool of its own and it is the primary shell, so every
PowerShell call was classified internal and passed `PreToolUse` untouched.

The two shells disagreed about the same effect:

| tool | command | decision |
|---|---|---|
| `Bash` | `rm -rf ./tmp` | deny |
| `PowerShell` | `Remove-Item -Recurse -Force ./tmp` | **allow** |

## Reproduce

The hook CLI can be driven directly, so this needs no nested session.

```bash
H="uv run --package individual-kernel-mcp efpf-hook"
echo '{"session_id":"x","source":"startup"}' | $H session-start      > /dev/null
echo '{"session_id":"x","prompt":"hi"}'      | $H user-prompt-submit > /dev/null

echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf ./tmp"}}' | $H pre-tool-use
echo '{"tool_name":"PowerShell","tool_input":{"command":"Remove-Item -Recurse -Force ./tmp"}}' | $H pre-tool-use
```

Before:

```json
{"permissionDecision":"deny", "permissionDecisionReason":"no matching pending intention; call propose_field_action first"}
{"permissionDecision":"allow","permissionDecisionReason":"internal/read-only tool; outward action gate not required"}
```

After, both deny.

## Fix

Classify `PowerShell` as outward.

```python
if tool_name in {"Write", "Edit", "NotebookEdit"}:
    return True
if tool_name == "PowerShell":
    return True
if tool_name == "Bash":
    command = str((tool_input or {}).get("command", ""))
    return not _bash_is_read_only(command)
```

### Why there is no `_powershell_is_read_only()`

`Bash` gets a read-only branch; `PowerShell` deliberately does not, and I want to
be explicit that this is a choice rather than an omission.

A PowerShell counterpart is not the same shape of problem as the Bash one:

- **aliases are user-extensible.** `rm`, `del`, `ri`, `sc`, `si` all resolve to
  mutating cmdlets, and the set is not fixed at parse time.
- **script blocks hide the verb.** `Get-ChildItem | ForEach-Object { Remove-Item $_ }`
  opens with an inspection cmdlet.
- **native commands still apply.** A PowerShell line can invoke `git push` or an
  arbitrary `.exe` through the call operator.

Each of those is a way for a write to read like an inspection, and a wrong
read-only verdict here **reopens exactly the bypass this PR closes**. The Bash
recognizer earned its allowlist against commands that were actually issued
(#117); I do not have the equivalent evidence for PowerShell yet.

So the cost lands on reads: on Windows, `Get-ChildItem` now needs an intention.
That is the side of the trade I would rather err on — refusing a read is visible
and recoverable, allowing a write is neither. `test_an_inspection_command_is_outward_too`
pins that decision so it stays visible, and says in a comment to delete it when a
counterpart lands.

**If you would rather not take that cost, say so and I will send a
`_powershell_is_read_only()` instead of this.** It is a bigger change and I did
not want to decide it unilaterally.

## The matcher has to move with it

`PostToolUse` and `PostToolUseFailure` match
`Write|Edit|NotebookEdit|Bash|mcp__.*` in both `settings.json` and
`settings.example.json`. `PreToolUse` carries no matcher, so it already gated
every tool — the post hooks are the ones that reach `close_tool` (`hook_cli.py:188`).

Fixing only the classification would gate a PowerShell call and then never close
its intention, and the one-outward-action bottleneck would block the next one.
Both matchers now include `PowerShell`.

## Tests

`test_powershell_gate.py` (new, 6 cases) covers the classification, that the two
shells agree about the same effect, that a missing `command` cannot soften the
verdict, and that Bash is unchanged.

`test_post_tool_hooks_match_every_shell_the_gate_can_refuse` in
`tests/test_uv_workspace.py` asserts both settings files name every tool the gate
can refuse. It sits with the other settings assertions, and that file is already
in the Windows CI list (`ci.yml:89`), so it runs there.

Verified by reverting each half:

| Reverted | Result |
|---|---|
| the `PowerShell` branch in `agency.py` | `4 failed, 2 passed` in `test_powershell_gate.py` |
| `PowerShell` out of both matchers | `test_post_tool_hooks_match_every_shell_the_gate_can_refuse` red |

- `consciousness-mcp/packages/individual-kernel-mcp`: 428 passed (+6)
- `tests/`: 78 passed (+1)
- `ruff check .`: All checks passed

### About the failures already on main

Both suites also report failures that this branch does not touch and does not
introduce. On clean `origin/main`, on Windows under a Japanese locale:

- `individual-kernel-mcp`: `3 failed, 422 passed` — `test_sleep.py`, addressed in #136
- `tests/`: `3 failed, 77 passed` — `test_docs.py` and `test_release_check.py`

They are the same class as #136 (text read without an explicit encoding) and I
will send them separately. Counts above are stated as deltas for that reason.

## Environment

- Windows 10 Pro build 19045 (x64), Japanese locale (`ACP=932`)
- Python 3.13.15 (uv-managed), uv 0.12.4
- `origin/main` @ `5177184`

---

## 日本語

### 症状

`is_external_tool` は `Bash` を見ていますが `PowerShell` を見ていません。
Windows の Claude Code は **PowerShell を独立したツールとして持っており、しかも
そちらが主シェル**です。そのため PowerShell の呼び出しはすべて internal と分類され、
`PreToolUse` を素通りしていました。

**同じ効果に対して、2つのシェルの判定が割れます。**

| tool | command | 判定 |
|---|---|---|
| `Bash` | `rm -rf ./tmp` | deny |
| `PowerShell` | `Remove-Item -Recurse -Force ./tmp` | **allow** |

### 再現手順

フック CLI に直接流せるので、セッションを入れ子にする必要はありません。

```bash
H="uv run --package individual-kernel-mcp efpf-hook"
echo '{"session_id":"x","source":"startup"}' | $H session-start      > /dev/null
echo '{"session_id":"x","prompt":"hi"}'      | $H user-prompt-submit > /dev/null

echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf ./tmp"}}' | $H pre-tool-use
echo '{"tool_name":"PowerShell","tool_input":{"command":"Remove-Item -Recurse -Force ./tmp"}}' | $H pre-tool-use
```

修正前は前者が deny、後者が allow になります。修正後は両方 deny です。

### 修正

`PowerShell` を外向きとして分類します。

#### `_powershell_is_read_only()` を入れていない理由

`Bash` には read-only の分岐がありますが、`PowerShell` には**意図的に付けていません**。
書き忘れではなく判断であることを明示しておきます。

PowerShell 版は Bash 版と同じ形の問題ではありません。

- **エイリアスが利用者側で拡張できる。** `rm` / `del` / `ri` / `sc` / `si` はいずれも
  変更系のコマンドレットに解決され、その集合は解析時に確定しません
- **スクリプトブロックが動詞を隠す。**
  `Get-ChildItem | ForEach-Object { Remove-Item $_ }` は検査系で始まります
- **ネイティブコマンドも通る。** 呼び出し演算子から `git push` や任意の `.exe` を
  起動できます

どれも「書き込みが検査に見える」経路です。そして**read-only の誤判定は、この PR が
塞ごうとしている抜け穴をそのまま開け直します。** Bash の判定器は実際に発行された
コマンドを相手に許可リストを育てた成果物（#117）ですが、PowerShell について同等の
実績を私はまだ持っていません。

その代償は読み取り側に出ます。Windows では `Get-ChildItem` にも intention が必要に
なります。**読み取りの拒否は目に見えて復帰できますが、書き込みの許可はどちらでも
ありません。**どちらに倒すかであれば前者だと考えました。
`test_an_inspection_command_is_outward_too` がこの判断を固定し、
「対の実装が入ったらこのテストは消すこと」とコメントに書いてあります。

**その代償を払いたくない、というご判断であれば、これではなく
`_powershell_is_read_only()` の PR を出します。** 規模が大きくなるので、
こちらで一方的に決めたくありませんでした。

### matcher も一緒に動かす必要があります

`PostToolUse` と `PostToolUseFailure` の matcher は、`settings.json` と
`settings.example.json` の両方で `Write|Edit|NotebookEdit|Bash|mcp__.*` です。
`PreToolUse` には matcher が無く既に全ツールを通しているので、**`close_tool` に
届くのは post 側だけ**です（`hook_cli.py:188`）。

分類だけ直すと、PowerShell の呼び出しはゲートされるのに intention が閉じられず、
一 tick 一外向き行為のボトルネックが次の行為を止めます。両方の matcher に
`PowerShell` を足しました。

### テスト

`test_powershell_gate.py`（新規・6件）で分類、2つのシェルの判定一致、
`command` 欠落時に判定が緩まないこと、Bash が変わっていないことを確認します。

`tests/test_uv_workspace.py` の
`test_post_tool_hooks_match_every_shell_the_gate_can_refuse` は、両方の設定ファイルが
ゲート対象のツールを漏れなく列挙していることを assert します。他の設定ファイル系の
assert と同じ場所に置きました。**このファイルは既に Windows CI の対象なので
（`ci.yml:89`）、あちらでも走ります。**

片方ずつ戻して確認しました。

| 戻した箇所 | 結果 |
|---|---|
| `agency.py` の `PowerShell` 分岐 | `test_powershell_gate.py` が `4 failed, 2 passed` |
| 両 matcher から `PowerShell` | `test_post_tool_hooks_match_every_shell_the_gate_can_refuse` が赤 |

- `consciousness-mcp/packages/individual-kernel-mcp`: 428 passed（+6）
- `tests/`: 78 passed（+1）
- `ruff check .`: All checks passed

#### main に既にある失敗について

どちらのスイートにも、**このブランチが触っておらず、また持ち込んでもいない失敗**が
含まれます。素の `origin/main` を Windows の日本語ロケールで走らせた場合:

- `individual-kernel-mcp`: `3 failed, 422 passed` — `test_sleep.py`。#136 で対応中
- `tests/`: `3 failed, 77 passed` — `test_docs.py` と `test_release_check.py`

いずれも #136 と同種（encoding を明示せずにテキストを読んでいる）で、別途出します。
上の件数を差分で書いているのはそのためです。

### 環境

- Windows 10 Pro build 19045 (x64)、日本語ロケール（`ACP=932`）
- Python 3.13.15（uv 管理）、uv 0.12.4
- `origin/main` @ `5177184`
