### PR TITLE
fix(individual-kernel): point the outward-action deny at setup when the kernel is not installed, and fail closed on unreadable hook input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to embodied-claude are documented here.
 
 ## [Unreleased]
 
+A Windows user cloned the repository with `uv` already on PATH, opened it in
+Claude Code, and could not write a single file. The committed
+`.claude/settings.json` hooks were firing, the gate was failing closed as
+designed, and the deny reason told them to call `propose_field_action` -- a
+tool of the `individual-kernel` MCP server that only exists once
+`scripts/setup.sh` has written the gitignored `.mcp.json`. The gate was armed
+and its key had not been issued (#137, reported by fmtowns3).
+
+### Fixed
+
+- individual-kernel: when the PreToolUse hook denies an outward action and the
+  project has no `.mcp.json` registering `individual-kernel`, the reason now
+  says so, names `./scripts/setup.sh` (or `scripts\setup.cmd`), and keeps the
+  runtime's own verdict after `Original reason:`. The decision is unchanged --
+  still a deny -- only the message became something a session can act on.
+  Detection reads the project-scoped `.mcp.json` only; a server registered at
+  user scope is not seen, and the hint is then merely a prefix on an otherwise
+  correct deny.
+- individual-kernel: the hook CLI no longer turns unreadable stdin into an
+  empty payload. For `pre-tool-use` an empty payload has no tool name, which
+  the gate reads as an internal tool and allows, so a pipe that lost its input
+  looked like a gate that had stopped working. Missing or invalid JSON is now
+  a deny with the reason `EFPF hook received no/invalid JSON on stdin; failing
+  closed`, matching the fail-closed stance `main` already took for exceptions.
+  Other hook events keep treating it as an empty payload.
+- doctor: a new `hooks:gate` check connects the two halves. When the
+  repository ships a PreToolUse hook and the configuration does not register
+  `individual-kernel`, it reports that the committed hooks are active as soon
+  as `uv` is on PATH and that outward tool actions are denied until setup has
+  run.
+- docs: setup guide and both READMEs now say to run setup before opening the
+  repository root in Claude Code, what the deny looks like beforehand, and
+  that the hooks invoke `uv run --directory ${CLAUDE_PROJECT_DIR}`, so firing
+  them with a foreign project root leaves a `.venv` there -- something `uv`
+  does before any hook code runs, so it is documented rather than prevented.
+
 ## [0.4.6] - 2026-07-31
 
 Setting up for a hands-on meant a room full of laptops with no cameras and no

--- a/README-ja.md
+++ b/README-ja.md
@@ -41,6 +41,13 @@ Core profile には camera、API key、追加 hardware は不要です。次の4
 - `sociality`: 人、関係、境界、interaction context
 - `individual-kernel`: Enacted First-Person Field runtime と diagnostics
 
+Claude Code を起動する前に setup を実行してください。リポジトリには
+`.claude/settings.json` が同梱されており、`uv` が PATH にあるだけでその hook が
+有効になります。setup が `.mcp.json` を書くまでは、リポジトリ直下を project root
+にした session での書き込みはすべて拒否され、拒否理由が setup を指し示します。
+詳細は [docs/setup.md](docs/setup.md#run-setup-before-opening-the-repository-in-claude-code)
+を参照してください。
+
 ## 動作確認
 
 1. この repository で `claude` を起動します。

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ The Core profile needs no camera, API key, or other hardware. It configures:
 - `sociality`: people, relationships, boundaries, and interaction context
 - `individual-kernel`: the Enacted First-Person Field runtime and diagnostics
 
+Run setup before starting Claude Code here. The repository ships
+`.claude/settings.json`, and its hooks are active as soon as `uv` is on PATH:
+until setup has written `.mcp.json`, every write in a session opened at the
+repository root is denied with a message pointing back at setup. See
+[Run setup before opening the repository in Claude
+Code](docs/setup.md#run-setup-before-opening-the-repository-in-claude-code).
+
 ## Confirm It Works
 
 1. Start `claude` from this repository.

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/hook_cli.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/hook_cli.py
@@ -52,12 +52,91 @@ not generated from a request to role-play consciousness.
    ordinary responses natural and use the compact field surface."""
 
 
-def _read_input() -> dict[str, Any]:
+def _read_input() -> dict[str, Any] | None:
+    """Parse the hook payload from stdin; `None` when there was none to parse.
+
+    This used to collapse unreadable input into `{}`. For `pre-tool-use` that
+    quietly became an allow: an empty payload has no `tool_name`, and an empty
+    tool name is not an external tool. A PowerShell `'{json}' | uv run ...`
+    pipe that never delivers stdin therefore looked like a gate that did not
+    work, when in fact the gate never saw the call (#137). Callers decide what
+    "nothing arrived" means for their event; `main` fails closed for the gate.
+    """
     try:
         value = json.load(sys.stdin)
-    except json.JSONDecodeError:
-        return {}
-    return value if isinstance(value, dict) else {}
+    except (ValueError, OSError):
+        # JSONDecodeError and UnicodeDecodeError are both ValueErrors.
+        return None
+    return value if isinstance(value, dict) else None
+
+
+KERNEL_SERVER_NAME = "individual-kernel"
+UNREADABLE_INPUT_REASON = "EFPF hook received no/invalid JSON on stdin; failing closed"
+
+
+def _project_dir() -> Path:
+    return Path(os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd())
+
+
+def kernel_server_configured(project_dir: Path | None = None) -> bool | None:
+    """Whether this project's `.mcp.json` registers the individual-kernel server.
+
+    Returns True/False, or None when that could not be determined. The hook
+    fires from the committed `.claude/settings.json` as soon as `uv` is on
+    PATH, while the only way out of a deny -- `propose_field_action` -- is an
+    MCP tool that `scripts/setup.sh` installs by writing the gitignored
+    `.mcp.json`. Knowing which side of that line a session is on is what lets
+    the deny reason point at setup instead of at a tool the session cannot
+    reach.
+
+    Only the project-scoped `.mcp.json` is consulted. A server registered at
+    user scope (`~/.claude.json`) or through managed settings is not seen, so
+    such a session would get the setup hint prefixed to an otherwise correct
+    deny; the original reason is always kept, so nothing is lost there. Never
+    raises: any error is reported as "unknown" and the caller leaves the
+    reason alone.
+    """
+    try:
+        root = project_dir if project_dir is not None else _project_dir()
+        path = root / ".mcp.json"
+        if not path.is_file():
+            return False
+        value = json.loads(path.read_text(encoding="utf-8"))
+        servers = value.get("mcpServers") if isinstance(value, dict) else None
+        if not isinstance(servers, dict):
+            return False
+        return KERNEL_SERVER_NAME in servers
+    except Exception:
+        return None
+
+
+def _deny_reason(reason: str) -> str:
+    """Make a gate deny actionable when the kernel is not installed here.
+
+    Still a deny. The runtime is right to fail closed; what was wrong was that
+    the reason named `propose_field_action`, which a pre-setup session has no
+    way to call (#137, reported by fmtowns3).
+    """
+    if kernel_server_configured() is not False:
+        return reason
+    project_dir = _project_dir()
+    return (
+        f"{KERNEL_SERVER_NAME} MCP server is not configured for this project "
+        f'(no .mcp.json with an "{KERNEL_SERVER_NAME}" entry under {project_dir}); '
+        "outward tool actions stay denied until it is. "
+        "Run ./scripts/setup.sh (or scripts\\setup.cmd on Windows) and restart "
+        f"the session. Original reason: {reason}"
+    )
+
+
+def _deny(reason: str) -> dict[str, Any]:
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
 
 
 def _emit(value: dict[str, Any]) -> None:
@@ -164,10 +243,12 @@ def pre_tool_use(payload: dict[str, Any], runtime: FieldRuntime) -> dict[str, An
         tool_input=_dict(payload.get("tool_input")),
         owner_id=_owner_id(payload, runtime.producer),
     )
+    if not decision.allow:
+        return _deny(_deny_reason(decision.reason))
     return {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
-            "permissionDecision": "allow" if decision.allow else "deny",
+            "permissionDecision": "allow",
             "permissionDecisionReason": decision.reason,
         }
     }
@@ -418,6 +499,12 @@ def main() -> None:
     parser.add_argument("command", choices=COMMANDS)
     args = parser.parse_args()
     payload = _read_input()
+    if payload is None:
+        if args.command == "pre-tool-use":
+            # Unreadable input must not pass for an internal tool call.
+            _emit(_deny(UNREADABLE_INPUT_REASON))
+            return
+        payload = {}
     db = SocialDB()
     producer = TickProducer(db)
     runtime = FieldRuntime(
@@ -442,17 +529,7 @@ def main() -> None:
         _emit(handlers[args.command]())
     except Exception as exc:
         if args.command == "pre-tool-use":
-            _emit(
-                {
-                    "hookSpecificOutput": {
-                        "hookEventName": "PreToolUse",
-                        "permissionDecision": "deny",
-                        "permissionDecisionReason": (
-                            "EFPF hook failed closed: " + str(exc)
-                        ),
-                    }
-                }
-            )
+            _emit(_deny(_deny_reason("EFPF hook failed closed: " + str(exc))))
         else:
             event = {
                 "session-start": "SessionStart",

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_hook_cli.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_hook_cli.py
@@ -12,16 +12,28 @@ from social_core import SocialDB
 
 from individual_kernel_mcp import tick
 from individual_kernel_mcp.agency import ActionProposal
-from individual_kernel_mcp.hook_cli import stop
+from individual_kernel_mcp.hook_cli import (
+    UNREADABLE_INPUT_REASON,
+    kernel_server_configured,
+    stop,
+)
 from individual_kernel_mcp.tick import FieldRuntime, TickProducer
 
 
-def _run_hook(tmp_path, command: str, payload: dict) -> dict:
+def _run_hook(
+    tmp_path,
+    command: str,
+    payload: dict | None,
+    *,
+    raw_input: str | None = None,
+    env_overrides: dict[str, str] | None = None,
+) -> dict:
     env = dict(os.environ)
     env["SOCIAL_DB_PATH"] = str(tmp_path / "hook-social.db")
+    env.update(env_overrides or {})
     result = subprocess.run(
         [sys.executable, "-m", "individual_kernel_mcp.hook_cli", command],
-        input=json.dumps(payload),
+        input=json.dumps(payload) if raw_input is None else raw_input,
         text=True,
         capture_output=True,
         env=env,
@@ -357,3 +369,154 @@ def test_forcing_one_shared_owner_takes_the_parents_committed_slot(
 
     assert child_field_id != parent_field_id
     assert _committed_field_id(tmp_path, "self") == child_field_id
+
+
+# --- #137: the gate fires from the committed .claude/settings.json as soon as
+# uv is on PATH, but the way out of a deny (propose_field_action) is an MCP tool
+# that only exists once scripts/setup.sh has written .mcp.json. Before setup the
+# deny must say so; and unreadable stdin must not pass for an internal tool.
+
+_WRITE_PAYLOAD = {
+    "hook_event_name": "PreToolUse",
+    "tool_name": "Write",
+    "tool_input": {"file_path": "a.txt", "content": "x"},
+    "tool_use_id": "write-137",
+}
+
+
+def _project_env(project_dir: Path) -> dict[str, str]:
+    return {"CLAUDE_PROJECT_DIR": str(project_dir)}
+
+
+def _write_mcp_json(project_dir: Path, servers: dict) -> None:
+    (project_dir / ".mcp.json").write_text(
+        json.dumps({"mcpServers": servers}), encoding="utf-8"
+    )
+
+
+def test_pre_tool_deny_points_at_setup_when_kernel_is_not_configured(
+    tmp_path: Path,
+) -> None:
+    """The reporter's exact script: clone, uv on PATH, no .mcp.json."""
+    project = tmp_path / "project"
+    project.mkdir()
+    env = _project_env(project)
+    _run_hook(
+        tmp_path,
+        "session-start",
+        {"session_id": "x", "source": "startup"},
+        env_overrides=env,
+    )
+    _run_hook(
+        tmp_path,
+        "user-prompt-submit",
+        {"session_id": "x", "prompt": "hi"},
+        env_overrides=env,
+    )
+    result = _run_hook(tmp_path, "pre-tool-use", _WRITE_PAYLOAD, env_overrides=env)
+
+    output = result["hookSpecificOutput"]
+    assert output["permissionDecision"] == "deny"
+    reason = output["permissionDecisionReason"]
+    assert reason.startswith("individual-kernel MCP server is not configured")
+    assert "scripts/setup.sh" in reason
+    assert str(project) in reason
+    # The runtime's own verdict is kept, so nothing about the gate is hidden.
+    assert reason.endswith(
+        "Original reason: no matching pending intention; call propose_field_action first"
+    )
+
+
+def test_pre_tool_deny_keeps_original_reason_when_kernel_is_configured(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_mcp_json(
+        project,
+        {
+            "individual-kernel": {
+                "command": "uv",
+                "args": ["run", "--package", "individual-kernel-mcp", "individual-kernel-mcp"],
+            }
+        },
+    )
+    result = _run_hook(
+        tmp_path, "pre-tool-use", _WRITE_PAYLOAD, env_overrides=_project_env(project)
+    )
+
+    output = result["hookSpecificOutput"]
+    assert output["permissionDecision"] == "deny"
+    assert output["permissionDecisionReason"] == (
+        "no COMMITTED field; refresh the field before outward action"
+    )
+
+
+def test_pre_tool_allow_is_unaffected_by_missing_kernel_config(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    result = _run_hook(
+        tmp_path,
+        "pre-tool-use",
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls -la"},
+        },
+        env_overrides=_project_env(project),
+    )
+
+    output = result["hookSpecificOutput"]
+    assert output["permissionDecision"] == "allow"
+    assert output["permissionDecisionReason"] == (
+        "internal/read-only tool; outward action gate not required"
+    )
+
+
+def test_kernel_server_configured_reads_only_the_project_mcp_json(tmp_path: Path) -> None:
+    assert kernel_server_configured(tmp_path) is False
+
+    _write_mcp_json(tmp_path, {"memory": {"command": "uv"}})
+    assert kernel_server_configured(tmp_path) is False
+
+    _write_mcp_json(tmp_path, {"individual-kernel": {"command": "uv"}})
+    assert kernel_server_configured(tmp_path) is True
+
+    (tmp_path / ".mcp.json").write_text("{not json", encoding="utf-8")
+    assert kernel_server_configured(tmp_path) is None
+
+
+def test_kernel_server_configured_honours_claude_project_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_mcp_json(project, {"individual-kernel": {"command": "uv"}})
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+    monkeypatch.chdir(tmp_path)
+
+    assert kernel_server_configured() is True
+
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR")
+    assert kernel_server_configured() is False
+
+
+@pytest.mark.parametrize("raw_input", ["", "not json", "[1, 2]", "   \n"])
+def test_pre_tool_use_fails_closed_on_unreadable_stdin(tmp_path: Path, raw_input: str) -> None:
+    """A pipe that loses stdin used to read as allow; it must read as a deny."""
+    result = _run_hook(tmp_path, "pre-tool-use", None, raw_input=raw_input)
+
+    output = result["hookSpecificOutput"]
+    assert output["hookEventName"] == "PreToolUse"
+    assert output["permissionDecision"] == "deny"
+    assert output["permissionDecisionReason"] == UNREADABLE_INPUT_REASON
+
+
+def test_other_hooks_treat_unreadable_stdin_as_an_empty_payload(tmp_path: Path) -> None:
+    result = _run_hook(tmp_path, "post-tool-batch", None, raw_input="not json")
+
+    output = result["hookSpecificOutput"]
+    assert output["hookEventName"] == "PostToolBatch"
+    assert output["additionalContext"] == "No committed field is available."
+
+    assert _run_hook(tmp_path, "stop-failure", None, raw_input="") == {}

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -50,6 +50,27 @@ Core contains:
 | `sociality` | People, relationships, boundaries, and interaction context |
 | `individual-kernel` | Enacted field runtime, action gate, and diagnostics |
 
+### Run setup before opening the repository in Claude Code
+
+The repository ships `.claude/settings.json`, whose hooks are active in any
+Claude Code session opened at the repository root as soon as `uv` is on PATH.
+The PreToolUse hook fails closed: with no registered intention it denies
+`Write`, `Edit`, and any `Bash` command that changes state. The only way to
+register an intention is `propose_field_action`, a tool of the
+`individual-kernel` MCP server, and that server is wired up by the gitignored
+`.mcp.json` that setup generates. A checkout that has not run setup therefore
+cannot write and cannot unlock writing from inside the session. The deny reason
+says so and names `./scripts/setup.sh`; the doctor reports the same state as
+`hooks:gate`. Run setup first, then start (or restart) Claude Code. To read the
+code without running setup, open a different directory as the project root.
+
+The hooks run `uv run --directory ${CLAUDE_PROJECT_DIR} ...`. If they fire with
+a project root that is not this repository -- for example when settings were
+copied elsewhere -- `uv` creates a fresh `.venv` in that directory before the
+hook code runs, which this project cannot prevent from inside the hook. Keep
+the project root at the repository root, and delete any stray `.venv` that
+appears in an unrelated folder.
+
 ## Guided Chooser
 
 Run without arguments:
@@ -385,6 +406,19 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 ```
 
 Open a new terminal and rerun setup.
+
+### Every write is denied right after cloning
+
+The deny reason begins with `individual-kernel MCP server is not configured for
+this project` and ends with the runtime's own verdict. Read-only tools still
+pass. Run `./scripts/setup.sh` (or `scripts\setup.cmd`), then restart Claude
+Code; see [Run setup before opening the repository in Claude
+Code](#run-setup-before-opening-the-repository-in-claude-code).
+
+A deny that reads `EFPF hook received no/invalid JSON on stdin; failing
+closed` means the hook ran but no payload reached it. When driving the hook by
+hand, PowerShell `'{json}' | uv run ...` can drop stdin; use Git Bash, or
+`cmd /c "... < file"`.
 
 ### A Core server is disconnected
 

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -338,6 +338,49 @@ def _load_config(path: Path) -> tuple[dict[str, Any] | None, CheckResult]:
     return value, CheckResult(CheckStatus.OK, "config:file", f"loaded {path}")
 
 
+def check_hook_gate(
+    repo_root: Path,
+    config: Mapping[str, Any] | None,
+    config_path: Path,
+) -> CheckResult | None:
+    """Connect the committed hook gate to the config that makes it passable.
+
+    `.claude/settings.json` is in git and fires `efpf-hook pre-tool-use` as soon
+    as `uv` is on PATH; `.mcp.json` is gitignored and only `scripts/setup.sh`
+    writes it. A checkout that has the first without the second denies every
+    outward tool action and has no way to register an intention (#137). The
+    missing-config check already says "run setup"; this one says why a session
+    opened at the repository root cannot write until then. Returns None when
+    the repository ships no PreToolUse hook, so the check is silent elsewhere.
+    """
+
+    settings_path = repo_root / ".claude" / "settings.json"
+    try:
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    hooks = settings.get("hooks") if isinstance(settings, Mapping) else None
+    if not isinstance(hooks, Mapping) or "PreToolUse" not in hooks:
+        return None
+
+    servers = config.get("mcpServers") if isinstance(config, Mapping) else None
+    if isinstance(servers, Mapping) and "individual-kernel" in servers:
+        return CheckResult(
+            CheckStatus.OK,
+            "hooks:gate",
+            "committed PreToolUse hook is backed by the configured individual-kernel server",
+        )
+    return CheckResult(
+        CheckStatus.ERROR,
+        "hooks:gate",
+        "the committed .claude/settings.json hooks are active as soon as uv is on PATH; "
+        f"until {config_path} registers individual-kernel, outward tool actions "
+        "(Write, Edit, mutating Bash) are denied in any Claude Code session opened at "
+        "this repository root",
+        "Run ./scripts/setup.sh (scripts\\setup.cmd on Windows), then restart the session.",
+    )
+
+
 def _check_python() -> CheckResult:
     if sys.version_info[:2] == (3, 13):
         return CheckResult(CheckStatus.OK, "python", sys.version.split()[0])
@@ -420,6 +463,9 @@ def run_doctor(
     ]
     config, config_result = _load_config(config_path)
     results.append(config_result)
+    gate_result = check_hook_gate(repo_root, config, config_path)
+    if gate_result is not None:
+        results.append(gate_result)
     if config is not None:
         results.extend(validate_mcp_config(config))
         results.extend(check_workspace_packages(repo_root, config))

--- a/tests/test_doctor_cli.py
+++ b/tests/test_doctor_cli.py
@@ -120,3 +120,54 @@ def test_live_checks_delegate_to_the_isolated_mcp_probe(
     assert results[0].status is CheckStatus.OK
     assert "31 tools" in results[0].detail
     assert "--remember-roundtrip" in calls[0]
+
+
+def _repo_with_hooks(tmp_path: Path) -> Path:
+    """A checkout as git delivers it: the hook settings, no .mcp.json."""
+    root = tmp_path / "repo"
+    (root / ".claude").mkdir(parents=True)
+    (root / ".claude" / "settings.json").write_text(
+        json.dumps({"hooks": {"PreToolUse": [{"hooks": [{"type": "command"}]}]}}),
+        encoding="utf-8",
+    )
+    return root
+
+
+def test_hook_gate_check_names_the_deny_when_mcp_json_is_missing(
+    tmp_path: Path,
+) -> None:
+    root = _repo_with_hooks(tmp_path)
+    config_path = root / ".mcp.json"
+
+    result = doctor.check_hook_gate(root, None, config_path)
+
+    assert result is not None
+    assert result.status is CheckStatus.ERROR
+    assert result.subject == "hooks:gate"
+    assert "active as soon as uv is on PATH" in result.detail
+    assert "denied" in result.detail
+    assert "setup.sh" in (result.remediation or "")
+
+
+def test_hook_gate_check_passes_when_individual_kernel_is_configured(
+    tmp_path: Path,
+) -> None:
+    root = _repo_with_hooks(tmp_path)
+    config = {"mcpServers": {"individual-kernel": {"command": "uv"}}}
+
+    result = doctor.check_hook_gate(root, config, root / ".mcp.json")
+
+    assert result is not None
+    assert result.status is CheckStatus.OK
+
+    missing_kernel = doctor.check_hook_gate(
+        root, {"mcpServers": {"memory": {}}}, root / ".mcp.json"
+    )
+    assert missing_kernel is not None
+    assert missing_kernel.status is CheckStatus.ERROR
+
+
+def test_hook_gate_check_is_silent_without_a_committed_pre_tool_use_hook(
+    tmp_path: Path,
+) -> None:
+    assert doctor.check_hook_gate(tmp_path, None, tmp_path / ".mcp.json") is None


### PR DESCRIPTION
Closes #137 (reported by @fmtowns3 — thank you for the precise repro).

## What was wrong
- The committed `.claude/settings.json` hooks fire as soon as `uv` is on PATH, but the only way out of a PreToolUse deny — `propose_field_action` — is an MCP tool that `scripts/setup.sh` installs by writing the gitignored `.mcp.json`. A freshly cloned checkout opened as a Claude Code project could not write a file, and the deny reason pointed at a tool the session could not reach.
- `_read_input()` collapsed unreadable stdin into `{}`, which for `pre-tool-use` meant "not an external tool" → allow. A PowerShell pipe that never delivered stdin looked like a gate that did not work.

## Changes (option 1 from the issue: stay fail-closed, make the message actionable)
- `hook_cli.py`: new `kernel_server_configured()` reads `<CLAUDE_PROJECT_DIR or cwd>/.mcp.json`; when `individual-kernel` is absent, deny reasons are prefixed with "individual-kernel MCP server is not configured for this project … Run ./scripts/setup.sh (or scripts\setup.cmd on Windows) and restart the session. Original reason: …". Never raises; allow decisions untouched. Only the project `.mcp.json` is consulted (documented limitation).
- `_read_input()` returns `None` for missing/invalid/non-object JSON; `main()` emits `EFPF hook received no/invalid JSON on stdin; failing closed` for `pre-tool-use`; other commands keep today's behaviour.
- `scripts/doctor.py`: new `hooks:gate` check that ties the committed hooks to the missing `.mcp.json`.
- `docs/setup.md`: "Run setup before opening the repository in Claude Code" + troubleshooting entry (incl. the stray `.venv` from `uv run --directory` — documented only, it happens before any hook code runs). Short pointers in README / README-ja.
- CHANGELOG `[Unreleased]`.

## Repro (Git Bash, fresh DB, no `.mcp.json`)
Before: `Write` → deny "no matching pending intention; call propose_field_action first"; `echo 'not json' | … pre-tool-use` → **allow**.
After: `Write` → deny "…not configured for this project … Run ./scripts/setup.sh … Original reason: no matching pending intention…"; invalid/empty stdin → deny "EFPF hook received no/invalid JSON on stdin; failing closed"; `Bash ls -la` still allow.

## Tests
- `uv run pytest consciousness-mcp/packages/individual-kernel-mcp/tests -q` → 442 passed
- `PYTHONUTF8=1 uv run pytest tests -q` → 87 passed (3 cp932 failures without PYTHONUTF8 are pre-existing on Windows)
- `uv run ruff check consciousness-mcp/packages/individual-kernel-mcp scripts` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 日本語版

Closes #137（@fmtowns3 さんの報告。正確な再現手順に感謝します）

### 何が問題だったか
- コミットされている `.claude/settings.json` のフックは `uv` が PATH にあるだけで発火するが、PreToolUse の deny を解除する唯一の手段 `propose_field_action` は `scripts/setup.sh` が gitignore 済みの `.mcp.json` を書いて初めて使える MCP ツール。clone 直後のリポジトリを Claude Code のプロジェクトとして開くと、何も書けず、deny 理由は到達できないツールを指していた。
- `_read_input()` が壊れた／空の stdin を `{}` に潰していたため、`pre-tool-use` では「外部ツールではない」と判定されて allow になっていた（PowerShell のパイプで stdin が届かないケースが「ゲートが効いていない」ように見えた）。

### 変更（issue の案 1：fail closed のまま、メッセージを行動可能にする）
- `hook_cli.py`：`kernel_server_configured()` を追加。`<CLAUDE_PROJECT_DIR or cwd>/.mcp.json` に `individual-kernel` が無いとき、deny 理由の先頭に「individual-kernel MCP server is not configured for this project … Run ./scripts/setup.sh (or scripts\setup.cmd on Windows) and restart the session. Original reason: …」を付ける。例外は投げない。allow の判定には影響しない。参照するのはプロジェクトの `.mcp.json` のみ（制限として明記）。
- `_read_input()` は読めない／オブジェクトでない JSON で `None` を返し、`main()` は `pre-tool-use` のときだけ「EFPF hook received no/invalid JSON on stdin; failing closed」で deny。他のイベントは従来どおり。
- `scripts/doctor.py`：フックと `.mcp.json` 不在を結びつける `hooks:gate` チェックを追加。
- `docs/setup.md`：「Claude Code で開く前に setup を実行する」節とトラブルシューティング項目（`uv run --directory` による別ディレクトリの `.venv` 生成も記載。これはフックのコードが動く前に起きるので文書化のみ）。README / README-ja に短い導線。
- CHANGELOG `[Unreleased]`。

### 再現（Git Bash、DB 新規、`.mcp.json` なし）
Before：`Write` → deny「no matching pending intention; call propose_field_action first」、`echo 'not json' | … pre-tool-use` → **allow**
After：`Write` → deny「…not configured for this project … Run ./scripts/setup.sh … Original reason: no matching pending intention…」、不正／空 stdin → deny「EFPF hook received no/invalid JSON on stdin; failing closed」、`Bash ls -la` は引き続き allow

### テスト
- `uv run pytest consciousness-mcp/packages/individual-kernel-mcp/tests -q` → 442 passed
- `PYTHONUTF8=1 uv run pytest tests -q` → 87 passed
- `uv run ruff check consciousness-mcp/packages/individual-kernel-mcp scripts` → All checks passed
