### PR TITLE
fix(wifi-cam): stop see_both claiming depth, read TAPO_RIGHT_PTZ_MODE, fix the README tool table

### DIFF
--- a/.claude/hooks/hearing-daemon.py
+++ b/.claude/hooks/hearing-daemon.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python3
-"""hearing-daemon は hearing/ ライブラリに移動しました。
+"""hearing-daemon は別リポジトリ lifemate-ai/embodied-codex の hearing/ に移動しました。
 
-wifi-cam-mcp の start_listening ツールで聞き耳を開始できます。
-hearing-hook.sh はそのまま [hearing] 行の注入に使用されます。
+    https://github.com/lifemate-ai/embodied-codex  →  hearing/
+
+そこにある MCP サーバーの start_listening / stop_listening ツールで聞き耳を
+開始・停止します（wifi-cam-mcp にはこれらのツールはありません）。
+このリポジトリの hearing-hook.sh / hearing-stop-hook.sh は、その hearing が
+書き込む /tmp/hearing_buffer.jsonl を読む側としてそのまま使われます。
 """
 raise SystemExit(
-    "hearing-daemon は hearing/ ライブラリに移行しました。\n"
-    "wifi-cam-mcp の start_listening ツールで聞き耳を開始してください。"
+    "hearing-daemon は lifemate-ai/embodied-codex の hearing/ に移行しました。\n"
+    "https://github.com/lifemate-ai/embodied-codex の hearing MCP サーバーで "
+    "start_listening を呼んで聞き耳を開始してください。"
 )

--- a/.claude/hooks/hearing-hook.sh
+++ b/.claude/hooks/hearing-hook.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # hearing-hook.sh - 聴覚バッファを Claude のコンテキストに注入する UserPromptSubmit フック
 #
-# hearing-daemon.py が /tmp/hearing_buffer.jsonl に蓄積した文字起こし結果を
+# hearing ライブラリ（別リポジトリ lifemate-ai/embodied-codex の hearing/）が
+# /tmp/hearing_buffer.jsonl に蓄積した文字起こし結果を
 # UserPromptSubmit のたびに読み取り、[hearing] プレフィックス付きで stdout に出力する。
 # 読み取り後はバッファをアトミックに空にする。
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to embodied-claude are documented here.
 
 ## [Unreleased]
 
+A reader going through `wifi-cam-mcp` with the code open (fmtowns3, #132)
+found that the second camera was documented in three places that disagreed
+with each other and with the implementation: the tool description promised
+depth, the config silently ignored one of its own variables, and the README
+listed tools by names that no longer exist.
+
+### Fixed
+
+- wifi-cam: `see_both` no longer describes itself as stereo vision with depth
+  perception. It captures both cameras and returns the two views as separate
+  images; nothing computes disparity, and the model reading that description
+  was one step from claiming it could judge distance. The text now says what
+  the two views are good for (occlusion, comparing viewpoints) and that no
+  depth is computed.
+- wifi-cam: `TAPO_RIGHT_PTZ_MODE` is read. `right_camera_from_env()` built its
+  `CameraConfig` without `ptz_mode`, so the right camera was always `auto`
+  regardless of the environment; it now follows the same read, fallback to
+  `TAPO_PTZ_MODE`, and validation as the left camera, with tests.
+
+### Changed
+
+- wifi-cam: the README tool table names the tools that are actually registered
+  (`see`, `look_left`, ... `listen`), documents the optional right camera and
+  the thirteen `see_right` / `see_both` / `right_eye_*` / `both_eyes_*` / eye
+  position tools it adds, and notes how to cover several locations by
+  registering the server more than once with different `TAPO_CAMERA_HOST`.
+- hooks: the `hearing-daemon.py` stub points at where hearing actually went,
+  `lifemate-ai/embodied-codex` -> `hearing/`, instead of a directory that is
+  not in this repository.
+
 ## [0.4.6] - 2026-07-31
 
 Setting up for a hands-on meant a room full of laptops with no cameras and no

--- a/wifi-cam-mcp/.env.example
+++ b/wifi-cam-mcp/.env.example
@@ -16,6 +16,9 @@ TAPO_PASSWORD=your-password
 # In ceiling mode, pan/tilt axes are inverted and images are rotated 180°
 # TAPO_MOUNT_MODE=normal
 
+# Optional: PTZ mode - "auto" (probe the camera), "relative" or "continuous"
+# TAPO_PTZ_MODE=auto
+
 # Optional: RTSP stream URL (auto-detected if not set)
 # TAPO_STREAM_URL=rtsp://192.168.1.100:554/stream1
 
@@ -23,12 +26,14 @@ TAPO_PASSWORD=your-password
 # CAPTURE_DIR=/tmp/wifi-cam-mcp
 
 # ============================================
-# Stereo Vision (Optional - Second Camera)
+# Second Camera (Optional - "right eye")
 # ============================================
-# Add a second camera for stereo vision (both eyes)
-# If configured, see_right and see_both tools become available
+# Add a second camera next to the first to see with both eyes.
+# If configured, see_right / see_both and the right_eye_* / both_eyes_* tools
+# become available. The two views are returned as separate images; no depth
+# or disparity is computed.
 
-# Right camera IP address (required for stereo)
+# Right camera IP address (required for the second eye)
 # TAPO_RIGHT_CAMERA_HOST=192.168.1.101
 
 # Right camera ONVIF port (optional - uses left camera's port if not set)
@@ -40,3 +45,6 @@ TAPO_PASSWORD=your-password
 
 # Right camera mount mode (optional - uses TAPO_MOUNT_MODE if not set)
 # TAPO_RIGHT_MOUNT_MODE=normal
+
+# Right camera PTZ mode (optional - uses TAPO_PTZ_MODE if not set)
+# TAPO_RIGHT_PTZ_MODE=auto

--- a/wifi-cam-mcp/README.md
+++ b/wifi-cam-mcp/README.md
@@ -10,17 +10,52 @@ Tapo C210などのWiFiカメラをMCP経由で制御して、AIに部屋を見�
 
 ## できること
 
+登録されるツール名は `server.py` の `list_tools()` のとおりです。
+
 | ツール | 説明 |
 |--------|------|
-| `camera_capture` | 今見えてる景色を撮影 |
-| `camera_pan_left` | 左を向く |
-| `camera_pan_right` | 右を向く |
-| `camera_tilt_up` | 上を向く |
-| `camera_tilt_down` | 下を向く |
-| `camera_look_around` | 部屋を見渡す（4方向撮影） |
+| `see` | 今見えてる景色を撮影（カメラの向きも一緒に返す） |
+| `look_left` | 左を向く（`degrees`、既定 30） |
+| `look_right` | 右を向く（`degrees`、既定 30） |
+| `look_up` | 上を向く（`degrees`、既定 20） |
+| `look_down` | 下を向く（`degrees`、既定 20） |
+| `look_around` | 部屋を見渡す（正面・左・右・上の4方向撮影） |
 | `camera_info` | カメラ情報取得 |
 | `camera_presets` | プリセット位置一覧 |
-| `camera_go_to_preset` | プリセット位置に移動 |
+| `camera_go_to_preset` | プリセット位置に移動（`preset_id`） |
+| `listen` | マイクで聞く（`duration` 秒、`transcribe` で文字起こし） |
+
+### 右カメラ（両目）を追加する
+
+同じ場所に 2 台目のカメラを置き、`TAPO_RIGHT_*` を設定すると、起動時に右カメラへ
+接続できた場合だけ次の 13 ツールが追加されます（`.env.example` も参照）。
+
+| 環境変数 | 説明 |
+|----------|------|
+| `TAPO_RIGHT_CAMERA_HOST` | 右カメラの IP アドレス（これが無いと右カメラは無効） |
+| `TAPO_RIGHT_USERNAME` / `TAPO_RIGHT_PASSWORD` | 右カメラの認証情報（未設定なら `TAPO_USERNAME` / `TAPO_PASSWORD` を流用） |
+| `TAPO_RIGHT_ONVIF_PORT` | ONVIF ポート（未設定なら `TAPO_ONVIF_PORT`、既定 2020） |
+| `TAPO_RIGHT_STREAM_URL` | RTSP URL（未設定なら自動検出） |
+| `TAPO_RIGHT_MOUNT_MODE` | `normal` / `ceiling`（未設定なら `TAPO_MOUNT_MODE`） |
+| `TAPO_RIGHT_PTZ_MODE` | `auto` / `relative` / `continuous`（未設定なら `TAPO_PTZ_MODE`） |
+
+| ツール | 説明 |
+|--------|------|
+| `see_right` | 右目だけで見る |
+| `see_both` | 両目で同時に撮影。左右の画像を別々に返す。手前・奥の関係（オクルージョン）の確認や視点の比較に使える。**視差や奥行きは計算しない** |
+| `right_eye_look_left` / `right_eye_look_right` / `right_eye_look_up` / `right_eye_look_down` | 右目だけを動かす |
+| `both_eyes_look_left` / `both_eyes_look_right` / `both_eyes_look_up` / `both_eyes_look_down` | 両目を同じ向きに動かす |
+| `get_eye_positions` | 両目の現在のパン・チルト角を取得 |
+| `align_eyes` | 右目を左目と同じ向きに合わせる |
+| `reset_eye_positions` | 両目の位置トラッキングを (0, 0) にリセット |
+
+### 複数拠点にカメラを置く
+
+離れた場所にカメラを置きたい場合は、右カメラではなく **wifi-cam-mcp を MCP サーバーとして
+複数回登録**し、それぞれに別の `TAPO_CAMERA_HOST` を env で渡してください
+（例: `wifi-cam-living` と `wifi-cam-office`）。ツール名は MCP サーバー名で名前空間が
+分かれるので衝突しません。このとき `TAPO_RIGHT_*` は設定しないでおくと、両目系のツールは
+生えません。両目系は同じ場所に並べた左右ペアのためのものです。
 
 ## セットアップ
 

--- a/wifi-cam-mcp/src/wifi_cam_mcp/config.py
+++ b/wifi-cam-mcp/src/wifi_cam_mcp/config.py
@@ -110,6 +110,15 @@ class CameraConfig:
         mount_mode = (
             os.getenv("TAPO_RIGHT_MOUNT_MODE", "") or os.getenv("TAPO_MOUNT_MODE", "") or "normal"
         ).lower()
+        if mount_mode not in ("normal", "ceiling"):
+            raise ValueError(f"Invalid mount mode '{mount_mode}'. Must be 'normal' or 'ceiling'.")
+        ptz_mode = (
+            os.getenv("TAPO_RIGHT_PTZ_MODE", "") or os.getenv("TAPO_PTZ_MODE", "") or "auto"
+        ).lower()
+        if ptz_mode not in ("auto", "relative", "continuous"):
+            raise ValueError(
+                f"Invalid PTZ mode '{ptz_mode}'. Must be 'auto', 'relative', or 'continuous'."
+            )
         max_width = int(os.getenv("CAPTURE_MAX_WIDTH", "1920"))
         max_height = int(os.getenv("CAPTURE_MAX_HEIGHT", "1080"))
 
@@ -123,6 +132,7 @@ class CameraConfig:
             onvif_port=onvif_port,
             stream_url=stream_url,
             mount_mode=mount_mode,
+            ptz_mode=ptz_mode,
             max_width=max_width,
             max_height=max_height,
         )

--- a/wifi-cam-mcp/src/wifi_cam_mcp/server.py
+++ b/wifi-cam-mcp/src/wifi_cam_mcp/server.py
@@ -187,7 +187,7 @@ class CameraMCPServer:
                 ),
             ]
 
-            # Add stereo vision tools if right camera is configured
+            # Add two-eye tools if right camera is configured (two views, no depth computed)
             if self._has_stereo:
                 tools.extend(
                     [
@@ -202,7 +202,7 @@ class CameraMCPServer:
                         ),
                         Tool(
                             name="see_both",
-                            description="See with BOTH eyes simultaneously (stereo vision). Returns two images side by side - left eye and right eye views. Use this for depth perception or comparing views from both cameras.",
+                            description="See with BOTH eyes simultaneously. Returns the left and right views as separate images. Useful for resolving occlusion (what is in front of what) and comparing viewpoints. Note: no disparity or depth is computed.",
                             inputSchema={
                                 "type": "object",
                                 "properties": {},
@@ -539,7 +539,7 @@ class CameraMCPServer:
                             ),
                             TextContent(
                                 type="text",
-                                text=f"Stereo capture at {left_result.timestamp} (L: {left_result.width}x{left_result.height}, R: {right_result.width}x{right_result.height})",
+                                text=f"Both-eyes capture at {left_result.timestamp} (L: {left_result.width}x{left_result.height}, R: {right_result.width}x{right_result.height})",
                             ),
                         ]
 
@@ -741,7 +741,7 @@ class CameraMCPServer:
                 )
                 await self._camera_right.connect()
                 self._has_stereo = True
-                logger.info(f"Connected to right camera at {right_config.host} (stereo vision enabled)")
+                logger.info(f"Connected to right camera at {right_config.host} (both-eyes tools enabled)")
             except Exception as e:
                 logger.warning(f"Failed to connect right camera at {right_config.host}: {e}")
                 self._camera_right = None

--- a/wifi-cam-mcp/tests/test_config.py
+++ b/wifi-cam-mcp/tests/test_config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from wifi_cam_mcp import config
-from wifi_cam_mcp.config import ServerConfig
+from wifi_cam_mcp.config import CameraConfig, ServerConfig
 from wifi_cam_mcp.server import resolve_transcribe
 
 
@@ -66,3 +66,56 @@ def test_listen_resolves_explicit_or_configured_transcription_default(
     expected: bool,
 ) -> None:
     assert resolve_transcribe(arguments, default=default) is expected
+
+
+@pytest.fixture
+def right_camera_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A minimal right-camera environment with no PTZ/mount overrides set."""
+    monkeypatch.setenv("TAPO_RIGHT_CAMERA_HOST", "192.0.2.2")
+    monkeypatch.setenv("TAPO_USERNAME", "user")
+    monkeypatch.setenv("TAPO_PASSWORD", "secret")
+    for name in (
+        "TAPO_PTZ_MODE",
+        "TAPO_RIGHT_PTZ_MODE",
+        "TAPO_MOUNT_MODE",
+        "TAPO_RIGHT_MOUNT_MODE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_right_camera_ptz_mode_defaults_to_auto(right_camera_env: None) -> None:
+    right = CameraConfig.right_camera_from_env()
+
+    assert right is not None
+    assert right.ptz_mode == "auto"
+
+
+def test_right_camera_reads_its_own_ptz_mode(
+    monkeypatch: pytest.MonkeyPatch, right_camera_env: None
+) -> None:
+    monkeypatch.setenv("TAPO_RIGHT_PTZ_MODE", "relative")
+
+    right = CameraConfig.right_camera_from_env()
+
+    assert right is not None
+    assert right.ptz_mode == "relative"
+
+
+def test_right_camera_falls_back_to_left_ptz_mode(
+    monkeypatch: pytest.MonkeyPatch, right_camera_env: None
+) -> None:
+    monkeypatch.setenv("TAPO_PTZ_MODE", "continuous")
+
+    right = CameraConfig.right_camera_from_env()
+
+    assert right is not None
+    assert right.ptz_mode == "continuous"
+
+
+def test_right_camera_rejects_invalid_ptz_mode(
+    monkeypatch: pytest.MonkeyPatch, right_camera_env: None
+) -> None:
+    monkeypatch.setenv("TAPO_RIGHT_PTZ_MODE", "sideways")
+
+    with pytest.raises(ValueError, match="PTZ mode"):
+        CameraConfig.right_camera_from_env()


### PR DESCRIPTION
Closes #132 (reported by @fmtowns3 — thank you).

## What was wrong
- `see_both`'s tool description promised stereo vision / depth perception. The implementation captures both cameras and returns two separately-labelled images; nothing computes disparity. Since tool descriptions are model input, this was one step from the model claiming it could judge distance.
- `right_camera_from_env()` never passed `ptz_mode`, so `TAPO_RIGHT_PTZ_MODE` was never read and the right camera was always `auto`.
- The README tool table listed `camera_*` names that no longer exist, and said nothing about the right camera / both-eyes tools.
- `.claude/hooks/hearing-daemon.py` said hearing moved to a `hearing/` directory that is not in this repo (it lives in `lifemate-ai/embodied-codex`).

## Changes
- `see_both` description → the wording proposed in the issue (two separate views; useful for occlusion and comparing viewpoints; no disparity or depth is computed). Related log/label text reworded.
- `right_camera_from_env()` reads `TAPO_RIGHT_PTZ_MODE` → fallback `TAPO_PTZ_MODE` → `auto`, validated like the left camera; `.env.example` updated; tests added. (Also validates the right camera's `mount_mode` like the left already did.)
- `wifi-cam-mcp/README.md`: tool table regenerated from `list_tools()`; new section for the optional right camera (`TAPO_RIGHT_*`) and the 13 tools it adds; note on covering several locations by registering the server more than once.
- `hearing-daemon.py` stub + `hearing-hook.sh` header point at `lifemate-ai/embodied-codex` → `hearing/`.
- CHANGELOG `[Unreleased]` entries.

## Tests
- `uv run --project . --directory wifi-cam-mcp pytest -q` → 34 passed
- `uv run ruff check wifi-cam-mcp` → All checks passed
- `PYTHONUTF8=1 uv run pytest tests -q` → 84 passed (3 cp932 decode failures without PYTHONUTF8 are pre-existing on Windows and unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 日本語版

Closes #132（@fmtowns3 さんの報告。ありがとうございます）

### 何が問題だったか
- `see_both` の説明文が「stereo vision / depth perception」を約束していたが、実装は 2 台から撮った画像を別々に返すだけで視差も深度も計算していない。ツール説明文はモデルへの入力なので、モデルが「奥行きが分かる」と言いかねない状態だった。
- `right_camera_from_env()` が `ptz_mode` を渡しておらず、`TAPO_RIGHT_PTZ_MODE` がどこからも読まれず右カメラは常に `auto` だった。
- README のツール表が旧名 `camera_*` のままで、右カメラ／両目系ツールの記載もなかった。
- `.claude/hooks/hearing-daemon.py` のスタブが「`hearing/` に移動」としか言っておらず、実際の移行先（`lifemate-ai/embodied-codex`）が分からなかった。

### 変更
- `see_both` の説明文を issue の提案どおりに（左右を別画像で返す／オクルージョンの確認や視点の比較に有用／視差・深度は計算しない）。関連するログ・ラベルも修正。
- `right_camera_from_env()` が `TAPO_RIGHT_PTZ_MODE` → `TAPO_PTZ_MODE` → `auto` の順で読み、左カメラと同じ検証をするように。`.env.example` とテストを追加。（右カメラの `mount_mode` も左と同様に検証するようにした）
- `wifi-cam-mcp/README.md`：ツール表を `list_tools()` から再生成。右カメラ（`TAPO_RIGHT_*`）と追加される 13 ツールの節、複数拠点に置くときは wifi-cam-mcp を複数登録する、という注記を追加。
- `hearing-daemon.py` スタブと `hearing-hook.sh` のヘッダを `lifemate-ai/embodied-codex` → `hearing/` を指すように。
- CHANGELOG `[Unreleased]`。

### テスト
- `uv run --project . --directory wifi-cam-mcp pytest -q` → 34 passed
- `uv run ruff check wifi-cam-mcp` → All checks passed
- `PYTHONUTF8=1 uv run pytest tests -q` → 84 passed（PYTHONUTF8 なしで落ちる 3 件は cp932 由来の既存の問題で無関係）
