### PR TITLE
fix: surface the four things headless startup was losing silently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ ENV/
 .mcp.json
 .mcp.json.backup-*
 
+# Per-machine Claude Code settings (setup writes the headless MCP approval here)
+.claude/settings.local.json
+
 # Captured images
 /captures/
 *.jpg

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -22,11 +22,7 @@
         "--package",
         "individual-kernel-mcp",
         "individual-kernel-mcp"
-      ],
-      "env": {
-        "SOCIAL_DB_PATH": "~/.claude/sociality/social.db",
-        "MEMORY_HTTP_PORT": "18900"
-      }
+      ]
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,53 @@ All notable changes to embodied-claude are documented here.
 
 ## [Unreleased]
 
+A Windows install (#140, reported by fmtowns3) turned up four ways a heartbeat
+could run with something missing and say nothing: the MCP servers were never
+approved for `claude -p`, the memory recall port had nobody listening, the
+`@SOUL.md` mentions pointed at files that did not exist, and the example config
+pinned a state path that was meant to be overridable. All four fail in the
+configuration layer and look healthy in the execution layer; interactive use
+catches them because a person is watching, and autonomous use has no one.
+
+### Added
+
+- setup: after writing `.mcp.json`, the same server names are written to
+  `enabledMcpjsonServers` in `.claude/settings.local.json`. Project MCP servers
+  are loaded only once approved, `claude -p` cannot ask, and every edit of
+  `.mcp.json` resets the approval -- so the list is replaced with exactly what
+  setup generated, other keys in the file are kept, and the file is now
+  ignored by Git. `docs/setup.md` gains a section on it.
+- doctor: warns for every `.mcp.json` server missing from that list, when the
+  memory HTTP recall port (`MEMORY_HTTP_PORT`, default 18900) is not
+  listening, and -- once `autonomous-action.sh` is installed -- for each of
+  `SOUL.md`, `TODO.md`, `ROUTINES.md` that is absent. The recall probe is the
+  one network action the static doctor now takes, a TCP connect on localhost.
+- `docs/autonomous-files.md` describes the three files the autonomous prompt
+  mentions with `@`, and `examples/SOUL.sample.md`, `TODO.sample.md`,
+  `ROUTINES.sample.md` are neutral templates to copy from. Until now the three
+  comment lines in the script were their only documentation.
+
+### Fixed
+
+- individual-kernel: when the HTTP recall endpoint does not answer, the tick
+  no longer returns in silence. It warns once per outage on stderr (and again
+  after a recovery and a second outage), and the committed field's epistemic
+  trace records `memory_recall` as `ok:<n>`, `unreachable:<error>` or
+  `disabled`, so a tick that ran on no memory is distinguishable from one
+  that did not. `MEMORY_HTTP_PORT=0` now means recall is off rather than a
+  doomed connect to port 0; the isolated probe already used it that way.
+- autonomous-action.sample.sh: checks that `SOUL.md`, `TODO.md` and
+  `ROUTINES.md` exist before building the prompt and writes a `WARN:` line to
+  its log and stderr for each that does not. It does not abort; the heartbeat
+  still runs on `CLAUDE.md` alone, as before.
+- `.mcp.json.example` and setup no longer pin `SOCIAL_DB_PATH` and
+  `MEMORY_HTTP_PORT` in the `individual-kernel` env block. A value there
+  overrides the inherited environment, so writing the code defaults made a
+  later `SOCIAL_DB_PATH=...` in the parent process a no-op -- staging and
+  production would share one database while looking separate. Setup writes
+  either only when the operator has set it, and then into every server that
+  reads it, so the readers cannot disagree.
+
 ## [0.4.6] - 2026-07-31
 
 Setting up for a hands-on meant a room full of laptops with no cameras and no

--- a/autonomous-action.sample.sh
+++ b/autonomous-action.sample.sh
@@ -337,6 +337,19 @@ fi
 # TODO.md — やりたいこと・タスクを管理するファイル（自分で作成する）
 # ROUTINES.md — 定期実行するルーチンを定義するファイル（任意）
 # これらが存在しない場合は CLAUDE.md のみで動作する。
+# 雛形は examples/SOUL.sample.md などに、説明は docs/autonomous-files.md にある。
+#
+# 存在しないファイルへの @ 参照は、エラーも出さずにただ解決されない。
+# Heartbeat は完走し、ログにも何も残らないので、ここで名指しで警告しておく（#140）。
+# 中断はしない。無い状態でも CLAUDE.md だけで動く、という今までの挙動はそのまま。
+for PROMPT_FILE in SOUL.md TODO.md ROUTINES.md; do
+  if [ ! -f "$SCRIPT_DIR/$PROMPT_FILE" ]; then
+    PROMPT_FILE_WARNING="WARN: $PROMPT_FILE not found in $SCRIPT_DIR; the @$PROMPT_FILE reference in the prompt will not resolve (see docs/autonomous-files.md)"
+    echo "$PROMPT_FILE_WARNING" >> "$LOG_FILE"
+    echo "$PROMPT_FILE_WARNING" >&2
+  fi
+done
+
 PROMPT="自律行動タイム（Heartbeat）
 
 @SOUL.md

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/tick.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/tick.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import secrets
+import sys
 import tempfile
 import urllib.parse
 import urllib.request
@@ -153,6 +154,61 @@ def default_interoception_path() -> Path:
     return Path(tempfile.gettempdir()) / "interoception_state.json"
 
 
+DEFAULT_MEMORY_HTTP_PORT = 18900
+MEMORY_HTTP_TIMEOUT_SECONDS = 1.2
+
+# Whether the last memory recall attempt in this process failed. Set on the
+# first failure so the warning is printed once rather than every tick, and
+# cleared by a success so a later outage is reported again (#140).
+_memory_http_unreachable = False
+
+
+def memory_http_port() -> int:
+    """The port memory-mcp binds its HTTP recall endpoint to.
+
+    0 means memory-mcp took an ephemeral port (the isolated probe does this),
+    so there is nothing knowable to ask and recall is treated as disabled.
+    """
+
+    return int(os.getenv("MEMORY_HTTP_PORT", str(DEFAULT_MEMORY_HTTP_PORT)))
+
+
+def memory_http_recall_url(user_text: str) -> str:
+    port = memory_http_port()
+    return (
+        f"http://127.0.0.1:{port}/recall?"
+        + urllib.parse.urlencode({"q": user_text, "n": 4})
+    )
+
+
+def _warn_memory_http_unreachable(url: str, error: BaseException) -> None:
+    """Say, once per outage, that ticks are running without memory.
+
+    The field commits normally either way and `<current_field>` still renders,
+    so nothing downstream reveals that recall never answered. The heartbeat
+    runs headless; stderr is the only channel that reaches its log.
+    """
+
+    global _memory_http_unreachable
+    if _memory_http_unreachable:
+        return
+    _memory_http_unreachable = True
+    endpoint = url.split("?", 1)[0]
+    print(
+        f"individual-kernel: memory HTTP recall at {endpoint} is unreachable "
+        f"({type(error).__name__}); fields are being committed without memory "
+        "candidates. Start memory-mcp's HTTP recall server or set "
+        "MEMORY_HTTP_PORT.",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def _note_memory_http_reachable() -> None:
+    global _memory_http_unreachable
+    _memory_http_unreachable = False
+
+
 class TickProducer:
     """Deterministically produces and commits one field per tick."""
 
@@ -235,6 +291,12 @@ class TickProducer:
         self.workspace.affect = self._tick_affect(interoception)
         desire_snapshot = self._read_json(self.desires_path)
         dominant_desire = str(desire_snapshot.get("dominant") or "") or None
+        # Network I/O stays outside the transaction; fetching first lets the
+        # field record whether recall answered, so a tick that ran without
+        # memory says so in its own trace instead of looking like every other.
+        memory_recall, memory_items = (
+            self._fetch_memory_http(user_text) if user_text else (None, [])
+        )
 
         with self.db.transaction():
             frame = self.frames.record(
@@ -282,6 +344,11 @@ class TickProducer:
                         "trigger": trigger_kind.value,
                         "raw_user_text_is_not_field_evidence": True,
                         "retention_decay": 0.72,
+                        **(
+                            {"memory_recall": memory_recall}
+                            if memory_recall is not None
+                            else {}
+                        ),
                     },
                 )
             )
@@ -300,8 +367,8 @@ class TickProducer:
             self._ingest_recent_social(field, exclude_session_id=session_id)
             self.generate_self_model_candidate(field.tick_id, owner_id=owner_id)
 
-        if user_text:
-            self._ingest_memory_http(field.tick_id, user_text)
+        if memory_items:
+            self.ingest_memory_candidates(field.tick_id, memory_items)
         return field
 
     def ingest_observation(
@@ -992,23 +1059,33 @@ class TickProducer:
             source_mode=SourceMode.REMEMBERED,
         )
 
-    def _ingest_memory_http(self, tick_id: str, user_text: str) -> None:
-        port = int(os.getenv("MEMORY_HTTP_PORT", "18900"))
-        url = (
-            f"http://127.0.0.1:{port}/recall?"
-            + urllib.parse.urlencode({"q": user_text, "n": 4})
-        )
+    def _fetch_memory_http(self, user_text: str) -> tuple[str, list[dict[str, Any]]]:
+        """Ask memory-mcp's HTTP recall endpoint for candidates.
+
+        Returns a short status for the field's epistemic trace and the items
+        to ingest. A failure yields no items; it used to yield no trace of
+        itself either, so a missing recall daemon meant every heartbeat ran on
+        zero memory while looking healthy (#140). The failure is now named in
+        the trace and warned about once per outage on stderr.
+        """
+
+        if memory_http_port() == 0:
+            return "disabled", []
+        url = memory_http_recall_url(user_text)
         try:
-            with urllib.request.urlopen(url, timeout=1.2) as response:
+            with urllib.request.urlopen(
+                url, timeout=MEMORY_HTTP_TIMEOUT_SECONDS
+            ) as response:
                 raw = json.loads(response.read().decode("utf-8"))
-        except Exception:
-            return
+        except Exception as error:
+            _warn_memory_http_unreachable(url, error)
+            return f"unreachable:{type(error).__name__}", []
+        _note_memory_http_reachable()
         items = raw if isinstance(raw, list) else raw.get("memories", raw.get("results", []))
-        if isinstance(items, list):
-            self.ingest_memory_candidates(
-                tick_id,
-                [item for item in items if isinstance(item, dict)],
-            )
+        if not isinstance(items, list):
+            return "ok:0", []
+        candidates = [item for item in items if isinstance(item, dict)]
+        return f"ok:{len(candidates)}", candidates
 
     def _read_interoception(
         self,

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_hook_cli.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_hook_cli.py
@@ -19,6 +19,8 @@ from individual_kernel_mcp.tick import FieldRuntime, TickProducer
 def _run_hook(tmp_path, command: str, payload: dict) -> dict:
     env = dict(os.environ)
     env["SOCIAL_DB_PATH"] = str(tmp_path / "hook-social.db")
+    # Keep the hook off the machine's real recall endpoint; 0 means "none".
+    env["MEMORY_HTTP_PORT"] = "0"
     result = subprocess.run(
         [sys.executable, "-m", "individual_kernel_mcp.hook_cli", command],
         input=json.dumps(payload),

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_memory_http_recall.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_memory_http_recall.py
@@ -1,0 +1,125 @@
+"""A tick that ran without memory has to say so.
+
+`_fetch_memory_http` asks memory-mcp's HTTP recall port for candidates and
+used to return silently when nothing was listening. The field still committed,
+`<current_field>` still rendered, and the only thing missing was the memory --
+which is exactly the thing nobody could see was missing (#140).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+import urllib.request
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from individual_kernel_mcp import tick as tick_module
+from individual_kernel_mcp.tick import TickProducer
+
+
+@pytest.fixture
+def producer(social_db, tmp_path: Path) -> TickProducer:
+    return TickProducer(
+        social_db,
+        interoception_path=tmp_path / "interoception.json",
+        desires_path=tmp_path / "desires.json",
+    )
+
+
+@pytest.fixture(autouse=True)
+def fresh_outage_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tick_module, "_memory_http_unreachable", False)
+
+
+def _refusing(*_args, **_kwargs):
+    raise urllib.error.URLError(ConnectionRefusedError(111, "Connection refused"))
+
+
+@contextmanager
+def _answering(payload):
+    yield io.BytesIO(json.dumps(payload).encode("utf-8"))
+
+
+def test_outage_is_warned_once_and_named_in_the_trace(
+    producer: TickProducer,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(urllib.request, "urlopen", _refusing)
+
+    first = producer.begin_tick("perception", user_text="hello", session_id="s")
+    producer.compete_and_commit(first.tick_id)
+    second = producer.begin_tick("perception", user_text="again", session_id="s")
+
+    err = capsys.readouterr().err
+    assert err.count("memory HTTP recall") == 1, err
+    assert "127.0.0.1:18900/recall" in err
+    assert "URLError" in err
+    assert "MEMORY_HTTP_PORT" in err
+    assert first.epistemic_trace["memory_recall"] == "unreachable:URLError"
+    assert second.epistemic_trace["memory_recall"] == "unreachable:URLError"
+
+
+def test_a_later_outage_is_warned_again_after_recall_recovers(
+    producer: TickProducer,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(urllib.request, "urlopen", _refusing)
+    producer.begin_tick("perception", user_text="one", session_id="s")
+    assert capsys.readouterr().err.count("memory HTTP recall") == 1
+
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda *_a, **_k: _answering(
+            {"memories": [{"id": "m1", "content": "a remembered room"}]}
+        ),
+    )
+    producer.compete_and_commit(producer.fields.query(limit=1)[0].tick_id)
+    recovered = producer.begin_tick("perception", user_text="two", session_id="s")
+    assert recovered.epistemic_trace["memory_recall"] == "ok:1"
+    assert capsys.readouterr().err == ""
+
+    monkeypatch.setattr(urllib.request, "urlopen", _refusing)
+    producer.compete_and_commit(recovered.tick_id)
+    producer.begin_tick("perception", user_text="three", session_id="s")
+    assert capsys.readouterr().err.count("memory HTTP recall") == 1
+
+
+def test_ticks_without_user_text_do_not_ask_recall(
+    producer: TickProducer,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(urllib.request, "urlopen", _refusing)
+
+    field = producer.begin_tick("heartbeat", session_id="s")
+
+    assert "memory_recall" not in field.epistemic_trace
+    assert capsys.readouterr().err == ""
+
+
+def test_port_zero_means_recall_is_off_and_nothing_is_asked(
+    producer: TickProducer,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MEMORY_HTTP_PORT", "0")
+    monkeypatch.setattr(urllib.request, "urlopen", _refusing)
+
+    field = producer.begin_tick("perception", user_text="hello", session_id="s")
+
+    assert field.epistemic_trace["memory_recall"] == "disabled"
+    assert capsys.readouterr().err == ""
+
+
+def test_recall_url_follows_memory_http_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MEMORY_HTTP_PORT", "18901")
+    assert tick_module.memory_http_recall_url("q").startswith(
+        "http://127.0.0.1:18901/recall?"
+    )

--- a/docs/autonomous-files.md
+++ b/docs/autonomous-files.md
@@ -1,0 +1,53 @@
+# Autonomous Prompt Files
+
+`autonomous-action.sample.sh` (installed as `autonomous-action.sh`) builds the
+heartbeat prompt with three `@FILE` mentions:
+
+```text
+@SOUL.md
+@TODO.md
+@ROUTINES.md
+```
+
+`@FILE` is Claude Code's context mention: the file's contents are expanded into
+the prompt. The files live in the project directory, next to the script
+(the script `cd`s there before running `claude -p`). None of them ship with the
+repository, because their contents are yours.
+
+## What each file is for
+
+| File | Purpose | Who writes it |
+|---|---|---|
+| `SOUL.md` | The agent's personality and values: name, voice, what it cares about, what it refuses. The post-compaction recovery hook re-reads it first ("remember who you are"). | You, once; the agent may revise with you |
+| `TODO.md` | What the agent wants to do. Read to pick an action, written back with what was finished. When a heartbeat runs out of `[CONTINUE]` chains it parks the rest under a "前回の続き" (carried over) section here. | You and the agent |
+| `ROUTINES.md` | Recurring things with an interval and a last-run date. On a routine heartbeat the agent picks the one furthest behind schedule, runs it, and updates the date. Optional. | You and the agent |
+
+Without them the heartbeat still runs on `CLAUDE.md` alone.
+
+## What happens when one is missing
+
+An `@` mention of a file that does not exist resolves to nothing, and Claude
+Code does not say so. The heartbeat completes, the log looks normal, and the
+prompt has been running with a dead reference the whole time. Three things now
+point at it:
+
+- `autonomous-action.sh` checks for each of the three files before building
+  the prompt and writes `WARN: SOUL.md not found in <dir>; the @SOUL.md
+  reference in the prompt will not resolve` to its log and to stderr. It does
+  not abort.
+- `scripts/doctor.sh` warns per missing file when `autonomous-action.sh` is
+  installed, and merely notes their absence before that.
+- This page exists.
+
+## Templates
+
+Minimal, neutral starting points are in `examples/`:
+
+```bash
+cp examples/SOUL.sample.md SOUL.md
+cp examples/TODO.sample.md TODO.md
+cp examples/ROUTINES.sample.md ROUTINES.md   # optional
+```
+
+Edit them before the first heartbeat. `presets/` is something else: those are
+`~/.claude/CLAUDE.md` personality templates, not these files.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -37,9 +37,10 @@ scripts\setup.cmd --profile core --non-interactive
 WSL2 is not required. The Windows launcher runs the same Python setup service
 and writes the same portable Claude Code hook configuration as POSIX setup.
 
-Setup performs one locked Core workspace sync, writes the Core `.mcp.json`, creates
-`socialPolicy.toml` only when absent, warms the selected memory model, and runs
-the doctor.
+Setup performs one locked Core workspace sync, writes the Core `.mcp.json`,
+approves those servers for headless runs in `.claude/settings.local.json`,
+creates `socialPolicy.toml` only when absent, warms the selected memory model,
+and runs the doctor.
 
 Core contains:
 
@@ -289,6 +290,48 @@ Setup does not merge unknown custom MCP servers into the generated profile.
 Keep a manual copy or re-add custom entries after generation. The doctor
 reports unknown entries as warnings and does not modify them.
 
+### `env` blocks override the inherited environment
+
+A value in a server's `env` block wins over whatever the parent process
+exported, so only put values there that you want pinned. Setup writes
+`SOCIAL_DB_PATH` and `MEMORY_HTTP_PORT` only when they are set in the
+environment it runs in; otherwise the servers fall back to their code defaults
+(`~/.claude/sociality/social.db` and `18900`) and a later
+`SOCIAL_DB_PATH=... claude` still takes effect. Copying the defaults into
+`.mcp.json` by hand would silently pin them.
+
+## Headless (`claude -p`) and MCP approval
+
+Claude Code loads project `.mcp.json` servers only after they have been
+approved once, and `claude -p` has no way to ask. Unapproved servers are skipped
+without a message, so an autonomous heartbeat can start with no memory, no
+sociality and no kernel and log a normal-looking run. Editing `.mcp.json`
+resets the approval, so adding a camera later puts every server back to
+pending.
+
+Setup therefore also writes the approval, as the list Claude Code reads from
+the repository:
+
+```json
+// .claude/settings.local.json
+{ "enabledMcpjsonServers": ["memory", "desire-system", "sociality", "individual-kernel"] }
+```
+
+Other keys in that file (for example `permissions.allow`, which
+`autonomous-action.sh` reads) are kept; only the list is replaced, and it is
+set to exactly the servers setup just generated. The file is ignored by Git.
+
+If you edit `.mcp.json` by hand, re-run setup or add the new server name to
+`enabledMcpjsonServers` yourself. The doctor warns for every `.mcp.json`
+server missing from the list:
+
+```text
+[warn] headless:memory: memory is in .mcp.json but not enabled for headless runs; `claude -p` will skip it silently
+```
+
+`claude mcp list` showing `Pending approval` is the same condition seen from
+the other side.
+
 ## Doctor
 
 Run static checks:
@@ -332,7 +375,8 @@ Statuses:
 | `[error]` | Core or a selected configuration cannot start correctly |
 
 Static doctor is read-only. It does not create state directories, start MCP
-servers, connect to hardware, or make network calls. It verifies:
+servers, or connect to hardware. Its one network action is a TCP connect to
+the memory HTTP recall port on localhost. It verifies:
 
 - Python 3.13
 - current `uv.lock`
@@ -342,6 +386,15 @@ servers, connect to hardware, or make network calls. It verifies:
 - `socialPolicy.toml`
 - writable existing state parents
 - optional `ffmpeg`, `mpv`, or `ffplay`
+- every `.mcp.json` server is enabled for headless runs (see above)
+- memory HTTP recall port (`MEMORY_HTTP_PORT`, default `18900`) is listening.
+  `individual-kernel` pulls memory candidates into each tick over it and
+  commits the field without them when nothing answers. memory-mcp binds the
+  port when Claude Code starts it, so this is a warning until the first
+  session is running.
+- `SOUL.md`, `TODO.md`, `ROUTINES.md` for the autonomous prompt (a warning
+  once `autonomous-action.sh` is installed; see
+  [`docs/autonomous-files.md`](autonomous-files.md))
 
 Unknown custom MCP entries are warnings.
 

--- a/examples/ROUTINES.sample.md
+++ b/examples/ROUTINES.sample.md
@@ -1,0 +1,10 @@
+# ROUTINES.md — recurring things / 定期的にやること
+
+Copy to the project root as `ROUTINES.md` and edit (optional). On a routine
+heartbeat the agent reads this with `@ROUTINES.md`, picks the routine whose
+last run is furthest behind its interval, runs it, and updates the date.
+
+| Routine / ルーチン | Interval / 間隔 | Last run / 最終実行 |
+|---|---|---|
+| Look outside and note the weather / 外を見て天気を記録 | daily | - |
+| Tidy TODO.md / TODO.md を整理 | weekly | - |

--- a/examples/SOUL.sample.md
+++ b/examples/SOUL.sample.md
@@ -1,0 +1,17 @@
+# SOUL.md — who this agent is / このエージェントが誰か
+
+Copy to the project root as `SOUL.md` and edit. `autonomous-action.sh` pulls it
+into every heartbeat with `@SOUL.md`, and the post-compaction recovery hook
+re-reads it first. Keep it short: this is the outline, not the biography.
+
+## Name and voice / 名前と話し方
+- Name: / First person and tone:
+
+## Values / 大事にしていること
+- 
+
+## Things this agent will not do / やらないこと
+- 
+
+## Who matters / 大切な人
+- 

--- a/examples/TODO.sample.md
+++ b/examples/TODO.sample.md
@@ -1,0 +1,14 @@
+# TODO.md — what this agent wants to do / やりたいこと
+
+Copy to the project root as `TODO.md` and edit. `autonomous-action.sh` pulls it
+into every heartbeat with `@TODO.md`; the agent reads it to pick something to
+do and writes back what it finished or could not finish.
+
+## Now / いま
+- [ ] 
+
+## Later / そのうち
+- [ ] 
+
+## 前回の続き / Carried over
+<!-- The heartbeat writes here when it hits the [CONTINUE] chain limit. -->

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -9,6 +9,7 @@ import os
 import platform
 import re
 import shutil
+import socket
 import subprocess
 import sys
 import tempfile
@@ -311,6 +312,170 @@ def check_optional_dependencies(
     return results
 
 
+HEADLESS_SETTINGS = Path(".claude") / "settings.local.json"
+AUTONOMOUS_FILES = ("SOUL.md", "TODO.md", "ROUTINES.md")
+DEFAULT_MEMORY_HTTP_PORT = 18900
+
+
+def check_headless_approval(
+    repo_root: Path,
+    config: Mapping[str, Any],
+) -> list[CheckResult]:
+    """Check that every `.mcp.json` server is approved for `claude -p`.
+
+    Project MCP servers need a one-time approval that only an interactive
+    session can give. Headless runs skip unapproved servers without a word, so
+    the autonomous heartbeat can start with no memory and log a normal-looking
+    session (#140). `.claude/settings.local.json` carries the approval.
+    """
+
+    servers = config.get("mcpServers", {})
+    if not isinstance(servers, Mapping) or not servers:
+        return []
+    settings_path = repo_root / HEADLESS_SETTINGS
+    enabled: set[str] = set()
+    enable_all = False
+    if settings_path.exists():
+        try:
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            return [
+                CheckResult(
+                    CheckStatus.WARN,
+                    "headless:settings",
+                    f"{settings_path} is not readable JSON: {error}",
+                    "Fix the file or re-run scripts/setup.sh.",
+                )
+            ]
+        if isinstance(settings, Mapping):
+            enable_all = settings.get("enableAllProjectMcpServers") is True
+            listed = settings.get("enabledMcpjsonServers", [])
+            if isinstance(listed, list):
+                enabled = {str(item) for item in listed}
+
+    results: list[CheckResult] = []
+    for raw_name in servers:
+        name = str(raw_name)
+        if enable_all or name in enabled:
+            continue
+        results.append(
+            CheckResult(
+                CheckStatus.WARN,
+                f"headless:{name}",
+                f"{name} is in .mcp.json but not enabled for headless runs; "
+                "`claude -p` will skip it silently",
+                "re-run scripts/setup.sh or add it to .claude/settings.local.json "
+                "enabledMcpjsonServers",
+            )
+        )
+    if not results:
+        results.append(
+            CheckResult(
+                CheckStatus.OK,
+                "headless:approval",
+                f"every .mcp.json server is enabled in {HEADLESS_SETTINGS}",
+            )
+        )
+    return results
+
+
+def _port_is_listening(host: str, port: int) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+def check_memory_http_port(
+    environment: Mapping[str, str] | None = None,
+    *,
+    is_listening: Callable[[str, int], bool] = _port_is_listening,
+) -> CheckResult:
+    """Check that memory-mcp's HTTP recall endpoint is reachable.
+
+    individual-kernel pulls memory candidates into each tick over this port and
+    commits the field without them when nothing answers, so a closed port means
+    every heartbeat runs on no memory while looking normal (#140).
+    """
+
+    source = os.environ if environment is None else environment
+    raw = str(source.get("MEMORY_HTTP_PORT", DEFAULT_MEMORY_HTTP_PORT)).strip()
+    try:
+        port = int(raw)
+    except ValueError:
+        return CheckResult(
+            CheckStatus.WARN,
+            "memory:http-recall",
+            f"MEMORY_HTTP_PORT is not a number: {raw!r}",
+            "Unset it or set it to the port memory-mcp binds (default 18900).",
+        )
+    if port == 0:
+        return CheckResult(
+            CheckStatus.WARN,
+            "memory:http-recall",
+            "MEMORY_HTTP_PORT=0 disables HTTP recall; individual-kernel ticks "
+            "will carry no memory candidates",
+            "Unset MEMORY_HTTP_PORT unless this is intended.",
+        )
+    if is_listening("127.0.0.1", port):
+        return CheckResult(
+            CheckStatus.OK,
+            "memory:http-recall",
+            f"memory HTTP recall port {port} is listening",
+        )
+    return CheckResult(
+        CheckStatus.WARN,
+        "memory:http-recall",
+        f"memory HTTP recall port {port} is not listening; individual-kernel "
+        "ticks will carry no memory candidates",
+        "Expected until memory-mcp is running (it binds the port at startup). "
+        "If it is running, check MEMORY_HTTP_PORT matches in .mcp.json and the "
+        "environment.",
+    )
+
+
+def check_autonomous_files(repo_root: Path) -> list[CheckResult]:
+    """Check the files the autonomous prompt pulls in with `@FILE`.
+
+    `autonomous-action.sh` references SOUL.md, TODO.md and ROUTINES.md; an
+    `@` mention of a missing file resolves to nothing and nothing says so
+    (#140). A warning is only worth raising once the script is installed;
+    before that the absence is merely stated.
+    """
+
+    missing = [name for name in AUTONOMOUS_FILES if not (repo_root / name).is_file()]
+    installed = (repo_root / "autonomous-action.sh").is_file()
+    if not missing:
+        return [
+            CheckResult(
+                CheckStatus.OK,
+                "autonomous:files",
+                "SOUL.md, TODO.md and ROUTINES.md are present",
+            )
+        ]
+    if not installed:
+        return [
+            CheckResult(
+                CheckStatus.OK,
+                "autonomous:files",
+                f"{', '.join(missing)} absent; only needed once autonomous-action.sh "
+                "is installed (see docs/autonomous-files.md)",
+            )
+        ]
+    return [
+        CheckResult(
+            CheckStatus.WARN,
+            f"autonomous:{name}",
+            f"{name} is missing from {repo_root}; the @{name} reference in the "
+            "autonomous prompt will not resolve",
+            f"Copy examples/{name.removesuffix('.md')}.sample.md to {name} and edit "
+            "it (see docs/autonomous-files.md).",
+        )
+        for name in missing
+    ]
+
+
 def _load_config(path: Path) -> tuple[dict[str, Any] | None, CheckResult]:
     try:
         value = json.loads(path.read_text())
@@ -418,10 +583,13 @@ def run_doctor(
         check_state_path(home / ".claude" / "memories"),
         check_state_path(home / ".claude" / "sociality" / "social.db"),
     ]
+    results.extend(check_autonomous_files(repo_root))
+    results.append(check_memory_http_port())
     config, config_result = _load_config(config_path)
     results.append(config_result)
     if config is not None:
         results.extend(validate_mcp_config(config))
+        results.extend(check_headless_approval(repo_root, config))
         results.extend(check_workspace_packages(repo_root, config))
         results.extend(check_optional_dependencies(config, which=which))
     return results

--- a/scripts/onboarding.py
+++ b/scripts/onboarding.py
@@ -114,6 +114,11 @@ TAPO_REQUIRED_ENVIRONMENT = (
 )
 ELEVENLABS_REQUIRED_ENVIRONMENT = ("ELEVENLABS_API_KEY",)
 ELEVENLABS_OPTIONAL_ENVIRONMENT = ("ELEVENLABS_VOICE_ID",)
+# Both have code defaults (~/.claude/sociality/social.db and 18900). A value in
+# a server's env block overrides the inherited environment, so writing the
+# default here would pin it and silently defeat a later SOCIAL_DB_PATH=... in
+# the parent process. They are emitted only when the operator has set them.
+INDIVIDUAL_KERNEL_OPTIONAL_ENVIRONMENT = ("SOCIAL_DB_PATH", "MEMORY_HTTP_PORT")
 X_REQUIRED_ENVIRONMENT = (
     "XAI_API_KEY",
     "X_CONSUMER_KEY",
@@ -260,17 +265,24 @@ def build_mcp_config(
         if selection.embedding_model == "small"
         else BASE_EMBEDDING_MODEL
     )
+    # Operator overrides are pinned into every server that reads them, so the
+    # readers cannot disagree about which database or port is meant.
+    memory_environment = {"MEMORY_EMBEDDING_MODEL": embedding_model}
+    memory_environment.update(
+        _selected_environment(environment, (), ("MEMORY_HTTP_PORT",))
+    )
     servers: dict[str, dict[str, Any]] = {
-        "memory": SERVER_SPECS["memory"].command(
-            {"MEMORY_EMBEDDING_MODEL": embedding_model}
-        ),
+        "memory": SERVER_SPECS["memory"].command(memory_environment),
         "desire-system": SERVER_SPECS["desire-system"].command(),
-        "sociality": SERVER_SPECS["sociality"].command(),
+        "sociality": SERVER_SPECS["sociality"].command(
+            _selected_environment(environment, (), ("SOCIAL_DB_PATH",))
+        ),
         "individual-kernel": SERVER_SPECS["individual-kernel"].command(
-            {
-                "SOCIAL_DB_PATH": "~/.claude/sociality/social.db",
-                "MEMORY_HTTP_PORT": "18900",
-            }
+            _selected_environment(
+                environment,
+                (),
+                INDIVIDUAL_KERNEL_OPTIONAL_ENVIRONMENT,
+            )
         ),
     }
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -30,6 +30,7 @@ from scripts.setup_io import (
     ConfigConflictError,
     apply_config_plan,
     copy_policy_if_missing,
+    enable_headless_servers,
     plan_config_write,
 )
 
@@ -262,6 +263,20 @@ def execute_setup(
     else:
         print(f"==> backed up old config to {plan.backup.name}", file=output)
         print("==> replaced .mcp.json", file=output)
+
+    # Without this, `claude -p` (the autonomous heartbeat) starts with none of
+    # the servers just written and says nothing about it (#140).
+    settings_path = repo_root / ".claude" / "settings.local.json"
+    server_names = list(config["mcpServers"])
+    if enable_headless_servers(settings_path, server_names):
+        print(
+            "==> approved "
+            + ", ".join(server_names)
+            + " for headless runs in .claude/settings.local.json",
+            file=output,
+        )
+    else:
+        print("==> keeping headless approval in .claude/settings.local.json", file=output)
 
     policy_source = repo_root / "examples" / "configs" / "socialPolicy.example.toml"
     if not policy_source.is_file():

--- a/scripts/setup_io.py
+++ b/scripts/setup_io.py
@@ -6,7 +6,7 @@ import json
 import os
 import shutil
 import tempfile
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -120,6 +120,48 @@ def apply_config_plan(plan: ConfigPlan, config: Mapping[str, Any]) -> None:
     finally:
         if temporary_path is not None:
             temporary_path.unlink(missing_ok=True)
+
+
+HEADLESS_ENABLE_KEY = "enabledMcpjsonServers"
+
+
+def enable_headless_servers(settings_path: Path, server_names: Sequence[str]) -> bool:
+    """Approve project MCP servers for `claude -p` by name.
+
+    Claude Code loads `.mcp.json` servers only after they are approved, and a
+    headless run has no way to ask. It skips them silently instead, and every
+    edit of `.mcp.json` resets the approval (#140). The list in
+    `.claude/settings.local.json` is what makes the approval survive, so it is
+    rewritten to exactly the servers setup just generated: other keys in the
+    file are left alone, and the list is replaced rather than appended to.
+
+    Returns whether the file changed.
+    """
+
+    settings: dict[str, Any] = {}
+    if settings_path.exists():
+        try:
+            loaded = json.loads(settings_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise ConfigConflictError(
+                f"{settings_path} is not valid JSON; fix it before rerunning setup"
+            ) from error
+        if not isinstance(loaded, dict):
+            raise ConfigConflictError(
+                f"{settings_path} must contain a JSON object at the top level"
+            )
+        settings = loaded
+
+    wanted = list(dict.fromkeys(str(name) for name in server_names))
+    if settings.get(HEADLESS_ENABLE_KEY) == wanted:
+        return False
+    settings[HEADLESS_ENABLE_KEY] = wanted
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(
+        json.dumps(settings, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return True
 
 
 def copy_policy_if_missing(source: Path, destination: Path) -> bool:

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -109,10 +109,28 @@ def test_core_profile_has_exactly_the_hardware_free_servers() -> None:
     assert config["mcpServers"]["memory"]["env"]["MEMORY_EMBEDDING_MODEL"] == (
         SMALL_EMBEDDING_MODEL
     )
-    assert config["mcpServers"]["individual-kernel"]["env"] == {
-        "SOCIAL_DB_PATH": "~/.claude/sociality/social.db",
-        "MEMORY_HTTP_PORT": "18900",
+    # An env block overrides the inherited environment, so pinning the code
+    # defaults here would make a later SOCIAL_DB_PATH=... in the parent
+    # process a no-op (#140). Nothing is written unless the operator set it.
+    assert "env" not in config["mcpServers"]["individual-kernel"]
+    assert "env" not in config["mcpServers"]["sociality"]
+    assert "MEMORY_HTTP_PORT" not in config["mcpServers"]["memory"]["env"]
+
+
+def test_state_overrides_are_pinned_only_when_the_operator_set_them() -> None:
+    config = build_mcp_config(
+        FeatureSelection(),
+        {"SOCIAL_DB_PATH": "/srv/staging/social.db", "MEMORY_HTTP_PORT": "18901"},
+    )
+
+    servers = config["mcpServers"]
+    assert servers["individual-kernel"]["env"] == {
+        "SOCIAL_DB_PATH": "/srv/staging/social.db",
+        "MEMORY_HTTP_PORT": "18901",
     }
+    # Every reader of a value gets the same pin, so they cannot disagree.
+    assert servers["sociality"]["env"] == {"SOCIAL_DB_PATH": "/srv/staging/social.db"}
+    assert servers["memory"]["env"]["MEMORY_HTTP_PORT"] == "18901"
 
 
 def test_generated_servers_use_root_workspace_entrypoints() -> None:

--- a/tests/test_startup_losses.py
+++ b/tests/test_startup_losses.py
@@ -1,0 +1,286 @@
+"""Four things headless startup used to lose without a word (#140).
+
+Each of these fails at the configuration layer and looks fine at the execution
+layer: the heartbeat completes, the log reads normally, and only the absence
+is missing. Interactive use mostly catches them because a person is watching;
+`claude -p` has nobody watching.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from scripts import doctor
+from scripts.doctor import CheckResult, CheckStatus
+from scripts.onboarding import CORE_SERVER_NAMES, FeatureSelection
+from scripts.setup import execute_setup
+from scripts.setup_io import ConfigConflictError, enable_headless_servers
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = (ROOT / "autonomous-action.sample.sh").read_text(encoding="utf-8")
+
+
+# --- 1. project MCP servers need approval before `claude -p` will load them ---
+
+
+def test_enable_list_is_created_with_every_written_server(tmp_path: Path) -> None:
+    settings = tmp_path / ".claude" / "settings.local.json"
+
+    assert enable_headless_servers(settings, ["memory", "sociality"]) is True
+
+    assert json.loads(settings.read_text(encoding="utf-8")) == {
+        "enabledMcpjsonServers": ["memory", "sociality"]
+    }
+
+
+def test_enable_list_merges_without_clobbering_other_keys(tmp_path: Path) -> None:
+    # autonomous-action.sh reads permissions.allow from this very file; losing
+    # it would trade one silent startup loss for another.
+    settings = tmp_path / ".claude" / "settings.local.json"
+    settings.parent.mkdir()
+    settings.write_text(
+        json.dumps(
+            {
+                "permissions": {"allow": ["mcp__memory__recall"]},
+                "enabledMcpjsonServers": ["individual-kernel", "stale-server"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert enable_headless_servers(settings, ["memory", "memory", "sociality"]) is True
+
+    loaded = json.loads(settings.read_text(encoding="utf-8"))
+    assert loaded["permissions"] == {"allow": ["mcp__memory__recall"]}
+    # Replaced, not appended: editing .mcp.json resets approval, so the list
+    # has to track exactly what was just written, duplicates and stale names
+    # included.
+    assert loaded["enabledMcpjsonServers"] == ["memory", "sociality"]
+
+
+def test_enable_list_is_left_alone_when_already_current(tmp_path: Path) -> None:
+    settings = tmp_path / "settings.local.json"
+    settings.write_text('{"enabledMcpjsonServers": ["memory"]}\n', encoding="utf-8")
+    before = settings.read_text(encoding="utf-8")
+
+    assert enable_headless_servers(settings, ["memory"]) is False
+    assert settings.read_text(encoding="utf-8") == before
+
+
+def test_enable_list_refuses_to_overwrite_unreadable_settings(tmp_path: Path) -> None:
+    settings = tmp_path / "settings.local.json"
+    settings.write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(ConfigConflictError):
+        enable_headless_servers(settings, ["memory"])
+
+
+def _fixture_workspace(root: Path) -> None:
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "fixture"\nversion = "0.1.0"\n'
+        'dependencies = ["memory-mcp", "desire-system", "sociality-mcp", '
+        '"individual-kernel-mcp"]\n'
+    )
+    (root / "uv.lock").write_text("version = 1\n")
+    policy = root / "examples" / "configs" / "socialPolicy.example.toml"
+    policy.parent.mkdir(parents=True)
+    policy.write_text('version = 1\nname = "fixture"\n')
+
+
+def test_setup_enables_exactly_the_servers_it_wrote(tmp_path: Path) -> None:
+    _fixture_workspace(tmp_path)
+    output = StringIO()
+
+    result = execute_setup(
+        FeatureSelection(),
+        {},
+        repo_root=tmp_path,
+        home=tmp_path / "home",
+        dry_run=False,
+        force=False,
+        skip_model_download=True,
+        runner=lambda command, **_k: __import__("subprocess").CompletedProcess(
+            command, 0, "", ""
+        ),
+        doctor=lambda *_a, **_k: [CheckResult(CheckStatus.OK, "fixture", "ready")],
+        output=output,
+    )
+
+    assert result == 0
+    written = json.loads((tmp_path / ".mcp.json").read_text())["mcpServers"]
+    settings = json.loads(
+        (tmp_path / ".claude" / "settings.local.json").read_text(encoding="utf-8")
+    )
+    assert settings["enabledMcpjsonServers"] == list(written) == list(CORE_SERVER_NAMES)
+    assert "headless" in output.getvalue()
+
+
+def test_dry_run_does_not_write_the_enable_list(tmp_path: Path) -> None:
+    _fixture_workspace(tmp_path)
+
+    execute_setup(
+        FeatureSelection(),
+        {},
+        repo_root=tmp_path,
+        home=tmp_path / "home",
+        dry_run=True,
+        force=False,
+        skip_model_download=True,
+        output=StringIO(),
+    )
+
+    assert not (tmp_path / ".claude").exists()
+
+
+def test_settings_local_is_ignored_by_git() -> None:
+    ignored = (ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert ".claude/settings.local.json" in ignored
+
+
+def _config(*names: str) -> dict:
+    return {"mcpServers": {name: {"command": "uv", "args": []} for name in names}}
+
+
+def test_doctor_warns_per_server_missing_from_the_enable_list(tmp_path: Path) -> None:
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "settings.local.json").write_text(
+        '{"enabledMcpjsonServers": ["memory"]}', encoding="utf-8"
+    )
+
+    results = doctor.check_headless_approval(tmp_path, _config("memory", "sociality"))
+
+    assert [(r.status, r.subject) for r in results] == [
+        (CheckStatus.WARN, "headless:sociality")
+    ]
+    assert "not enabled for headless runs" in results[0].detail
+    assert "`claude -p` will skip it silently" in results[0].detail
+    assert "enabledMcpjsonServers" in results[0].remediation
+
+
+def test_doctor_warns_for_every_server_when_the_settings_file_is_absent(
+    tmp_path: Path,
+) -> None:
+    results = doctor.check_headless_approval(tmp_path, _config("memory", "sociality"))
+
+    assert [r.subject for r in results] == ["headless:memory", "headless:sociality"]
+    assert all(r.status is CheckStatus.WARN for r in results)
+
+
+def test_doctor_is_satisfied_by_a_complete_list_or_enable_all(tmp_path: Path) -> None:
+    (tmp_path / ".claude").mkdir()
+    settings = tmp_path / ".claude" / "settings.local.json"
+
+    settings.write_text('{"enabledMcpjsonServers": ["memory", "sociality"]}')
+    [result] = doctor.check_headless_approval(tmp_path, _config("memory", "sociality"))
+    assert result.status is CheckStatus.OK
+
+    settings.write_text('{"enableAllProjectMcpServers": true}')
+    [result] = doctor.check_headless_approval(tmp_path, _config("memory", "sociality"))
+    assert result.status is CheckStatus.OK
+
+
+# --- 2. memory HTTP recall port -------------------------------------------
+
+
+def test_doctor_warns_when_the_recall_port_is_closed() -> None:
+    result = doctor.check_memory_http_port({}, is_listening=lambda _h, _p: False)
+
+    assert result.status is CheckStatus.WARN
+    assert result.detail == (
+        "memory HTTP recall port 18900 is not listening; individual-kernel ticks "
+        "will carry no memory candidates"
+    )
+
+
+def test_doctor_probes_the_configured_recall_port() -> None:
+    probed: list[tuple[str, int]] = []
+
+    def listening(host: str, port: int) -> bool:
+        probed.append((host, port))
+        return True
+
+    result = doctor.check_memory_http_port(
+        {"MEMORY_HTTP_PORT": "18901"}, is_listening=listening
+    )
+
+    assert probed == [("127.0.0.1", 18901)]
+    assert result.status is CheckStatus.OK
+
+
+def test_doctor_really_connects_to_a_closed_port() -> None:
+    import socket
+
+    # Bind and release to find a port nothing is listening on right now.
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+
+    result = doctor.check_memory_http_port({"MEMORY_HTTP_PORT": str(port)})
+
+    assert result.status is CheckStatus.WARN
+    assert f"port {port} is not listening" in result.detail
+
+
+# --- 3. @SOUL.md / @TODO.md / @ROUTINES.md --------------------------------
+
+
+def test_script_checks_each_mentioned_file_before_building_the_prompt() -> None:
+    check_at = SCRIPT.index("for PROMPT_FILE in SOUL.md TODO.md ROUTINES.md")
+    prompt_at = SCRIPT.index('PROMPT="自律行動タイム')
+    assert check_at < prompt_at
+
+    for name in ("SOUL.md", "TODO.md", "ROUTINES.md"):
+        assert f"@{name}" in SCRIPT
+    assert re.search(r'WARN: \$PROMPT_FILE not found in \$SCRIPT_DIR', SCRIPT)
+    assert ">&2" in SCRIPT[check_at:prompt_at]
+    assert '>> "$LOG_FILE"' in SCRIPT[check_at:prompt_at]
+    # Warn, do not abort: the heartbeat still runs on CLAUDE.md alone.
+    assert "exit" not in SCRIPT[check_at:prompt_at]
+
+
+def test_templates_and_doc_exist_for_the_three_files() -> None:
+    for name in ("SOUL", "TODO", "ROUTINES"):
+        assert (ROOT / "examples" / f"{name}.sample.md").is_file()
+    doc = (ROOT / "docs" / "autonomous-files.md").read_text(encoding="utf-8")
+    for name in ("SOUL.md", "TODO.md", "ROUTINES.md"):
+        assert name in doc
+
+
+def test_doctor_warns_for_missing_files_once_the_script_is_installed(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "SOUL.md").write_text("# me\n")
+
+    [before] = doctor.check_autonomous_files(tmp_path)
+    assert before.status is CheckStatus.OK
+    assert "TODO.md, ROUTINES.md absent" in before.detail
+
+    (tmp_path / "autonomous-action.sh").write_text("#!/bin/bash\n")
+    after = doctor.check_autonomous_files(tmp_path)
+    assert [(r.status, r.subject) for r in after] == [
+        (CheckStatus.WARN, "autonomous:TODO.md"),
+        (CheckStatus.WARN, "autonomous:ROUTINES.md"),
+    ]
+    assert "@TODO.md reference" in after[0].detail
+
+    (tmp_path / "TODO.md").write_text("- [ ]\n")
+    (tmp_path / "ROUTINES.md").write_text("|\n")
+    [present] = doctor.check_autonomous_files(tmp_path)
+    assert present.status is CheckStatus.OK
+
+
+# --- 4. .mcp.json.example no longer pins SOCIAL_DB_PATH --------------------
+
+
+def test_examples_do_not_pin_state_overrides() -> None:
+    for name in (".mcp.json.example", "autonomous-mcp.json.example"):
+        config = json.loads((ROOT / name).read_text(encoding="utf-8"))
+        for server in config["mcpServers"].values():
+            env = server.get("env", {})
+            assert "SOCIAL_DB_PATH" not in env, name
+            assert "MEMORY_HTTP_PORT" not in env, name


### PR DESCRIPTION
Closes #140 (reported by @fmtowns3 — thank you for bundling these four under the axis that matters: autonomous runs degrade where nobody is watching).

## Changes
**1. Project MCP servers skipped by `claude -p` until approved**
- `scripts/setup.py` now writes/merges `enabledMcpjsonServers` (every server it wrote to `.mcp.json`) into `.claude/settings.local.json` (other keys kept, list replaced/deduped). `.gitignore` now covers that file (it did not before).
- `scripts/doctor.py`: `headless:*` warning for each `.mcp.json` server missing from the enable list (honours `enableAllProjectMcpServers`).
- `docs/setup.md`: "Headless (`claude -p`) and MCP approval", incl. that hand-editing `.mcp.json` resets approval.

**2. HTTP recall silently absent**
- `tick.py`: `_ingest_memory_http` → `_fetch_memory_http`, called before the tick transaction; the result status is recorded in the field's `epistemic_trace["memory_recall"]` (`ok:<n>` / `unreachable:<Exc>` / `disabled`); a stderr warning is printed once per process on failure and re-armed after a success; 1.2 s timeout kept; `MEMORY_HTTP_PORT=0` = recall off.
- `doctor.py`: `memory:http-recall` TCP probe of `127.0.0.1:${MEMORY_HTTP_PORT:-18900}`.

**3. `@SOUL.md` / `@TODO.md` / `@ROUTINES.md` silently unresolved**
- `autonomous-action.sample.sh` checks the three files before building PROMPT and logs `WARN: X not found …; the @X reference in the prompt will not resolve` (no abort).
- New `docs/autonomous-files.md` + `examples/{SOUL,TODO,ROUTINES}.sample.md` (neutral templates).
- `doctor.py`: `autonomous:files` warning when `autonomous-action.sh` exists and a file is missing.

**4. `.mcp.json.example` pinning `SOCIAL_DB_PATH`**
- Dropped the individual-kernel `env` block from the example (both values equal the code defaults). `scripts/onboarding.py` emits `SOCIAL_DB_PATH` / `MEMORY_HTTP_PORT` only when set in the environment at setup time. `docs/setup.md` notes that `env` blocks override the inherited environment.

## Tests
- `PYTHONUTF8=1 uv run pytest tests -q` → 102 passed (new `tests/test_startup_losses.py`)
- `PYTHONUTF8=1 uv run pytest consciousness-mcp/packages/individual-kernel-mcp/tests -q` → 437 passed (new `test_memory_http_recall.py`)
- `uv run ruff check scripts tests consciousness-mcp/packages/individual-kernel-mcp` → All checks passed
- `bash -n autonomous-action.sample.sh` → ok
(3 cp932 failures without PYTHONUTF8 are pre-existing on Windows.)

---

## 日本語版

Closes #140（@fmtowns3 さんの報告。「自律行動は誰も見ていない時間帯に静かに劣化する」という軸で 4 件を束ねていただいたのがありがたかったです）

### 変更
**1. `.mcp.json` のサーバーが承認されるまで `claude -p` で無言スキップ**
- `scripts/setup.py` が `.mcp.json` に書いた全サーバー名を `.claude/settings.local.json` の `enabledMcpjsonServers` に書く／マージする（他のキーは保持、リストは置き換え・重複除去）。`.gitignore` にこのファイルを追加（従来は入っていなかった）。
- `scripts/doctor.py`：`.mcp.json` にあるのに有効化リストに無いサーバーごとに `headless:*` 警告（`enableAllProjectMcpServers` も考慮）。
- `docs/setup.md`：「Headless (`claude -p`) and MCP approval」節。`.mcp.json` を手で編集すると承認が戻ることも記載。

**2. HTTP recall が落ちていても無言**
- `tick.py`：`_ingest_memory_http` → `_fetch_memory_http` にし、tick のトランザクション前に呼ぶ。結果を field の `epistemic_trace["memory_recall"]`（`ok:<n>` / `unreachable:<Exc>` / `disabled`）に記録。失敗時はプロセス中 1 回だけ stderr に警告し、成功したら再度警告できるようにリセット。1.2 秒タイムアウトは維持。`MEMORY_HTTP_PORT=0` で recall 無効。
- `doctor.py`：`memory:http-recall` で `127.0.0.1:${MEMORY_HTTP_PORT:-18900}` への TCP 到達性を確認。

**3. `@SOUL.md` / `@TODO.md` / `@ROUTINES.md` が無言で未解決**
- `autonomous-action.sample.sh` が PROMPT を組む前に 3 ファイルの存在を確認し、無ければ `WARN: X not found …; the @X reference in the prompt will not resolve` をログに残す（中断しない）。
- `docs/autonomous-files.md` と `examples/{SOUL,TODO,ROUTINES}.sample.md`（中立な雛形）を追加。
- `doctor.py`：`autonomous-action.sh` があるのに 3 ファイルが欠けていれば `autonomous:files` 警告。

**4. `.mcp.json.example` が `SOCIAL_DB_PATH` を固定**
- individual-kernel の `env` ブロックを例から削除（どちらもコードの既定値と同じ）。`scripts/onboarding.py` は setup 時の環境に `SOCIAL_DB_PATH` / `MEMORY_HTTP_PORT` が設定されているときだけ出力。`docs/setup.md` に「`env` ブロックは継承した環境変数を上書きする」を注記。

### テスト
- `PYTHONUTF8=1 uv run pytest tests -q` → 102 passed（新規 `tests/test_startup_losses.py`）
- `PYTHONUTF8=1 uv run pytest consciousness-mcp/packages/individual-kernel-mcp/tests -q` → 437 passed（新規 `test_memory_http_recall.py`）
- `uv run ruff check scripts tests consciousness-mcp/packages/individual-kernel-mcp` → All checks passed
- `bash -n autonomous-action.sample.sh` → ok
（PYTHONUTF8 なしで落ちる 3 件は Windows の cp932 由来で既存）

🤖 Generated with [Claude Code](https://claude.com/claude-code)