### PR TITLE
fix(autonomous): stop the prompt executing the tool names it documents

### DIFF
--- a/autonomous-action.sample.sh
+++ b/autonomous-action.sample.sh
@@ -348,11 +348,11 @@ ${MORNING_SECTION}${ROUTINE_MODE}
 ${DESIRE_SECTION}
 ## 補足ルール
 - ${TIME_RULE}
-- 人に話しかける、say する、軽く促す前に `get_social_state` → `evaluate_action(action_type=\"say\" または \"nudge_human\")` を通し、許可されないなら黙るか後回しにする
-- X に投稿する前に `get_social_state` → `get_person_model` → `review_social_post` → `evaluate_action(action_type=\"post_tweet\")` を通す
-- 人の発話・依頼・境界・約束を拾ったら `ingest_social_event` と `ingest_interaction` を使って social DB に反映する。明確な境界は `record_boundary`、約束は `create_commitment` を使う
-- 物や人の位置関係をある程度構造化できるときは `ingest_scene_parse` を使う。参照が曖昧なときは `resolve_reference` や `get_current_joint_focus` を使う
-- 一日の節目や余力があるタイミングでは `append_daybook` を使って自己要約を更新する
+- 人に話しかける、say する、軽く促す前に \`get_social_state\` → \`evaluate_action(action_type=\"say\" または \"nudge_human\")\` を通し、許可されないなら黙るか後回しにする
+- X に投稿する前に \`get_social_state\` → \`get_person_model\` → \`review_social_post\` → \`evaluate_action(action_type=\"post_tweet\")\` を通す
+- 人の発話・依頼・境界・約束を拾ったら \`ingest_social_event\` と \`ingest_interaction\` を使って social DB に反映する。明確な境界は \`record_boundary\`、約束は \`create_commitment\` を使う
+- 物や人の位置関係をある程度構造化できるときは \`ingest_scene_parse\` を使う。参照が曖昧なときは \`resolve_reference\` や \`get_current_joint_focus\` を使う
+- 一日の節目や余力があるタイミングでは \`append_daybook\` を使って自己要約を更新する
 - 人がいないことはよくある。一日のうち人がいるのは2時間程度やそれ以下の場合も少なくない
 - 部屋を見るときは see で撮って、予測→観察→記憶照合→保存のサイクルで発見を拾え。朝日や天気の変化、部屋の明るさなど、人がいなくても観察すべきものはある
 - 読書を選択した場合は、ゆっくり読んで、感想をしっかり書き残す。感想は長くなっても良い。読書を味わうこと。読書を味わうとは、予想して、伏線に注目して、感じたことを大切にする。

--- a/tests/test_autonomous_prompt.py
+++ b/tests/test_autonomous_prompt.py
@@ -1,0 +1,60 @@
+"""The autonomous prompt has to reach Claude as written.
+
+PROMPT is assembled as a double-quoted shell string, so anything the prompt
+says with backticks is command substitution rather than markup. The tool names
+in the supplementary rules were being executed, failing, and substituted with
+the empty string -- the rules arrived as arrows pointing at nothing.
+
+Nothing surfaces that: `command not found` goes to stderr, which cron discards,
+and the log records the prompt after the stripping.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+
+# The script is mostly Japanese, so the encoding cannot be left to the locale.
+SCRIPT = (ROOT / "autonomous-action.sample.sh").read_text(encoding="utf-8")
+
+PROMPT_START = 'PROMPT="自律行動タイム'
+PROMPT_END = '${INTEROCEPTION_SECTION}"'
+
+
+def _prompt_block() -> str:
+    start = SCRIPT.index(PROMPT_START)
+    return SCRIPT[start : SCRIPT.index(PROMPT_END, start)]
+
+
+def test_prompt_block_is_where_we_think_it_is() -> None:
+    # If the prompt is ever rewritten as a quoted heredoc, the check below stops
+    # being meaningful rather than starting to fail. Pin the assumption.
+    assert SCRIPT.count(PROMPT_START) == 1
+    assert SCRIPT.count(PROMPT_END) == 1
+    assert 'PROMPT=$(cat <<' not in SCRIPT
+
+
+def test_prompt_quotes_tool_names_without_running_them() -> None:
+    unescaped = [match.start() for match in re.finditer(r"(?<!\\)`", _prompt_block())]
+    assert unescaped == [], (
+        "unescaped backtick in the prompt: the shell runs what it encloses and "
+        "substitutes the empty string, so the tool name never reaches Claude"
+    )
+
+
+def test_the_tool_names_are_still_there() -> None:
+    # Escaping is only half of it: deleting the names would satisfy the check
+    # above and lose the rules the prompt is trying to state. Dropping the
+    # backticks instead of escaping them is a fine way to fix this, so the
+    # names are checked without them.
+    prompt = _prompt_block()
+    for tool in (
+        "get_social_state",
+        "evaluate_action",
+        "review_social_post",
+        "ingest_social_event",
+        "append_daybook",
+    ):
+        assert tool in prompt


### PR DESCRIPTION

## Problem

Every heartbeat sends a prompt with its tool names removed.

`autonomous-action.sample.sh` builds `PROMPT` as a double-quoted shell string.
The supplementary rules inside it name the MCP tools in backticks:

```bash
PROMPT="自律行動タイム（Heartbeat）
...
- 人に話しかける、say する、軽く促す前に `get_social_state` → `evaluate_action(...)` を通し、…
- X に投稿する前に `get_social_state` → `get_person_model` → `review_social_post` → …
${INTEROCEPTION_SECTION}"
```

In a double-quoted string those backticks are command substitution, not markup.
The shell runs `get_social_state`, `evaluate_action`, `ingest_scene_parse` and the
rest as commands, they fail, and bash substitutes the empty string.

What Claude actually receives:

```
## 補足ルール
- say は部屋に人がいるときだけ使ってよい。…
- 人に話しかける、say する、軽く促す前に  →  を通し、許可されないなら黙るか後回しにする
- X に投稿する前に  →  →  →  を通す
- 人の発話・依頼・境界・約束を拾ったら  と  を使って social DB に反映する。…
```

The Heartbeat Protocol rules arrive as arrows pointing at nothing.

## Why it is invisible

Two things hide it.

The failures print to stderr:

```
./autonomous-action.sh: line 361: get_social_state: command not found
./autonomous-action.sh: command substitution: line 361: syntax error near
  unexpected token `action_type="say"'
```

Under cron that stream is discarded. And the log file records `$PROMPT` *after*
the substitution has already happened, so the log shows the stripped text as if
that were what was built.

I found it because I was running the script by hand with `--dry-run` and read
the output.

This is not platform specific — the substitution happens the same way anywhere
bash runs.

## Fix

Escape the backticks.

The double quotes on those same lines are already escaped (`\"say\"`), so this
one metacharacter was the only one missed.

## Tests

`tests/test_autonomous_prompt.py` (new) pins three things.

**The prompt is still a double-quoted string.** If it is ever rewritten as a
quoted heredoc, the backtick check stops being meaningful rather than starting
to fail, so the assumption is asserted rather than assumed.

**No unescaped backtick survives in the prompt block.**

**The tool names are still there.** Escaping is only half of it — deleting the
names would satisfy the check above and lose the rules the prompt is stating.
The names are checked *without* their backticks, since dropping the markup
instead of escaping it would be a perfectly good fix and should not fail.

Against the unescaped script, `test_prompt_quotes_tool_names_without_running_them`
is the only failure.

The script is almost entirely Japanese, so the test reads it with an explicit
`encoding="utf-8"` (same reason as #136).

- `tests/`: **80 passed**
- `ruff check .`: **All checks passed**

## Environment

- Windows 10 Pro (x64), Git Bash 5.2.37
- `main` @ `5177184`

---

## 日本語

### 症状

**Heartbeat は毎回、ツール名が消えたプロンプトを送っています。**

`autonomous-action.sample.sh` の `PROMPT` は二重引用符の文字列で、
その中の補足ルールが MCP のツール名をバッククォートで囲んでいます。

二重引用符の中でバッククォートは**コマンド置換**であり、記法ではありません。
`get_social_state` や `evaluate_action` がシェルのコマンドとして実行され、
失敗し、空文字に置換されます。

Claude に実際に届いているもの:

```
- 人に話しかける、say する、軽く促す前に  →  を通し、許可されないなら黙るか後回しにする
- X に投稿する前に  →  →  →  を通す
- 人の発話・依頼・境界・約束を拾ったら  と  を使って social DB に反映する。…
```

**Heartbeat Protocol の規則が、行き先の無い矢印だけになって届いています。**

### なぜ見えないか

隠している要因が 2 つあります。

失敗は stderr に出ます。

```
./autonomous-action.sh: line 361: get_social_state: command not found
```

cron はこれを捨てます。そしてログファイルに記録される `$PROMPT` は
**置換が済んだ後**のものなので、ログを読むと「そういうプロンプトを組んだ」
ように見えます。

手元で `--dry-run` を回して出力を読んでいて気づきました。

**プラットフォーム固有の問題ではありません。** bash が走る環境ならどこでも同じです。

### 修正

バッククォートをエスケープします。

同じ行の二重引用符は既に `\"say\"` とエスケープされているので、
**この 1 文字だけが漏れていた**形です。

### テスト

`tests/test_autonomous_prompt.py`（新規）で 3 点を固定します。

**プロンプトが今も二重引用符の文字列であること。** quoted heredoc に書き換えられた
場合、バッククォートの検査は「落ちる」のではなく「意味を失う」ので、
前提のほうを assert しています。

**プロンプト内にエスケープされていないバッククォートが無いこと。**

**ツール名が残っていること。** エスケープは半分でしかなく、名前ごと削除しても
上の検査は通ってしまいます。ただし**バッククォートを外す直し方も正当**なので、
名前はバッククォート抜きで確認しています。

エスケープ前のスクリプトに対しては、
`test_prompt_quotes_tool_names_without_running_them` **だけ**が落ちます。

このスクリプトはほぼ全編が日本語なので、テストは `encoding="utf-8"` を
明示して読んでいます（#136 と同じ理由です）。

- `tests/`: **80 passed**
- `ruff check .`: **All checks passed**

### 環境

- Windows 10 Pro (x64)、Git Bash 5.2.37
- `main` @ `5177184`
