### PR TITLE
fix(hearing): make the hearing hooks work under Git Bash on Windows

### DIFF
--- a/.claude/hooks/hearing-hook.sh
+++ b/.claude/hooks/hearing-hook.sh
@@ -119,10 +119,12 @@ DRAIN_TMP = HEARING_DIR / "hearing_buffer_drain.jsonl"
 if not BUFFER.exists() or BUFFER.stat().st_size == 0:
     sys.exit(0)
 
-# os.rename はアトミック操作。rename 後にデーモンが書き込む新エントリは
+# os.replace は両 OS でアトミック操作。rename 後にデーモンが書き込む新エントリは
 # open("a") によって新しい BUFFER ファイルへ書かれるため、データ欠損なし。
+# os.rename は Windows では宛先が残っていると FileExistsError になり、
+# 以降毎回無言で失敗し続けるので使わない（#144 での fmtowns3 さんの指摘）。
 try:
-    os.rename(str(BUFFER), str(DRAIN_TMP))
+    os.replace(str(BUFFER), str(DRAIN_TMP))
 except OSError as e:
     print(f"[hearing] drain_error={e}", file=sys.stderr)
     sys.exit(0)

--- a/.claude/hooks/hearing-hook.sh
+++ b/.claude/hooks/hearing-hook.sh
@@ -1,25 +1,88 @@
 #!/bin/bash
 # hearing-hook.sh - 聴覚バッファを Claude のコンテキストに注入する UserPromptSubmit フック
 #
-# hearing-daemon.py が /tmp/hearing_buffer.jsonl に蓄積した文字起こし結果を
+# hearing デーモンが $HEARING_DIR/hearing_buffer.jsonl に蓄積した文字起こし結果を
 # UserPromptSubmit のたびに読み取り、[hearing] プレフィックス付きで stdout に出力する。
 # 読み取り後はバッファをアトミックに空にする。
 #
 # デーモンが未稼働の場合は何も出力せず静かに終了する。
+#
+# 移植性メモ（#139）:
+#   - バッファ等の置き場所は HEARING_DIR（既定: $TMPDIR または /tmp）。シェル側で
+#     解決して環境変数で Python に渡す。Windows (Git Bash) では Python の
+#     Path("/tmp") がカレントドライブ直下を指してしまうため、Python 内に
+#     "/tmp/..." を直接書かない。
+#   - python3 は Microsoft Store のエイリアスに取られていることがあるので、
+#     実際に動くインタプリタを探す（HEARING_PYTHON で固定も可）。
+#   - MSYS の kill -0 はネイティブプロセスを見られないので tasklist にフォールバック。
 
-BUFFER_FILE="/tmp/hearing_buffer.jsonl"
-PID_FILE="/tmp/hearing-daemon.pid"
-TIMING_LOG="/tmp/hearing_timing.log"
-USER_PROMPT_FILE="/tmp/hearing_user_prompt.txt"
+HEARING_DIR="${HEARING_DIR:-${TMPDIR:-/tmp}}"
+export HEARING_DIR
+# Windows の Python は既定で stdout/ファイルをロケール（cp932 等）で扱うので、
+# [hearing] 行と JSON が UTF-8 で往復するよう UTF-8 モードを強制する（POSIX では実質無変化）。
+export PYTHONUTF8=1
 
-# stdinからユーザーのプロンプトを保存
-jq -r '.prompt // empty' > "$USER_PROMPT_FILE"
+BUFFER_FILE="$HEARING_DIR/hearing_buffer.jsonl"
+PID_FILE="$HEARING_DIR/hearing-daemon.pid"
+TIMING_LOG="$HEARING_DIR/hearing_timing.log"
+USER_PROMPT_FILE="$HEARING_DIR/hearing_user_prompt.txt"
+LAST_TS_FILE="$HEARING_DIR/hearing_hook_last_ts"
+
+# ── 動く Python を選ぶ ───────────────────────────────────────────────────────
+# HEARING_PYTHON が設定されていればそれを使う。なければ python3 → python の順で
+# "import sys" が通る最初のものを採用する（Store のエイリアスは終了コード 49 で弾かれる）。
+find_python() {
+    local candidate
+    if [ -n "${HEARING_PYTHON:-}" ]; then
+        # 明示指定はそれだけを試す（動かなければ黙って終了）
+        if "$HEARING_PYTHON" -c "import sys" >/dev/null 2>&1; then
+            printf '%s\n' "$HEARING_PYTHON"
+            return 0
+        fi
+        return 1
+    fi
+    for candidate in python3 python; do
+        if command -v "$candidate" >/dev/null 2>&1 &&
+           "$candidate" -c "import sys" >/dev/null 2>&1; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+PY="$(find_python)" || exit 0
+[ -z "$PY" ] && exit 0
+
+# ── PID 生存確認（kill -0 → tasklist フォールバック）────────────────────────
+# MSYS の kill はネイティブプロセス（Windows で起動したデーモン）を見られないので、
+# kill -0 が失敗したら tasklist に聞く。MSYS_NO_PATHCONV / MSYS2_ARG_CONV_EXCL は
+# "/FI" が "C:/Program Files/Git/FI" に変換されるのを止めるため（POSIX では無視される）。
+pid_alive() {
+    kill -0 "$1" 2>/dev/null && return 0
+    if command -v tasklist >/dev/null 2>&1; then
+        MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' tasklist /FI "PID eq $1" /FO CSV /NH 2>/dev/null | grep -q "\"$1\"" && return 0
+    fi
+    return 1
+}
+
+# stdinからユーザーのプロンプトを保存（jq がなければ Python で読む）
+if command -v jq >/dev/null 2>&1; then
+    jq -r '.prompt // empty' > "$USER_PROMPT_FILE"
+else
+    "$PY" -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("prompt") or "")
+except Exception:
+    pass' > "$USER_PROMPT_FILE" 2>/dev/null
+fi
 
 # タイミング記録
-NOW=$(python3 -c "import time; print(f'{time.time():.3f}')")
-PREV=$(cat /tmp/hearing_hook_last_ts 2>/dev/null || echo "$NOW")
-DELTA=$(python3 -c "print(f'{$NOW - $PREV:.1f}')")
-echo "$NOW" > /tmp/hearing_hook_last_ts
+NOW=$("$PY" -c "import time; print(f'{time.time():.3f}')")
+PREV=$(cat "$LAST_TS_FILE" 2>/dev/null)
+PREV=${PREV:-$NOW}
+DELTA=$("$PY" -c "print(f'{$NOW - $PREV:.1f}')")
+echo "$NOW" > "$LAST_TS_FILE"
 echo "[$(date +%H:%M:%S)] submit-hook  delta=${DELTA}s" >> "$TIMING_LOG"
 
 # ── デーモン稼働確認 ──────────────────────────────────────────────────────────
@@ -27,7 +90,7 @@ echo "[$(date +%H:%M:%S)] submit-hook  delta=${DELTA}s" >> "$TIMING_LOG"
 DAEMON_RUNNING=false
 if [ -f "$PID_FILE" ]; then
     PID=$(cat "$PID_FILE" 2>/dev/null)
-    if [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then
+    if [ -n "$PID" ] && pid_alive "$PID"; then
         DAEMON_RUNNING=true
     fi
 fi
@@ -39,14 +102,17 @@ fi
 
 # ── バッファをアトミックにドレインして出力 ────────────────────────────────────
 
-python3 - <<'PYEOF' 2>/dev/null
+"$PY" - <<'PYEOF' 2>/dev/null
 import json
 import os
 import sys
+import tempfile
 from pathlib import Path
 
-BUFFER = Path("/tmp/hearing_buffer.jsonl")
-DRAIN_TMP = Path("/tmp/hearing_buffer_drain.jsonl")
+HEARING_DIR = Path(os.environ.get("HEARING_DIR") or tempfile.gettempdir())
+
+BUFFER = HEARING_DIR / "hearing_buffer.jsonl"
+DRAIN_TMP = HEARING_DIR / "hearing_buffer_drain.jsonl"
 
 # バッファが空なら何もしない
 if not BUFFER.exists() or BUFFER.stat().st_size == 0:
@@ -76,7 +142,7 @@ finally:
     DRAIN_TMP.unlink(missing_ok=True)
 
 # Stopフックのoffsetをリセット（バッファがdrainされたので）
-Path("/tmp/hearing_stop_offset").unlink(missing_ok=True)
+(HEARING_DIR / "hearing_stop_offset").unlink(missing_ok=True)
 
 if not entries:
     sys.exit(0)
@@ -94,7 +160,7 @@ texts    = [e["text"] for e in entries]
 combined = " / ".join(texts)
 
 # チェーン保証フラグ: stop hookが最低1回は待つようにする
-Path("/tmp/hearing_had_speech").write_text(str(n))
+(HEARING_DIR / "hearing_had_speech").write_text(str(n))
 
 # interoception.sh に合わせた key=value 形式で出力
 print(f"[hearing] chunks={n} span={first_ts}~{last_ts} text={combined}")

--- a/.claude/hooks/hearing-stop-hook.sh
+++ b/.claude/hooks/hearing-stop-hook.sh
@@ -6,25 +6,86 @@
 #   - バッファは消さずに読む（offset以降の新しい行だけ処理）
 #   - 有効 → offset更新 & 処理済み行を削除 & block
 #   - 無効 → offset据え置き → 短いsleep後に即リトライ（新データが溜まるのを待つ）
+#
+# 登録時の注意:
+#   - このフックは無音 1 回あたり約 21 秒かかる（既定値: HEARING_WAIT_SECONDS 5
+#     + リトライ 3×HEARING_RETRY_WAIT 3 + HEARING_GUARANTEED_SLEEP 5）。
+#     同梱の core フックは "timeout": 10 だが、このフックは **25 秒以上** にすること。
+#     10 秒のままだと待機の途中で打ち切られ、ターン延長が一度も成立しない（エラーも出ない）。
+#   - Windows では "command": "bash" が WSL のエイリアスに当たるので、Git Bash の実体
+#     （C:\Program Files\Git\bin\bash.exe）を明示する。詳細は docs/hearing-hooks.md。
+#
+# 移植性メモ（#139）:
+#   - バッファ等の置き場所は HEARING_DIR（既定: $TMPDIR または /tmp）。シェル側で解決して
+#     環境変数で Python に渡す。Python 内に "/tmp/..." を直接書かない。
+#   - hearing ライブラリの場所（uv run --directory に渡す）は HEARING_LIB_DIR。別物。
+#   - python3 は Store のエイリアスのことがあるので実際に動くものを探す（HEARING_PYTHON で固定可）。
+#   - MSYS の kill -0 はネイティブプロセスを見られないので tasklist にフォールバック。
 
-BUFFER_FILE="/tmp/hearing_buffer.jsonl"
-PID_FILE="/tmp/hearing-daemon.pid"
-OFFSET_FILE="/tmp/hearing_stop_offset"
-TIMING_LOG="/tmp/hearing_timing.log"
-GUARANTEED_COUNTER="/tmp/hearing-guaranteed-counter"
-CONTEXT_FILE="/tmp/hearing_context.json"
+HEARING_DIR="${HEARING_DIR:-${TMPDIR:-/tmp}}"
+export HEARING_DIR
+# Windows の Python は既定で stdout/ファイルをロケール（cp932 等）で扱うので、
+# [hearing] 行と JSON が UTF-8 で往復するよう UTF-8 モードを強制する（POSIX では実質無変化）。
+export PYTHONUTF8=1
+
+BUFFER_FILE="$HEARING_DIR/hearing_buffer.jsonl"
+PID_FILE="$HEARING_DIR/hearing-daemon.pid"
+OFFSET_FILE="$HEARING_DIR/hearing_stop_offset"
+TIMING_LOG="$HEARING_DIR/hearing_timing.log"
+GUARANTEED_COUNTER="$HEARING_DIR/hearing-guaranteed-counter"
+CONTEXT_FILE="$HEARING_DIR/hearing_context.json"
+LAST_TS_FILE="$HEARING_DIR/hearing_stop_last_ts"
+
+# ── 動く Python を選ぶ ───────────────────────────────────────────
+# HEARING_PYTHON が設定されていればそれを使う。なければ python3 → python の順で
+# "import sys" が通る最初のものを採用する（Store のエイリアスは終了コード 49 で弾かれる）。
+find_python() {
+    local candidate
+    if [ -n "${HEARING_PYTHON:-}" ]; then
+        # 明示指定はそれだけを試す（動かなければ黙って終了）
+        if "$HEARING_PYTHON" -c "import sys" >/dev/null 2>&1; then
+            printf '%s\n' "$HEARING_PYTHON"
+            return 0
+        fi
+        return 1
+    fi
+    for candidate in python3 python; do
+        if command -v "$candidate" >/dev/null 2>&1 &&
+           "$candidate" -c "import sys" >/dev/null 2>&1; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+PY="$(find_python)" || exit 0
+[ -z "$PY" ] && exit 0
+
+# ── PID 生存確認（kill -0 → tasklist フォールバック）──────────────
+# MSYS の kill はネイティブプロセス（Windows で起動したデーモン）を見られないので、
+# kill -0 が失敗したら tasklist に聞く。MSYS_NO_PATHCONV / MSYS2_ARG_CONV_EXCL は
+# "/FI" が "C:/Program Files/Git/FI" に変換されるのを止めるため（POSIX では無視される）。
+pid_alive() {
+    kill -0 "$1" 2>/dev/null && return 0
+    if command -v tasklist >/dev/null 2>&1; then
+        MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' tasklist /FI "PID eq $1" /FO CSV /NH 2>/dev/null | grep -q "\"$1\"" && return 0
+    fi
+    return 1
+}
 
 # stdinからコンテキストを保存（1回だけ読める）
 cat > "$CONTEXT_FILE"
 
 # タイミング記録
-NOW=$(python3 -c "import time; print(f'{time.time():.3f}')")
-PREV=$(cat /tmp/hearing_stop_last_ts 2>/dev/null || echo "$NOW")
-DELTA=$(python3 -c "print(f'{$NOW - $PREV:.1f}')")
-echo "$NOW" > /tmp/hearing_stop_last_ts
+NOW=$("$PY" -c "import time; print(f'{time.time():.3f}')")
+PREV=$(cat "$LAST_TS_FILE" 2>/dev/null)
+PREV=${PREV:-$NOW}
+DELTA=$("$PY" -c "print(f'{$NOW - $PREV:.1f}')")
+echo "$NOW" > "$LAST_TS_FILE"
 echo "[$(date +%H:%M:%S)] stop-hook-start delta=${DELTA}s count=${COUNT:-?}" >> "$TIMING_LOG"
 MAX_HEARING_CONTINUES=${MAX_HEARING_CONTINUES:-20}
-COUNTER_FILE="/tmp/hearing-stop-counter"
+COUNTER_FILE="$HEARING_DIR/hearing-stop-counter"
 WAIT_SECONDS=${HEARING_WAIT_SECONDS:-5}
 RETRY_WAIT=${HEARING_RETRY_WAIT:-3}
 NO_SPEECH_THRESHOLD=${HEARING_NO_SPEECH_THRESHOLD:-0.6}
@@ -36,9 +97,11 @@ if [ -z "$MCP_BEHAVIOR_TOML" ]; then
     [ -f "$_PROJECT_ROOT/mcpBehavior.toml" ] && MCP_BEHAVIOR_TOML="$_PROJECT_ROOT/mcpBehavior.toml"
 fi
 if [ -n "$MCP_BEHAVIOR_TOML" ] && [ -f "$MCP_BEHAVIOR_TOML" ]; then
-    HEARING_DIR="$(cd "$(dirname "$0")/../.." && pwd)/embodied-claude/hearing"
-    [ ! -d "$HEARING_DIR" ] && HEARING_DIR="$(cd "$(dirname "$0")/../.." && pwd)/hearing"
-    eval "$(uv run --directory "$HEARING_DIR" python3 -c "
+    # HEARING_LIB_DIR: hearing ライブラリ（uv プロジェクト）の場所。
+    # バッファ置き場の HEARING_DIR とは別物なので名前を分けている。
+    HEARING_LIB_DIR="${HEARING_LIB_DIR:-$(cd "$(dirname "$0")/../.." && pwd)/embodied-claude/hearing}"
+    [ ! -d "$HEARING_LIB_DIR" ] && HEARING_LIB_DIR="$(cd "$(dirname "$0")/../.." && pwd)/hearing"
+    eval "$(uv run --directory "$HEARING_LIB_DIR" python -c "
 import tomllib
 try:
     with open('$MCP_BEHAVIOR_TOML', 'rb') as f:
@@ -57,7 +120,7 @@ HEARING_GUARANTEED_SLEEP=${HEARING_GUARANTEED_SLEEP:-5}
 DAEMON_RUNNING=false
 if [ -f "$PID_FILE" ]; then
     PID=$(cat "$PID_FILE" 2>/dev/null)
-    if [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then
+    if [ -n "$PID" ] && pid_alive "$PID"; then
         DAEMON_RUNNING=true
     fi
 fi
@@ -76,16 +139,20 @@ fi
 sleep "$WAIT_SECONDS"
 
 # ── バッファを行番号ベースで読み取り・判定 ─────────────────────
-RESULT=$(python3 - "$NO_SPEECH_THRESHOLD" "$OFFSET_FILE" "$BUFFER_FILE" "$RETRY_WAIT" "$COUNT" <<'PYEOF' 2>>/tmp/hearing_timing.log
+RESULT=$("$PY" - "$NO_SPEECH_THRESHOLD" "$OFFSET_FILE" "$BUFFER_FILE" "$RETRY_WAIT" "$COUNT" <<'PYEOF' 2>>"$TIMING_LOG"
 import json
 import os
 import sys
+import tempfile
 import time
 from pathlib import Path
 
+# バッファ等の置き場所。シェル側の HEARING_DIR と一致させる（Windows では /tmp を直接書かない）
+HEARING_DIR = Path(os.environ.get("HEARING_DIR") or tempfile.gettempdir())
+
 threshold = float(sys.argv[1]) if len(sys.argv) > 1 else 0.6
-offset_file = Path(sys.argv[2]) if len(sys.argv) > 2 else Path("/tmp/hearing_stop_offset")
-buffer_file = Path(sys.argv[3]) if len(sys.argv) > 3 else Path("/tmp/hearing_buffer.jsonl")
+offset_file = Path(sys.argv[2]) if len(sys.argv) > 2 else HEARING_DIR / "hearing_stop_offset"
+buffer_file = Path(sys.argv[3]) if len(sys.argv) > 3 else HEARING_DIR / "hearing_buffer.jsonl"
 retry_wait = float(sys.argv[4]) if len(sys.argv) > 4 else 4.0
 
 def read_offset():
@@ -173,8 +240,8 @@ def llm_filter(texts):
 
     # コンテキスト読み込み（短く切る。[hearing]やhookメタ情報を除去）
     context_parts = []
-    user_prompt = Path("/tmp/hearing_user_prompt.txt")
-    context_json = Path("/tmp/hearing_context.json")
+    user_prompt = HEARING_DIR / "hearing_user_prompt.txt"
+    context_json = HEARING_DIR / "hearing_context.json"
     if user_prompt.exists():
         up = user_prompt.read_text().strip()
         # LLMプロンプトの再帰ネスト除去: 【タスク】マーカーがあれば手前を切る
@@ -302,7 +369,7 @@ PYEOF
 )
 
 # ── 判定 ──────────────────────────────────────────────────────
-END_TS=$(python3 -c "import time; print(f'{time.time():.3f}')")
+END_TS=$("$PY" -c "import time; print(f'{time.time():.3f}')")
 GCOUNT=$(cat "$GUARANTEED_COUNTER" 2>/dev/null || echo 0)
 MIN_GUARANTEED=${HEARING_MIN_GUARANTEED:-5}
 
@@ -310,12 +377,12 @@ if [ -n "$RESULT" ]; then
     echo $((COUNT + 1)) > "$COUNTER_FILE"
     # HIT → 保証カウンターリセット（発話があったので）
     rm -f "$GUARANTEED_COUNTER"
-    ELAPSED=$(python3 -c "print(f'{$END_TS - $NOW:.1f}')")
+    ELAPSED=$("$PY" -c "print(f'{$END_TS - $NOW:.1f}')")
     echo "[$(date +%H:%M:%S)] stop-hook-block elapsed=${ELAPSED}s chain=$((COUNT+1))" >> "$TIMING_LOG"
     ESCAPED=$(echo "$RESULT" | sed 's/"/\\"/g')
     echo "{\"decision\": \"block\", \"reason\": \"Stop hook feedback:\n${ESCAPED}\nチェイン($((COUNT+1))/${MAX_HEARING_CONTINUES}) 保証(0/${MIN_GUARANTEED})\"}"
 else
-    ELAPSED=$(python3 -c "print(f'{$END_TS - $NOW:.1f}')")
+    ELAPSED=$("$PY" -c "print(f'{$END_TS - $NOW:.1f}')")
     # チェーン保証: 連続空回数が保証回数以内なら待機
     if [ "$GCOUNT" -lt "$MIN_GUARANTEED" ]; then
         # 保証待機: 次のセグメントが来るまで待つ

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ check failed closed, so the hook exited 0 and the buffer stayed full.
   Reported with a tested patch by fmtowns3 in #139.
 - hearing: the stop hook's library location is now `HEARING_LIB_DIR`; the same
   name had been doing double duty for the buffer directory.
+- hearing: the buffer drain uses `os.replace` instead of `os.rename`. On
+  Windows `os.rename` raises `FileExistsError` when a leftover drain file
+  exists (a hook killed between rename and unlink leaves one), and with stderr
+  discarded every later run silently skipped the drain while the buffer grew.
+  Found and verified by fmtowns3 while testing this PR on the #139 machine.
 - docs: `docs/hearing-hooks.md` documents registration, the `Stop` timeout
   (one silent pass is about 21 s, so `"timeout": 30` rather than the core
   hooks' 10), and the Windows notes -- point `command` at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to embodied-claude are documented here.
 
 ## [Unreleased]
 
+On Windows the hearing hooks did nothing and said nothing. Three idioms that
+are unambiguous on macOS and Linux mean something else under Git Bash:
+`/tmp` written inside the embedded Python resolves to the current drive root
+(the shell's `/tmp` is the user's temp folder), `python3` is often the
+Microsoft Store alias that exits 49 without running anything, and MSYS
+`kill -0` cannot see a daemon started as a native Windows process. Every
+check failed closed, so the hook exited 0 and the buffer stayed full.
+
+### Fixed
+
+- hearing: both hooks resolve the working directory once in the shell
+  (`HEARING_DIR`, default `$TMPDIR` or `/tmp`) and hand it to the embedded
+  Python, which no longer hard-codes `/tmp/...`; they probe for an interpreter
+  that actually runs `import sys` (`HEARING_PYTHON` to pin one, otherwise
+  `python3` then `python`); and `pid_alive` falls back to `tasklist` when
+  `kill -0` cannot reach the daemon. Python runs in UTF-8 mode so the
+  `[hearing]` line survives a cp932 console. POSIX behaviour is unchanged.
+  Reported with a tested patch by fmtowns3 in #139.
+- hearing: the stop hook's library location is now `HEARING_LIB_DIR`; the same
+  name had been doing double duty for the buffer directory.
+- docs: `docs/hearing-hooks.md` documents registration, the `Stop` timeout
+  (one silent pass is about 21 s, so `"timeout": 30` rather than the core
+  hooks' 10), and the Windows notes -- point `command` at
+  `C:/Program Files/Git/bin/bash.exe` rather than the WSL alias `bash`.
+
 ## [0.4.6] - 2026-07-31
 
 Setting up for a hands-on meant a room full of laptops with no cameras and no

--- a/docs/hearing-hooks.md
+++ b/docs/hearing-hooks.md
@@ -1,0 +1,81 @@
+# Hearing Hooks
+
+Two Claude Code hooks under `.claude/hooks/` turn a running hearing daemon
+(started with the `start_listening` tool of `wifi-cam-mcp`) into conversation:
+
+| Script | Event | What it does |
+|---|---|---|
+| `hearing-hook.sh` | `UserPromptSubmit` | Drains the transcript buffer and injects it as a `[hearing] chunks=… span=… text=…` line. |
+| `hearing-stop-hook.sh` | `Stop` | Waits for new speech after a reply and, when some arrives, returns `decision: block` so the turn is extended. |
+
+Both exit `0` without output when no daemon PID is alive, so a mis-registration
+shows up as silence rather than an error. The shipped `.claude/settings.json`
+does not register them; they are opt-in through `.claude/settings.local.json`.
+
+## Registration
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      { "hooks": [ { "type": "command", "command": "bash .claude/hooks/hearing-hook.sh", "timeout": 10 } ] }
+    ],
+    "Stop": [
+      { "hooks": [ { "type": "command", "command": "bash .claude/hooks/hearing-stop-hook.sh", "timeout": 30 } ] }
+    ]
+  }
+}
+```
+
+**Give the `Stop` hook a timeout of at least 25 seconds.** One silent pass
+takes about 21 s with the defaults (`HEARING_WAIT_SECONDS` 5 + three retries of
+`HEARING_RETRY_WAIT` 3 + `HEARING_GUARANTEED_SLEEP` 5). The core hooks ship
+with `"timeout": 10`; copying that value kills the hook mid-wait, the turn is
+never extended, and nothing is logged. `30` is a comfortable value.
+
+## Files and overrides
+
+All working files live in one directory, `HEARING_DIR`, which defaults to
+`$TMPDIR` or `/tmp`: the buffer (`hearing_buffer.jsonl`), the daemon PID
+(`hearing-daemon.pid`), the offset/counter files and `hearing_timing.log`.
+The shell resolves the directory once and exports it, so the embedded Python
+always reads the same place the shell writes to.
+
+| Variable | Meaning | Default |
+|---|---|---|
+| `HEARING_DIR` | Directory holding the buffer, PID file and state | `$TMPDIR`, else `/tmp` |
+| `HEARING_PYTHON` | Interpreter used for the embedded Python | first of `python3`, `python` that can run `import sys` |
+| `HEARING_LIB_DIR` | The hearing library project handed to `uv run --directory` when reading `[hearing]` from `mcpBehavior.toml` (stop hook only) | `<repo>/embodied-claude/hearing`, else `<repo>/hearing` |
+| `HEARING_WAIT_SECONDS`, `HEARING_RETRY_WAIT`, `HEARING_GUARANTEED_SLEEP`, `MAX_HEARING_CONTINUES`, `HEARING_NO_SPEECH_THRESHOLD` | Timing and filtering knobs of the stop hook | 5 / 3 / 5 / 20 / 0.6 |
+
+`HEARING_DIR` and `HEARING_LIB_DIR` are different things: the first is where
+the daemon writes, the second is where the hearing library's `pyproject.toml`
+lives.
+
+## Windows (Git Bash)
+
+The hooks run under Git Bash (`C:\Program Files\Git\bin\bash.exe`). Three
+things that mean something else on Windows are handled inside the scripts
+(#139), and two need attention when registering:
+
+- **Point at Git Bash explicitly.** A bare `"command": "bash …"` resolves to
+  the WSL App Execution Alias on a default Windows install and fails with
+  "Windows Subsystem for Linux has no installed distributions". Use the full
+  path (forward slashes avoid JSON escaping; quote it because of the space):
+
+  ```json
+  { "type": "command", "command": "\"C:/Program Files/Git/bin/bash.exe\" .claude/hooks/hearing-stop-hook.sh", "timeout": 30 }
+  ```
+
+- **Keep the `Stop` timeout at 30.** Same reason as above; the symptom on
+  Windows is identical and just as silent.
+- `HEARING_DIR` defaults to Git Bash's `/tmp`, which is
+  `C:\Users\<you>\AppData\Local\Temp`. Python receives the already-converted
+  Windows path, so no `D:\tmp` surprises. Set `HEARING_DIR` if the daemon
+  writes somewhere else.
+- `python3` is often the Microsoft Store alias (it exits 49 without running
+  anything). The hooks try `python3` then `python` and keep the first one that
+  actually executes; set `HEARING_PYTHON` (for example to the interpreter of a
+  `uv` environment) to skip the probe.
+- A daemon started as a native Windows process is invisible to MSYS
+  `kill -0`; the hooks fall back to `tasklist` to check the PID.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -239,6 +239,12 @@ uses the LibreHardwareMonitor bridge documented in
 [`system-temperature-mcp/README_WinNative.md`](../system-temperature-mcp/README_WinNative.md).
 WSL2 normally cannot see Windows host temperature sensors.
 
+### Hearing hooks
+
+The `UserPromptSubmit` / `Stop` hooks that feed microphone transcripts into the
+conversation are opt-in. Registration, the `Stop` timeout (at least 25 s), and
+the Windows notes live in [docs/hearing-hooks.md](hearing-hooks.md).
+
 ## Preview Without Side Effects
 
 Use `--dry-run` to inspect a redacted generated config:

--- a/tests/test_hearing_hooks.py
+++ b/tests/test_hearing_hooks.py
@@ -1,0 +1,101 @@
+"""The hearing hooks are plain bash + embedded Python and have to survive Git Bash
+on Windows (#139). These tests read the scripts as text and pin the three
+portability fixes so they cannot quietly regress on a POSIX-only machine.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+HOOKS = ROOT / ".claude" / "hooks"
+SCRIPTS = ("hearing-hook.sh", "hearing-stop-hook.sh")
+
+
+def _read(name: str) -> str:
+    return (HOOKS / name).read_text(encoding="utf-8")
+
+
+def _python_heredocs(script: str) -> list[str]:
+    """Return the bodies of every ``<<'PYEOF' ... PYEOF`` block in the script."""
+    blocks = re.findall(r"<<'PYEOF'.*?\n(.*?)\nPYEOF", script, flags=re.DOTALL)
+    assert blocks, "expected at least one embedded Python heredoc"
+    return blocks
+
+
+@pytest.mark.parametrize("name", SCRIPTS)
+def test_embedded_python_never_hardcodes_tmp(name: str) -> None:
+    """Python's Path("/tmp/...") resolves to the current drive on Windows, while the
+    shell's /tmp is the MSYS temp dir. The location has to come from the shell via
+    HEARING_DIR, with tempfile.gettempdir() as the stand-alone fallback."""
+    script = _read(name)
+    for body in _python_heredocs(script):
+        assert '"/tmp/' not in body, name
+        assert "'/tmp/" not in body, name
+        assert 'os.environ.get("HEARING_DIR") or tempfile.gettempdir()' in body, name
+    # Shell side resolves the directory exactly once and exports it for Python.
+    assert 'HEARING_DIR="${HEARING_DIR:-${TMPDIR:-/tmp}}"' in script, name
+    assert "export HEARING_DIR" in script, name
+    # No shell-level literal either (PID/offset/timing/context files all live under it).
+    for line in script.splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        assert not re.search(r'(?<![\w{:-])/tmp/', line), (name, line)
+
+
+@pytest.mark.parametrize("name", SCRIPTS)
+def test_interpreter_is_probed_not_assumed(name: str) -> None:
+    """`python3` may be the Microsoft Store alias (exits 49 without running anything).
+    The hook must honour HEARING_PYTHON, otherwise try python3 then python and keep
+    the first that actually executes `import sys`; none -> exit 0 quietly."""
+    script = _read(name)
+    assert "find_python()" in script, name
+    assert "HEARING_PYTHON" in script, name
+    assert "for candidate in python3 python; do" in script, name
+    assert '"$candidate" -c "import sys"' in script, name
+    assert 'PY="$(find_python)" || exit 0' in script, name
+    # Every remaining interpreter call goes through $PY, never a bare python3.
+    for line in script.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or "for candidate in" in stripped:
+            continue
+        assert not re.match(r'^\w+=\$\(python3? ', stripped), (name, line)
+        assert not stripped.startswith("python3 -"), (name, line)
+
+
+@pytest.mark.parametrize("name", SCRIPTS)
+def test_daemon_liveness_falls_back_to_tasklist(name: str) -> None:
+    """MSYS `kill -0` only sees MSYS processes; a daemon started as a native Windows
+    process looks dead. pid_alive() asks tasklist when kill -0 fails."""
+    script = _read(name)
+    assert "pid_alive()" in script, name
+    assert 'kill -0 "$1" 2>/dev/null && return 0' in script, name
+    assert 'tasklist /FI "PID eq $1"' in script, name
+    # Git Bash rewrites "/FI" into a Windows path unless conversion is disabled.
+    assert "MSYS_NO_PATHCONV=1" in script, name
+    assert 'pid_alive "$PID"' in script, name
+    assert 'kill -0 "$PID"' not in script, name
+
+
+def test_stop_hook_separates_library_dir_from_buffer_dir() -> None:
+    """HEARING_DIR is where the buffer lives; the hearing library handed to
+    `uv run --directory` is HEARING_LIB_DIR. The two used to share one name."""
+    script = _read("hearing-stop-hook.sh")
+    assert '--directory "$HEARING_LIB_DIR"' in script
+    assert '--directory "$HEARING_DIR"' not in script
+
+
+def test_stop_hook_documents_its_timeout_budget() -> None:
+    """A Stop hook registered with the core hooks' timeout of 10 is killed mid-wait
+    and never extends a turn, silently. The header and the docs both say >= 25 s."""
+    script = _read("hearing-stop-hook.sh")
+    header = "\n".join(line for line in script.splitlines()[:40] if line.startswith("#"))
+    assert "25" in header
+    doc = (ROOT / "docs" / "hearing-hooks.md").read_text(encoding="utf-8")
+    assert '"timeout": 30' in doc
+    assert "HEARING_PYTHON" in doc
+    assert "HEARING_DIR" in doc
+    assert "bash.exe" in doc


### PR DESCRIPTION
Closes #139 (reported, diagnosed and patched by @fmtowns3 — the patch is theirs, so the commit carries their Co-authored-by).

## What was wrong
Three "POSIX would write it this way" idioms mean something else on Windows, so `hearing-hook.sh` / `hearing-stop-hook.sh` silently did nothing:
1. `/tmp` resolves to the Git Bash temp dir in the shell but to `<current drive>:\tmp` inside Python literals (only argv/env get MSYS path conversion).
2. `python3` is the Microsoft Store App Execution Alias (exit code 49).
3. MSYS `kill -0` cannot see native Windows processes, so a live daemon counts as dead → both hooks `exit 0`.

## Changes (POSIX behaviour unchanged)
- `HEARING_DIR="${HEARING_DIR:-${TMPDIR:-/tmp}}"` exported from the shell; embedded Python uses `Path(os.environ.get("HEARING_DIR") or tempfile.gettempdir())`. No `/tmp` literal remains inside Python.
- `find_python()`: `HEARING_PYTHON` → `python3` → `python`, first one that runs `-c "import sys"`; otherwise exit 0 quietly as before.
- `pid_alive()`: `kill -0`, then `tasklist /FI "PID eq N" /FO CSV /NH`. Two things found while verifying here: MSYS rewrites `/FI` to `C:/Program Files/Git/FI`, so the fallback runs with `MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*'`; and without `PYTHONUTF8=1` the `[hearing]` line came out as cp932 mojibake, so both scripts export it (no-op on UTF-8 POSIX).
- The library path passed to `uv run --directory` is now `HEARING_LIB_DIR` (distinct from the buffer dir).
- `jq` fallback to Python when jq is absent.
- New `docs/hearing-hooks.md` (linked from `docs/setup.md`): registration JSON, **Stop hook `timeout` must be ≥ 25 s (use 30)** — the shipped core hooks use 10 and would cut the wait short with no error — and a Windows (Git Bash) subsection: point `command` at `C:/Program Files/Git/bin/bash.exe` (plain `bash` hits the WSL alias), `HEARING_DIR` / `HEARING_PYTHON` overrides.
- `tests/test_hearing_hooks.py` (8 tests) pins the above textually (they fail against the old scripts).
- CHANGELOG `[Unreleased]`.

## Verified on a Windows 11 host (Git Bash)
- PID alive via MSYS `$$`, via native `explorer.exe` (kill -0 fails → tasklist fallback), dead PID, `HEARING_PYTHON=/nonexistent`, `HEARING_DIR` override — all behave as intended; `[hearing] chunks=1 … text=テスト` is emitted and the buffer drained.
- Stop hook with shortened waits returns `decision: block` when speech is buffered and `聞き取り待機中…` when not.
- `bash -n` both scripts OK; `PYTHONUTF8=1 uv run pytest tests -q` → 92 passed (3 cp932 failures without it are pre-existing and unrelated); `test_core_hook_settings_do_not_require_posix_shell_scripts` still passes (settings.json untouched). shellcheck not available here.

Note: the identical `hearing-hook.sh` in `lifemate-ai/embodied-codex` needs the same change; will follow separately.

---

## 日本語版

Closes #139（@fmtowns3 さんの報告・診断・パッチ。差分はそのまま使わせてもらったので Co-authored-by を入れています）

### 何が問題だったか
「POSIX ならこう書く」が Windows では別の意味になる箇所が 3 つあり、両フックが黙って何もしなかった：
1. `/tmp` がシェルでは Git Bash の temp、Python リテラルでは `<カレントドライブ>:\tmp` を指す（MSYS のパス変換は argv/env にしか効かない）
2. `python3` が Microsoft Store のエイリアス（終了コード 49）
3. MSYS の `kill -0` はネイティブプロセスを見られず、生きているデーモンを死んでいると判定 → 両フックが `exit 0`

### 変更（POSIX 側の挙動は不変）
- `HEARING_DIR="${HEARING_DIR:-${TMPDIR:-/tmp}}"` をシェルで解決して export。埋め込み Python は `Path(os.environ.get("HEARING_DIR") or tempfile.gettempdir())`。Python 内の `/tmp` リテラルは全廃。
- `find_python()`：`HEARING_PYTHON` → `python3` → `python` の順で `-c "import sys"` が通るものを採用。無ければ従来どおり静かに exit 0。
- `pid_alive()`：`kill -0` → `tasklist /FI "PID eq N" /FO CSV /NH`。検証中に 2 点追加で判明：MSYS が `/FI` を `C:/Program Files/Git/FI` に書き換えるので `MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*'` を付ける／`PYTHONUTF8=1` が無いと `[hearing]` 行が cp932 で文字化けするので両スクリプトで export（UTF-8 の POSIX では無変化）。
- `uv run --directory` に渡す側を `HEARING_LIB_DIR` に改名（バッファ置き場と分離）。
- jq が無ければ Python で代替。
- `docs/hearing-hooks.md` を新設（`docs/setup.md` からリンク）：登録用 JSON、**Stop フックの `timeout` は 25 秒以上（30 推奨）**——同梱のコアフックは 10 秒で、そのまま真似すると待機途中で打ち切られて何も起きない——、Windows (Git Bash) 節（`command` は `C:/Program Files/Git/bin/bash.exe` を明示、`HEARING_DIR` / `HEARING_PYTHON`）。
- `tests/test_hearing_hooks.py`（8 件）で上記をテキストレベルで固定（旧スクリプトでは落ちることを確認）。
- CHANGELOG `[Unreleased]`。

### Windows 11 (Git Bash) で確認
- MSYS の `$$`、ネイティブ `explorer.exe`（kill -0 失敗 → tasklist）、死んだ PID、`HEARING_PYTHON=/nonexistent`、`HEARING_DIR` 上書き——いずれも意図どおり。`[hearing] chunks=1 … text=テスト` が出てバッファがドレインされる。
- Stop フック（待機短縮）：発話ありで `decision: block`、無音で `聞き取り待機中…`。
- `bash -n` OK、`PYTHONUTF8=1 uv run pytest tests -q` → 92 passed。`test_core_hook_settings_do_not_require_posix_shell_scripts` も引き続き pass。shellcheck はこの環境に無いので未実行。

補足：`lifemate-ai/embodied-codex` にある同一の `hearing-hook.sh` にも同じ修正が必要。別途対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)