### PR TITLE
fix: make companion, tone and quiet-hours configurable instead of hardcoded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           uv run --project "$GITHUB_WORKSPACE" --directory wifi-cam-mcp pytest -q
           uv run --project "$GITHUB_WORKSPACE" --directory desire-system pytest -q
           uv run --project "$GITHUB_WORKSPACE" --directory system-temperature-mcp pytest -q
+          uv run --project "$GITHUB_WORKSPACE" --directory x-mcp pytest -q
           uv run --project "$GITHUB_WORKSPACE" --directory consciousness-mcp/packages/individual-kernel-mcp pytest -q
           uv run --project "$GITHUB_WORKSPACE" --directory sociality-mcp pytest -q
           uv run --project "$GITHUB_WORKSPACE" --directory sociality-mcp/packages/agent-grammar pytest -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to embodied-claude are documented here.
 
 ## [Unreleased]
 
+A contributor running the servers under a different agent, in a different
+time zone, found the code still assumed one particular household (#135,
+fmtowns3). None of it failed. The desire updater ran its "night" in someone
+else's afternoon, the thermometer answered in a dialect the agent did not
+speak, a successful post came back with a link to another account's timeline,
+and the social tools opened every tick on a `person_id` nobody in the room
+answered to. Each value was a fact about one deployment, left where the code
+made it look like a fact about the system.
+
+### Changed
+
+- desire-system, individual-kernel: the allostatic quiet hours read
+  `DESIRE_TIMEZONE` (IANA name or `+09:00`), `DESIRE_NIGHT_START`,
+  `DESIRE_NIGHT_END` and `DESIRE_DAWN_END` instead of hardcoding JST and
+  0-5 / 5-7. Defaults keep the previous behaviour; a band whose end is before
+  its start wraps past midnight, since a night-shift household's night does.
+  Both projections of the same need now read the same four variables, so they
+  cannot disagree about when night is. The `miss_kouta` spec the kernel
+  carried was a guess that nothing ever emitted, and is gone.
+- system-temperature: `SYSTEM_TEMPERATURE_TONE` selects between the original
+  Kansai phrasing (default) and a neutral one; both are plain tables keyed by
+  the same band names, so a third voice is a one-table addition. Every reply
+  also ends with a structured line -- `level=comfortable max_celsius=52.0`,
+  `iso=... part_of_day=morning` -- so an agent with its own voice can ignore the
+  sentence altogether. `SYSTEM_TEMPERATURE_TIMEZONE` moves the clock.
+- x-mcp: `post_tweet` returns `https://x.com/i/status/<id>`, which resolves for
+  whichever account actually posted, and its description no longer names one.
+- memory, sociality, individual-kernel: the default companion is
+  `COMPANION_NAME` (display name, shared with desire-system) and `COMPANION_ID`
+  (the `person_id` used by the social substrate and the kernel's hooks); the
+  primary-companion response contract is keyed on the latter rather than on a
+  literal. `get_self_summary` names the agent from `SELF_NAME`. All defaults
+  are neutral; this project's own values live in the `.env.example` files, and
+  `scripts/setup.py` carries these variables into the generated config only
+  when they are already set.
+- desire-system: the two "desires.json not found" messages are operator-facing
+  errors and now read as such, in neutral Japanese.
+
 ## [0.4.6] - 2026-07-31
 
 Setting up for a hands-on meant a room full of laptops with no cameras and no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,15 @@ and its key had not been issued (#137, reported by fmtowns3).
   that the hooks invoke `uv run --directory ${CLAUDE_PROJECT_DIR}`, so firing
   them with a foreign project root leaves a `.venv` there -- something `uv`
   does before any hook code runs, so it is documented rather than prevented.
+- system-temperature: `_run_powershell` decodes with the OEM code page on
+  Windows (`encoding="oem"`, with `errors="replace"`). PowerShell 5.1 writes
+  OEM while bare `text=True` reads the ANSI code page -- or UTF-8 under
+  `PYTHONUTF8=1` -- and a decode failure inside subprocess's reader thread
+  leaves `returncode=0` with `stdout=None`, so the following `strip()` raised
+  an `AttributeError` the function's own contract says cannot happen. On a
+  Japanese host both code pages are 932 and it happened to line up; where they
+  differ the output mojibakes silently instead. Found, measured and patched by
+  fmtowns3 on this PR.
 
 ### Changed
 

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/allostasis.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/allostasis.py
@@ -21,11 +21,81 @@ caller supplies the clock and tests stay deterministic.
 
 from __future__ import annotations
 
+import os
+import re
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, tzinfo
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-JST = timezone(timedelta(hours=9))
+# Quiet-hours clock. Mirrors desire-system/desire_updater.py: the same four
+# environment variables, the same defaults, so both projections of the same
+# need agree on when night is. Hardcoding JST and 0-5 meant a non-JST
+# deployment ran its "night" in the local afternoon, silently.
+DEFAULT_TIMEZONE = "Asia/Tokyo"
+DEFAULT_NIGHT_START = 0
+DEFAULT_NIGHT_END = 5
+DEFAULT_DAWN_END = 7
+
+_OFFSET_RE = re.compile(r"^([+-])(\d{1,2})(?::?(\d{2}))?$")
+
+
+def _fixed_offset(spec: str) -> tzinfo | None:
+    match = _OFFSET_RE.match(spec.strip())
+    if not match:
+        return None
+    sign = 1 if match.group(1) == "+" else -1
+    hours = int(match.group(2))
+    minutes = int(match.group(3) or 0)
+    if hours > 23 or minutes > 59:
+        return None
+    return timezone(sign * timedelta(hours=hours, minutes=minutes), spec.strip())
+
+
+def resolve_timezone(spec: str | None = None) -> tzinfo:
+    """Resolve ``DESIRE_TIMEZONE`` (IANA name or ``+09:00``), defaulting to Asia/Tokyo.
+
+    A name zoneinfo cannot resolve falls back to the fixed +09:00 this module
+    always used, rather than failing the body state over a configuration string.
+    """
+    raw = (spec if spec is not None else os.getenv("DESIRE_TIMEZONE", "")).strip()
+    if not raw:
+        raw = DEFAULT_TIMEZONE
+    fixed = _fixed_offset(raw)
+    if fixed is not None:
+        return fixed
+    try:
+        return ZoneInfo(raw)
+    except (ZoneInfoNotFoundError, ValueError):
+        return timezone(timedelta(hours=9), "JST")
+
+
+def _env_hour(name: str, default: int) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw) % 24
+    except ValueError:
+        return default
+
+
+def quiet_bands() -> tuple[int, int, int]:
+    """``(night_start, night_end, dawn_end)`` hours from the environment."""
+    return (
+        _env_hour("DESIRE_NIGHT_START", DEFAULT_NIGHT_START),
+        _env_hour("DESIRE_NIGHT_END", DEFAULT_NIGHT_END),
+        _env_hour("DESIRE_DAWN_END", DEFAULT_DAWN_END),
+    )
+
+
+def hour_in_band(hour: int, start: int, end: int) -> bool:
+    """``start <= hour < end`` on a 24-hour clock, wrapping past midnight if ``end < start``."""
+    if start == end:
+        return False
+    if start < end:
+        return start <= hour < end
+    return hour >= start or hour < end
 
 # Weights for the two valence terms. Chosen so that a fully good context reaches
 # +1 and a fully bad one reaches -1; see tests/test_valence_composition.py.
@@ -43,14 +113,13 @@ class DesireSpec:
     set_point: float
 
 
-# Mirrors desire-system/desire_updater.py. That package has its own virtualenv
-# and is not part of this workspace, so the constants are duplicated rather than
-# imported; mcpBehavior.toml can override them without touching code.
+# Mirrors desire-system/desire_updater.py. That package is a separate
+# distribution, so the constants are duplicated rather than imported;
+# mcpBehavior.toml can override them without touching code.
 DEFAULT_DESIRE_SPECS: dict[str, DesireSpec] = {
     "look_outside": DesireSpec(satisfaction_hours=1.0, set_point=0.3),
     "browse_curiosity": DesireSpec(satisfaction_hours=2.0, set_point=0.3),
     "miss_companion": DesireSpec(satisfaction_hours=3.0, set_point=0.3),
-    "miss_kouta": DesireSpec(satisfaction_hours=3.0, set_point=0.3),
     "observe_room": DesireSpec(satisfaction_hours=0.167, set_point=0.2),
     "identity_coherence": DesireSpec(satisfaction_hours=1.0, set_point=0.9),
     "cognitive_load": DesireSpec(satisfaction_hours=1.5, set_point=0.3),
@@ -148,18 +217,21 @@ def allostatic_set_point(name: str, spec: DesireSpec, now: datetime) -> float:
 
     Being alone at 3am is not the same as being alone at noon, so the social and
     outward-looking needs settle overnight. Identity coherence does not: it is
-    wanted equally at every hour.
+    wanted equally at every hour. "Night" is read from DESIRE_TIMEZONE /
+    DESIRE_NIGHT_START / DESIRE_NIGHT_END / DESIRE_DAWN_END (default JST, 0-5,
+    5-7), the same variables desire-system uses.
     """
 
     if name == "identity_coherence":
         return spec.set_point
-    hour = now.astimezone(JST).hour
-    if 0 <= hour < 5:
-        if name in ("miss_companion", "miss_kouta"):
+    hour = now.astimezone(resolve_timezone()).hour
+    night_start, night_end, dawn_end = quiet_bands()
+    if hour_in_band(hour, night_start, night_end):
+        if name == "miss_companion":
             return max(0.0, spec.set_point - 0.15)
         if name in ("look_outside", "observe_room"):
             return max(0.0, spec.set_point - 0.1)
-    if 5 <= hour < 7 and name in ("miss_companion", "miss_kouta"):
+    if hour_in_band(hour, night_end, dawn_end) and name == "miss_companion":
         return max(0.0, spec.set_point - 0.05)
     return spec.set_point
 

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/hook_cli.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/hook_cli.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from boundary_mcp.store import BoundaryStore
-from social_core import SocialDB
+from social_core import SocialDB, companion_id
 
 from individual_kernel_mcp.agency import is_external_tool
 from individual_kernel_mcp.boundary_adapter import BoundaryPolicyAdapter
@@ -150,7 +150,7 @@ def user_prompt_submit(
     field = producer.begin_tick(
         "heartbeat" if is_heartbeat else "user_prompt",
         owner_id,
-        person_id=str(payload.get("person_id") or "kouta"),
+        person_id=str(payload.get("person_id") or companion_id()),
         user_text=None if is_heartbeat else prompt,
         session_id=payload.get("session_id"),
     )

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_allostasis.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_allostasis.py
@@ -65,6 +65,71 @@ class TestAllostaticSetPoint:
         assert allostatic_set_point("not_a_real_desire", spec, T0) == spec.set_point
 
 
+class TestQuietHoursAreConfigurable:
+    """Night is read from the same env desire-system uses (#135).
+
+    With JST and 0-5 hardcoded, a deployment elsewhere ran its night in the
+    local afternoon and nothing said so.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch) -> None:
+        for key in ("DESIRE_TIMEZONE", "DESIRE_NIGHT_START", "DESIRE_NIGHT_END", "DESIRE_DAWN_END"):
+            monkeypatch.delenv(key, raising=False)
+
+    def test_default_is_jst_zero_to_five(self) -> None:
+        spec = DEFAULT_DESIRE_SPECS["miss_companion"]
+        night = datetime(2026, 7, 27, 17, 0, tzinfo=UTC)  # 02:00 JST
+        assert allostatic_set_point("miss_companion", spec, night) == pytest.approx(
+            spec.set_point - 0.15
+        )
+        assert DEFAULT_DESIRE_SPECS.keys() >= {"miss_companion"}
+        assert "miss_kouta" not in DEFAULT_DESIRE_SPECS
+
+    def test_other_timezone_shifts_the_band(self, monkeypatch) -> None:
+        spec = DEFAULT_DESIRE_SPECS["miss_companion"]
+        instant = datetime(2026, 7, 27, 8, 0, tzinfo=UTC)  # 17:00 JST, 04:00 New York
+        assert allostatic_set_point("miss_companion", spec, instant) == spec.set_point
+
+        monkeypatch.setenv("DESIRE_TIMEZONE", "America/New_York")
+        assert allostatic_set_point("miss_companion", spec, instant) == pytest.approx(
+            spec.set_point - 0.15
+        )
+
+    def test_fixed_offset_and_unknown_name(self, monkeypatch) -> None:
+        from individual_kernel_mcp.allostasis import resolve_timezone
+
+        monkeypatch.setenv("DESIRE_TIMEZONE", "-05:00")
+        probe = datetime(2026, 7, 27, 0, 0, tzinfo=UTC)
+        assert probe.astimezone(resolve_timezone()).utcoffset() == timedelta(hours=-5)
+
+        monkeypatch.setenv("DESIRE_TIMEZONE", "Not/AZone")
+        assert probe.astimezone(resolve_timezone()).utcoffset() == timedelta(hours=9)
+
+    def test_wrap_around_night_band(self, monkeypatch) -> None:
+        monkeypatch.setenv("DESIRE_TIMEZONE", "+09:00")
+        monkeypatch.setenv("DESIRE_NIGHT_START", "22")
+        monkeypatch.setenv("DESIRE_NIGHT_END", "5")
+        spec = DEFAULT_DESIRE_SPECS["miss_companion"]
+        jst = timezone(timedelta(hours=9))
+
+        at_23 = datetime(2026, 7, 27, 23, 0, tzinfo=jst)
+        at_03 = datetime(2026, 7, 27, 3, 0, tzinfo=jst)
+        at_06 = datetime(2026, 7, 27, 6, 0, tzinfo=jst)
+        at_12 = datetime(2026, 7, 27, 12, 0, tzinfo=jst)
+
+        assert allostatic_set_point("miss_companion", spec, at_23) == pytest.approx(
+            spec.set_point - 0.15
+        )
+        assert allostatic_set_point("miss_companion", spec, at_03) == pytest.approx(
+            spec.set_point - 0.15
+        )
+        assert allostatic_set_point("miss_companion", spec, at_06) == pytest.approx(
+            spec.set_point - 0.05
+        )
+        assert allostatic_set_point("miss_companion", spec, at_12) == spec.set_point
+
+
 class TestProjectDesires:
     def test_stalled_snapshot_still_moves(self) -> None:
         """The live failure mode: the writer stopped months ago."""

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_desire_staleness.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_desire_staleness.py
@@ -32,7 +32,7 @@ def _snapshot(age: timedelta) -> dict:
         "desires": {
             "look_outside": 0.018,
             "browse_curiosity": 1.0,
-            "miss_kouta": 1.0,
+            "miss_companion": 1.0,
             "observe_room": 1.0,
             "identity_coherence": 0.4,
         },

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_hook_cli.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_hook_cli.py
@@ -357,3 +357,47 @@ def test_forcing_one_shared_owner_takes_the_parents_committed_slot(
 
     assert child_field_id != parent_field_id
     assert _committed_field_id(tmp_path, "self") == child_field_id
+
+
+class _RecordingProducer:
+    """Just enough of a TickProducer to see what person_id a tick is opened with."""
+
+    def __init__(self) -> None:
+        self.begin_kwargs: dict = {}
+
+    def resolve_owner_id(self, _session_id):
+        return "self"
+
+    def begin_tick(self, _kind, _owner_id, **kwargs):
+        self.begin_kwargs = kwargs
+        return type("Field", (), {"tick_id": "tick-1"})()
+
+    def compete_and_commit(self, _tick_id):
+        return type("Outcome", (), {"field": None})()
+
+
+def _record_user_prompt(monkeypatch, payload: dict) -> dict:
+    from individual_kernel_mcp import hook_cli
+
+    monkeypatch.setattr(hook_cli, "_surface_context", lambda _field: "")
+    producer = _RecordingProducer()
+    hook_cli.user_prompt_submit(payload, producer)
+    return producer.begin_kwargs
+
+
+def test_user_prompt_person_id_defaults_to_neutral_companion(monkeypatch) -> None:
+    monkeypatch.delenv("COMPANION_ID", raising=False)
+    kwargs = _record_user_prompt(monkeypatch, {"prompt": "hi", "session_id": "s"})
+    assert kwargs["person_id"] == "companion"
+
+
+def test_user_prompt_person_id_honours_companion_id_env(monkeypatch) -> None:
+    monkeypatch.setenv("COMPANION_ID", "kouta")
+    kwargs = _record_user_prompt(monkeypatch, {"prompt": "hi", "session_id": "s"})
+    assert kwargs["person_id"] == "kouta"
+
+    # An explicit person_id in the payload still wins over the environment.
+    kwargs = _record_user_prompt(
+        monkeypatch, {"prompt": "hi", "session_id": "s", "person_id": "guest"}
+    )
+    assert kwargs["person_id"] == "guest"

--- a/desire-system/.env.example
+++ b/desire-system/.env.example
@@ -24,3 +24,12 @@ SELF_PRONOUN=ウチ
 # DESIRE_BROWSE_CURIOSITY_HOURS=2.0  # 2時間調べてないと気になる
 # DESIRE_MISS_COMPANION_HOURS=3.0    # 3時間話してないと寂しくなる
 # DESIRE_OBSERVE_ROOM_HOURS=0.167    # 10分ごとのベースライン観察
+
+# アロスタシス（時間帯でセットポイントを下げる）のタイムゾーンと時間帯
+# 既定はこれまでどおり JST / 深夜 0-5 時 / 早朝 5-7 時。
+# DESIRE_TIMEZONE は IANA 名か固定オフセット（+09:00 / -05:00）。
+# DESIRE_NIGHT_END < DESIRE_NIGHT_START なら日付をまたぐ帯（例: 22 → 5）。
+# DESIRE_TIMEZONE=Asia/Tokyo
+# DESIRE_NIGHT_START=0
+# DESIRE_NIGHT_END=5
+# DESIRE_DAWN_END=7

--- a/desire-system/desire_updater.py
+++ b/desire-system/desire_updater.py
@@ -19,10 +19,12 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, tzinfo
 from pathlib import Path
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from dotenv import load_dotenv
 
@@ -58,8 +60,88 @@ COMPANION_NAME = os.getenv("COMPANION_NAME", "あなた")
 SELF_NAME = os.getenv("SELF_NAME", "自分")
 SELF_PRONOUN = os.getenv("SELF_PRONOUN", "自分")
 
-# JST timezone
-JST = timezone(timedelta(hours=9))
+# ──────────────────────────────────────────────
+# 時間帯（アロスタシス用）。既定値はこれまでの JST / 0-5 時 / 5-7 時と同じ。
+# ──────────────────────────────────────────────
+#
+# タイムゾーンも深夜帯も固定だと、JST 以外の地域では現地の昼間に「深夜モード」が
+# 発火し、夜勤の生活では逆に効く。しかもエラーもログも出ないので、外からは
+# 「今日はあまり寂しがらないな」としか見えない。env で上書きできるようにする。
+#
+# DESIRE_TIMEZONE : IANA 名（Asia/Tokyo）か固定オフセット（+09:00 / -05:00）。
+#                   解決できなければ +09:00 に落ちる（クラッシュしない）。
+# DESIRE_NIGHT_START / DESIRE_NIGHT_END : 深夜帯 [start, end)。end < start なら
+#                   日付をまたぐ帯（22-5 時など）として扱う。
+# DESIRE_DAWN_END : 早朝帯 [NIGHT_END, DAWN_END)。
+DEFAULT_TIMEZONE = "Asia/Tokyo"
+DEFAULT_NIGHT_START = 0
+DEFAULT_NIGHT_END = 5
+DEFAULT_DAWN_END = 7
+
+_OFFSET_RE = re.compile(r"^([+-])(\d{1,2})(?::?(\d{2}))?$")
+
+
+def _fixed_offset(spec: str) -> tzinfo | None:
+    """Parse ``+09:00`` / ``-0500`` / ``+9`` into a fixed-offset timezone."""
+    m = _OFFSET_RE.match(spec.strip())
+    if not m:
+        return None
+    sign = 1 if m.group(1) == "+" else -1
+    hours = int(m.group(2))
+    minutes = int(m.group(3) or 0)
+    if hours > 23 or minutes > 59:
+        return None
+    return timezone(sign * timedelta(hours=hours, minutes=minutes), spec.strip())
+
+
+def resolve_timezone(spec: str | None = None) -> tzinfo:
+    """Resolve ``DESIRE_TIMEZONE`` to a tzinfo, defaulting to Asia/Tokyo.
+
+    Accepts an IANA name or a fixed offset. When zoneinfo cannot resolve the
+    name (Windows without tzdata, or a typo) it falls back to the fixed +09:00
+    that this module always used, rather than failing a body sense over a
+    configuration string.
+    """
+    raw = (spec if spec is not None else os.getenv("DESIRE_TIMEZONE", "")).strip()
+    if not raw:
+        raw = DEFAULT_TIMEZONE
+    fixed = _fixed_offset(raw)
+    if fixed is not None:
+        return fixed
+    try:
+        return ZoneInfo(raw)
+    except (ZoneInfoNotFoundError, ValueError):
+        return timezone(timedelta(hours=9), "JST")
+
+
+def _env_hour(name: str, default: int) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value % 24
+
+
+def quiet_bands() -> tuple[int, int, int]:
+    """Return ``(night_start, night_end, dawn_end)`` hours from env (or defaults)."""
+    return (
+        _env_hour("DESIRE_NIGHT_START", DEFAULT_NIGHT_START),
+        _env_hour("DESIRE_NIGHT_END", DEFAULT_NIGHT_END),
+        _env_hour("DESIRE_DAWN_END", DEFAULT_DAWN_END),
+    )
+
+
+def hour_in_band(hour: int, start: int, end: int) -> bool:
+    """``start <= hour < end`` on a 24-hour clock, wrapping past midnight if end < start."""
+    if start == end:
+        return False
+    if start < end:
+        return start <= hour < end
+    return hour >= start or hour < end
+
 
 
 # ──────────────────────────────────────────────
@@ -167,26 +249,30 @@ def get_allostatic_set_point(desire_name: str, now: datetime) -> float:
     """
     アロスタシス: 時間帯によるセットポイントの予測的調整。
 
-    深夜(0-5時)はsocial系欲求のセットポイントを下げる（一人でも平気）。
-    identity_coherenceは常に高いまま。
+    深夜帯（既定 0-5 時）は social 系欲求のセットポイントを下げる（一人でも平気）。
+    早朝帯（既定 5-7 時）は徐々に元に戻る。identity_coherence は常に高いまま。
+    タイムゾーンと時間帯は DESIRE_TIMEZONE / DESIRE_NIGHT_START / DESIRE_NIGHT_END /
+    DESIRE_DAWN_END で上書きできる（既定は従来どおり JST / 0-5 / 5-7）。
     """
     cfg = DESIRE_CONFIGS[desire_name]
     base_sp = cfg.set_point
 
-    # JSTに変換（naive datetimeの場合はUTCとみなす）
+    # ローカル時刻に変換（naive datetime の場合は UTC とみなす）
+    local_tz = resolve_timezone()
     if now.tzinfo is None:
-        now_jst = now.replace(tzinfo=timezone.utc).astimezone(JST)
+        now_local = now.replace(tzinfo=timezone.utc).astimezone(local_tz)
     else:
-        now_jst = now.astimezone(JST)
+        now_local = now.astimezone(local_tz)
 
-    hour = now_jst.hour
+    hour = now_local.hour
+    night_start, night_end, dawn_end = quiet_bands()
 
     # identity_coherenceは時間帯に関係なく不変
     if desire_name == "identity_coherence":
         return base_sp
 
-    # 深夜帯（0-5時JST）の調整
-    if 0 <= hour < 5:
+    # 深夜帯の調整
+    if hour_in_band(hour, night_start, night_end):
         if desire_name == "miss_companion":
             # 深夜は一人でも平気: セットポイントを下げる
             return max(0.0, base_sp - 0.15)
@@ -194,8 +280,8 @@ def get_allostatic_set_point(desire_name: str, now: datetime) -> float:
             # 深夜は外や部屋を見る欲求も落ち着く
             return max(0.0, base_sp - 0.1)
 
-    # 早朝帯（5-7時JST）: 徐々に元に戻る
-    if 5 <= hour < 7:
+    # 早朝帯: 徐々に元に戻る
+    if hour_in_band(hour, night_end, dawn_end):
         if desire_name == "miss_companion":
             return max(0.0, base_sp - 0.05)
 

--- a/desire-system/pyproject.toml
+++ b/desire-system/pyproject.toml
@@ -7,6 +7,10 @@ dependencies = [
     "chromadb>=0.5.0",
     "mcp>=1.0.0",
     "python-dotenv>=1.0.0",
+    # Windows ships no IANA time zone database, so zoneinfo needs tzdata to
+    # resolve DESIRE_TIMEZONE keys like "Asia/Tokyo". Linux/WSL2 has the
+    # system tzdb already; without it the updater falls back to fixed +09:00.
+    "tzdata>=2024.1; sys_platform == 'win32'",
 ]
 
 [project.optional-dependencies]

--- a/desire-system/server.py
+++ b/desire-system/server.py
@@ -192,9 +192,9 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             return [TextContent(
                 type="text",
                 text=(
-                    "desires.jsonが見つからへん。\n"
+                    "desires.json が見つかりません。\n"
                     f"パス: {DESIRES_PATH}\n"
-                    "desire_updater を先に実行: "
+                    "先に desire-updater を実行してください: "
                     "uv run --directory desire-system desire-updater"
                 ),
             )]
@@ -250,7 +250,7 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         if data is None:
             return [TextContent(
                 type="text",
-                text="desires.jsonが見つからへん。先にdesire-updaterを実行して。",
+                text="desires.json が見つかりません。先に desire-updater を実行してください。",
             )]
 
         desires = data.get("desires", {})

--- a/desire-system/tests/test_homeostasis.py
+++ b/desire-system/tests/test_homeostasis.py
@@ -259,6 +259,98 @@ class TestAllostasis:
         assert state_night.discomforts["miss_companion"] != state_day.discomforts["miss_companion"]
 
 
+class TestAllostasisConfigurableQuietHours:
+    """時間帯判定は DESIRE_TIMEZONE / DESIRE_NIGHT_* / DESIRE_DAWN_END に従う。
+
+    固定だと JST 以外の地域では現地の昼間に深夜モードが発火する。エラーもログも
+    出ないので、外からは見えない（#135）。
+    """
+
+    def _clear(self, monkeypatch):
+        for key in ("DESIRE_TIMEZONE", "DESIRE_NIGHT_START", "DESIRE_NIGHT_END", "DESIRE_DAWN_END"):
+            monkeypatch.delenv(key, raising=False)
+
+    def test_defaults_are_jst_and_zero_to_five(self, monkeypatch):
+        """env 未設定なら従来どおり: UTC 18:00 = JST 03:00 は深夜帯。"""
+        self._clear(monkeypatch)
+        from desire_updater import quiet_bands, resolve_timezone
+
+        assert quiet_bands() == (0, 5, 7)
+        probe = datetime(2026, 4, 8, 0, 0, 0, tzinfo=timezone.utc)
+        assert probe.astimezone(resolve_timezone()).utcoffset() == timedelta(hours=9)
+
+        base_sp = DESIRE_CONFIGS["miss_companion"].set_point
+        utc_evening = datetime(2026, 4, 8, 18, 0, 0, tzinfo=timezone.utc)  # 03:00 JST
+        assert get_allostatic_set_point("miss_companion", utc_evening) == pytest.approx(
+            base_sp - 0.15
+        )
+
+    def test_other_timezone_shifts_the_band(self, monkeypatch):
+        """同じ UTC 瞬間でも、タイムゾーンが違えば深夜かどうかが変わる。"""
+        self._clear(monkeypatch)
+        base_sp = DESIRE_CONFIGS["miss_companion"].set_point
+        instant = datetime(2026, 4, 8, 8, 0, 0, tzinfo=timezone.utc)  # 17:00 JST / 03:00 New York
+
+        assert get_allostatic_set_point("miss_companion", instant) == pytest.approx(base_sp)
+
+        monkeypatch.setenv("DESIRE_TIMEZONE", "America/New_York")
+        assert get_allostatic_set_point("miss_companion", instant) == pytest.approx(
+            base_sp - 0.15
+        )
+
+    def test_fixed_offset_timezone_is_accepted(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("DESIRE_TIMEZONE", "-05:00")
+        from desire_updater import resolve_timezone
+
+        probe = datetime(2026, 4, 8, 0, 0, 0, tzinfo=timezone.utc)
+        assert probe.astimezone(resolve_timezone()).utcoffset() == timedelta(hours=-5)
+
+        base_sp = DESIRE_CONFIGS["miss_companion"].set_point
+        instant = datetime(2026, 4, 8, 8, 0, 0, tzinfo=timezone.utc)  # 03:00 at -05:00
+        assert get_allostatic_set_point("miss_companion", instant) == pytest.approx(
+            base_sp - 0.15
+        )
+
+    def test_unknown_timezone_falls_back_to_jst(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("DESIRE_TIMEZONE", "Not/AZone")
+        from desire_updater import resolve_timezone
+
+        probe = datetime(2026, 4, 8, 0, 0, 0, tzinfo=timezone.utc)
+        assert probe.astimezone(resolve_timezone()).utcoffset() == timedelta(hours=9)
+
+    def test_wrap_around_night_band(self, monkeypatch):
+        """NIGHT_START=22, NIGHT_END=5 なら 23 時も 3 時も深夜、12 時は昼。"""
+        self._clear(monkeypatch)
+        monkeypatch.setenv("DESIRE_TIMEZONE", "+09:00")
+        monkeypatch.setenv("DESIRE_NIGHT_START", "22")
+        monkeypatch.setenv("DESIRE_NIGHT_END", "5")
+        monkeypatch.setenv("DESIRE_DAWN_END", "7")
+        jst = timezone(timedelta(hours=9))
+        base_sp = DESIRE_CONFIGS["miss_companion"].set_point
+
+        at_23 = datetime(2026, 4, 8, 23, 0, 0, tzinfo=jst)
+        at_03 = datetime(2026, 4, 8, 3, 0, 0, tzinfo=jst)
+        at_06 = datetime(2026, 4, 8, 6, 0, 0, tzinfo=jst)
+        at_12 = datetime(2026, 4, 8, 12, 0, 0, tzinfo=jst)
+
+        assert get_allostatic_set_point("miss_companion", at_23) == pytest.approx(base_sp - 0.15)
+        assert get_allostatic_set_point("miss_companion", at_03) == pytest.approx(base_sp - 0.15)
+        assert get_allostatic_set_point("miss_companion", at_06) == pytest.approx(base_sp - 0.05)
+        assert get_allostatic_set_point("miss_companion", at_12) == pytest.approx(base_sp)
+
+    def test_hour_in_band_helper(self):
+        from desire_updater import hour_in_band
+
+        assert hour_in_band(3, 0, 5)
+        assert not hour_in_band(5, 0, 5)
+        assert hour_in_band(23, 22, 5)
+        assert hour_in_band(4, 22, 5)
+        assert not hour_in_band(12, 22, 5)
+        assert not hour_in_band(3, 3, 3)
+
+
 # ──────────────────────────────────────────────
 # 6. 後方互換性: 既存テストが壊れない
 # ──────────────────────────────────────────────

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -239,6 +239,30 @@ uses the LibreHardwareMonitor bridge documented in
 [`system-temperature-mcp/README_WinNative.md`](../system-temperature-mcp/README_WinNative.md).
 WSL2 normally cannot see Windows host temperature sensors.
 
+The tool replies are phrased in Kansai dialect by default. Set
+`SYSTEM_TEMPERATURE_TONE=neutral` for plain Japanese and
+`SYSTEM_TEMPERATURE_TIMEZONE` (IANA name, default `Asia/Tokyo`) for the clock;
+see [Persona and companion](#persona-and-companion) below.
+
+## Persona and companion
+
+Several servers carry names or a voice. None of them is required, and every
+default is neutral; the values used by this project's own agent live in the
+package `.env.example` files. The setup script passes any of these through to
+the generated `.mcp.json` when they are set in the environment it runs under.
+
+| Variable | Default | Used by |
+| --- | --- | --- |
+| `COMPANION_NAME` | `あなた` | memory (`person` default of `tom` / `joint_attention`), desire-system (`miss_companion` label) |
+| `COMPANION_ID` | `companion` | sociality / interaction-orchestrator (`person_id` default and the primary-companion response contract), individual-kernel hooks |
+| `SELF_NAME` | `自分` (desire-system) / `This agent` (self-narrative summary) | desire-system `identity_coherence`, sociality `get_self_summary` |
+| `SELF_PRONOUN` | `自分` | desire-system `identity_coherence` |
+| `SYSTEM_TEMPERATURE_TONE` | `kansai` | system-temperature phrasing (`kansai` or `neutral`) |
+| `SYSTEM_TEMPERATURE_TIMEZONE` | `Asia/Tokyo` | system-temperature `get_current_time` |
+| `DESIRE_TIMEZONE` | `Asia/Tokyo` | desire-system and individual-kernel allostatic quiet hours (IANA name or `+09:00`) |
+| `DESIRE_NIGHT_START` / `DESIRE_NIGHT_END` | `0` / `5` | night band `[start, end)`; `end < start` wraps past midnight |
+| `DESIRE_DAWN_END` | `7` | dawn band `[NIGHT_END, DAWN_END)` |
+
 ## Preview Without Side Effects
 
 Use `--dry-run` to inspect a redacted generated config:

--- a/memory-mcp/.env.example
+++ b/memory-mcp/.env.example
@@ -5,3 +5,7 @@
 
 # Collection name for memories (default: claude_memories)
 # MEMORY_COLLECTION_NAME=claude_memories
+
+# Display name of the person you live with. Default "person" for the tom /
+# joint_attention tools (default: あなた). Same variable as desire-system.
+COMPANION_NAME=コウタ

--- a/memory-mcp/src/memory_mcp/server.py
+++ b/memory-mcp/src/memory_mcp/server.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import os
 from collections.abc import Awaitable, Callable
 from contextlib import AsyncExitStack, asynccontextmanager
 from pathlib import Path
@@ -21,6 +22,12 @@ from .types import CameraPosition
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+# Display name of the person the agent lives with. Used as the default ``person``
+# for the theory-of-mind and joint-attention tools; read once at import so the
+# advertised schema default and the value actually used are the same string.
+# Same variable and default as desire-system (see #134, #135).
+COMPANION_NAME = os.getenv("COMPANION_NAME", "あなた")
 
 
 async def _start_http_recall_server(
@@ -676,8 +683,8 @@ class MemoryMCPServer:
                             },
                             "person": {
                                 "type": "string",
-                                "description": "Who you are talking to (default: コウタ)",
-                                "default": "コウタ",
+                                "description": f"Who you are talking to (default: {COMPANION_NAME})",
+                                "default": COMPANION_NAME,
                             },
                         },
                         "required": ["situation"],
@@ -706,8 +713,8 @@ class MemoryMCPServer:
                             },
                             "person": {
                                 "type": "string",
-                                "description": "Who you are sharing attention with (default: コウタ)",
-                                "default": "コウタ",
+                                "description": f"Who you are sharing attention with (default: {COMPANION_NAME})",
+                                "default": COMPANION_NAME,
                             },
                         },
                         "required": ["target"],
@@ -1392,7 +1399,7 @@ Date Range:
                         if not situation:
                             return [TextContent(type="text", text="Error: situation is required")]
 
-                        person = arguments.get("person", "コウタ")
+                        person = arguments.get("person", COMPANION_NAME)
 
                         # Pull relevant memories: personality, communication patterns
                         tom_memories = await self._memory_store.recall(
@@ -1446,7 +1453,7 @@ Date Range:
 
                         direction = arguments.get("direction", "respond")
                         my_observation = arguments.get("my_observation", "")
-                        person = arguments.get("person", "コウタ")
+                        person = arguments.get("person", COMPANION_NAME)
 
                         # Pull memories related to the shared target
                         ja_memories = await self._memory_store.recall(

--- a/memory-mcp/tests/test_companion_name.py
+++ b/memory-mcp/tests/test_companion_name.py
@@ -1,0 +1,58 @@
+"""The default ``person`` of the social tools follows COMPANION_NAME (#135).
+
+The literal default used to be one specific person's name, so every other
+deployment's theory-of-mind and joint-attention calls were about someone they
+had never met.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from mcp.types import ListToolsRequest
+
+
+async def _tool_schemas(server_module) -> dict[str, dict]:
+    mcp_server = server_module.MemoryMCPServer()
+    handler = mcp_server._server.request_handlers[ListToolsRequest]
+    result = await handler(ListToolsRequest(method="tools/list"))
+    return {tool.name: tool.inputSchema for tool in result.root.tools}
+
+
+@pytest.fixture
+def reloaded_server(monkeypatch):
+    """Reload memory_mcp.server under a controlled COMPANION_NAME and restore it after."""
+
+    import memory_mcp.server as server_module
+
+    def _reload(value: str | None):
+        if value is None:
+            monkeypatch.delenv("COMPANION_NAME", raising=False)
+        else:
+            monkeypatch.setenv("COMPANION_NAME", value)
+        return importlib.reload(server_module)
+
+    yield _reload
+    monkeypatch.delenv("COMPANION_NAME", raising=False)
+    importlib.reload(server_module)
+
+
+async def test_default_person_is_neutral(reloaded_server) -> None:
+    server_module = reloaded_server(None)
+
+    assert server_module.COMPANION_NAME == "あなた"
+    schemas = await _tool_schemas(server_module)
+    assert schemas["tom"]["properties"]["person"]["default"] == "あなた"
+    assert schemas["joint_attention"]["properties"]["person"]["default"] == "あなた"
+    assert "コウタ" not in schemas["tom"]["properties"]["person"]["description"]
+
+
+async def test_default_person_follows_companion_name(reloaded_server) -> None:
+    server_module = reloaded_server("コウタ")
+
+    assert server_module.COMPANION_NAME == "コウタ"
+    schemas = await _tool_schemas(server_module)
+    assert schemas["tom"]["properties"]["person"]["default"] == "コウタ"
+    assert "コウタ" in schemas["tom"]["properties"]["person"]["description"]
+    assert schemas["joint_attention"]["properties"]["person"]["default"] == "コウタ"

--- a/scripts/onboarding.py
+++ b/scripts/onboarding.py
@@ -122,6 +122,27 @@ X_REQUIRED_ENVIRONMENT = (
     "X_ACCESS_TOKEN_SECRET",
 )
 
+# Persona and quiet-hours settings (#135). None is required and every server
+# has a neutral default, so these are only carried into the generated config
+# when the environment setup runs under already sets them; setup never invents
+# a name for anyone.
+PERSONA_OPTIONAL_ENVIRONMENT = (
+    "COMPANION_NAME",
+    "COMPANION_ID",
+    "SELF_NAME",
+    "SELF_PRONOUN",
+)
+QUIET_HOURS_OPTIONAL_ENVIRONMENT = (
+    "DESIRE_TIMEZONE",
+    "DESIRE_NIGHT_START",
+    "DESIRE_NIGHT_END",
+    "DESIRE_DAWN_END",
+)
+SYSTEM_TEMPERATURE_OPTIONAL_ENVIRONMENT = (
+    "SYSTEM_TEMPERATURE_TONE",
+    "SYSTEM_TEMPERATURE_TIMEZONE",
+)
+
 # Deliberately fake values for --all. They keep the `changeme-` marker that
 # is_placeholder_value() rejects, so a demo config announces itself as one
 # rather than passing for a working setup.
@@ -260,16 +281,26 @@ def build_mcp_config(
         if selection.embedding_model == "small"
         else BASE_EMBEDDING_MODEL
     )
+    persona_environment = _selected_environment(
+        environment, (), PERSONA_OPTIONAL_ENVIRONMENT
+    )
+    quiet_hours_environment = _selected_environment(
+        environment, (), QUIET_HOURS_OPTIONAL_ENVIRONMENT
+    )
     servers: dict[str, dict[str, Any]] = {
         "memory": SERVER_SPECS["memory"].command(
-            {"MEMORY_EMBEDDING_MODEL": embedding_model}
+            {"MEMORY_EMBEDDING_MODEL": embedding_model, **persona_environment}
         ),
-        "desire-system": SERVER_SPECS["desire-system"].command(),
-        "sociality": SERVER_SPECS["sociality"].command(),
+        "desire-system": SERVER_SPECS["desire-system"].command(
+            {**persona_environment, **quiet_hours_environment}
+        ),
+        "sociality": SERVER_SPECS["sociality"].command(persona_environment),
         "individual-kernel": SERVER_SPECS["individual-kernel"].command(
             {
                 "SOCIAL_DB_PATH": "~/.claude/sociality/social.db",
                 "MEMORY_HTTP_PORT": "18900",
+                **persona_environment,
+                **quiet_hours_environment,
             }
         ),
     }
@@ -327,7 +358,11 @@ def build_mcp_config(
         )
 
     if selection.system_temperature:
-        servers["system-temperature"] = SERVER_SPECS["system-temperature"].command()
+        servers["system-temperature"] = SERVER_SPECS["system-temperature"].command(
+            _selected_environment(
+                environment, (), SYSTEM_TEMPERATURE_OPTIONAL_ENVIRONMENT
+            )
+        )
 
     return {"mcpServers": servers}
 

--- a/sociality-mcp/packages/interaction-orchestrator-mcp/src/interaction_orchestrator_mcp/compose.py
+++ b/sociality-mcp/packages/interaction-orchestrator-mcp/src/interaction_orchestrator_mcp/compose.py
@@ -11,7 +11,7 @@ from boundary_mcp.store import BoundaryStore
 from joint_attention_mcp.store import JointAttentionStore
 from relationship_mcp.store import RelationshipStore
 from self_narrative_mcp.store import SelfNarrativeStore
-from social_core import DEFAULT_POLICY_TIMEZONE, local_view, utc_now
+from social_core import DEFAULT_POLICY_TIMEZONE, companion_id, local_view, utc_now
 from social_state_mcp.store import SocialStateStore
 
 from .desire_source import load_desire_snapshot
@@ -358,7 +358,9 @@ def _pick_contract(
     *, person_id: str | None, channel: str, quiet_active: bool
 ) -> ResponseContract:
     base = ResponseContract()
-    if person_id == "kouta":
+    # Contract for the configured primary companion (COMPANION_ID); everyone
+    # else gets the neutral default above.
+    if person_id == companion_id():
         base = ResponseContract(
             treat_user_as="high-context technical partner",
             avoid=[

--- a/sociality-mcp/packages/interaction-orchestrator-mcp/src/interaction_orchestrator_mcp/schemas.py
+++ b/sociality-mcp/packages/interaction-orchestrator-mcp/src/interaction_orchestrator_mcp/schemas.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from social_core.models import EpistemicClaim, EvidenceType
+from social_core.persona import companion_id
 
 Channel = Literal["chat", "voice", "autonomous", "x", "file", "system"]
 
@@ -47,7 +48,9 @@ class ComposeInteractionContextInput(BaseModel):
 
     model_config = ConfigDict(extra="ignore")
 
-    person_id: str | None = "kouta"
+    # The primary companion's identifier comes from COMPANION_ID; read per
+    # instance so a changed environment is honoured without a reload.
+    person_id: str | None = Field(default_factory=companion_id)
     channel: Channel = "chat"
     user_text: str | None = None
     autonomous_trigger: str | None = None

--- a/sociality-mcp/packages/interaction-orchestrator-mcp/tests/conftest.py
+++ b/sociality-mcp/packages/interaction-orchestrator-mcp/tests/conftest.py
@@ -41,6 +41,16 @@ preferred_nudge_style = "brief_gentle"
     return path
 
 
+@pytest.fixture(autouse=True)
+def companion_is_kouta(monkeypatch):
+    """The fixture policy and events name the companion "kouta".
+
+    The primary-companion contract is keyed on COMPANION_ID (#135), so the
+    tests state that binding instead of relying on a literal in the code.
+    """
+    monkeypatch.setenv("COMPANION_ID", "kouta")
+
+
 @pytest.fixture
 def db(tmp_path: Path) -> SocialDB:
     social_db = SocialDB(tmp_path / "social.db")

--- a/sociality-mcp/packages/interaction-orchestrator-mcp/tests/test_orchestrator.py
+++ b/sociality-mcp/packages/interaction-orchestrator-mcp/tests/test_orchestrator.py
@@ -72,6 +72,25 @@ class TestCompose:
         assert ctx.compact_prompt_block.startswith("[interaction_context]")
         assert ctx.timezone == "Asia/Tokyo"
 
+    def test_primary_contract_follows_companion_id(self, stores, monkeypatch):
+        """The primary-companion contract is for whoever COMPANION_ID names (#135)."""
+        monkeypatch.delenv("COMPANION_ID", raising=False)
+        default_ctx = _compose(stores, user_text="テスト", person_id="companion")
+        assert "generic reassurance" in default_ctx.response_contract.avoid
+
+        other = _compose(stores, user_text="テスト", person_id="kouta")
+        assert "generic reassurance" not in other.response_contract.avoid
+
+        monkeypatch.setenv("COMPANION_ID", "kouta")
+        named = _compose(stores, user_text="テスト", person_id="kouta")
+        assert "generic reassurance" in named.response_contract.avoid
+
+    def test_person_id_defaults_to_companion_id(self, monkeypatch):
+        monkeypatch.delenv("COMPANION_ID", raising=False)
+        assert ComposeInteractionContextInput().person_id == "companion"
+        monkeypatch.setenv("COMPANION_ID", "kouta")
+        assert ComposeInteractionContextInput().person_id == "kouta"
+
     def test_autonomous_channel_tightens_contract(self, stores):
         ctx = _compose(stores, user_text=None, channel="autonomous")
         joined = " ".join(ctx.response_contract.avoid)

--- a/sociality-mcp/packages/self-narrative-mcp/src/self_narrative_mcp/summarizer.py
+++ b/sociality-mcp/packages/self-narrative-mcp/src/self_narrative_mcp/summarizer.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from collections import Counter
 
+from social_core.persona import self_name
+
 
 def build_day_summary(day: str, event_kinds: list[str], person_ids: list[str]) -> str:
     """Build a compact daybook summary from event kinds and participants."""
@@ -52,7 +54,7 @@ def build_self_summary(
     continuity trace rather than a generic posture statement.
     """
 
-    pieces = ["Kokone keeps a socially aware, continuity-seeking self-model."]
+    pieces = [f"{self_name()} keeps a socially aware, continuity-seeking self-model."]
     if facets:
         pieces.append(f"Current facets: {', '.join(facets[:2])}.")
     if arcs:

--- a/sociality-mcp/packages/self-narrative-mcp/tests/test_narrative.py
+++ b/sociality-mcp/packages/self-narrative-mcp/tests/test_narrative.py
@@ -131,5 +131,17 @@ def test_self_summary_and_reflect_on_change(store):
     summary = store.get_self_summary()
     change = store.reflect_on_change(horizon_days=2)
 
-    assert "Kokone" in summary.summary
+    assert summary.summary.startswith("This agent keeps a socially aware")
     assert change.summary
+
+
+def test_self_summary_names_the_configured_agent(monkeypatch):
+    """get_self_summary is injected into prompts, so it must not name someone else's agent."""
+    from self_narrative_mcp.summarizer import build_self_summary
+
+    monkeypatch.delenv("SELF_NAME", raising=False)
+    assert build_self_summary(None, [], []).startswith("This agent keeps")
+    assert "Kokone" not in build_self_summary(None, [], [])
+
+    monkeypatch.setenv("SELF_NAME", "Kokone")
+    assert build_self_summary(None, [], []).startswith("Kokone keeps")

--- a/sociality-mcp/packages/social-core/src/social_core/__init__.py
+++ b/sociality-mcp/packages/social-core/src/social_core/__init__.py
@@ -1,9 +1,17 @@
-"""Shared storage and schema helpers for Kokone sociality MCPs."""
+"""Shared storage and schema helpers for the sociality MCPs."""
 
 from .confidence import clamp01, confidence_from_evidence, weighted_average
 from .db import DEFAULT_SOCIAL_DB_PATH, SocialDB, get_social_db_path
 from .events import EventStore, build_event_id
 from .models import EVENT_KINDS, SocialEvent, SocialEventCreate
+from .persona import (
+    DEFAULT_COMPANION_ID,
+    DEFAULT_COMPANION_NAME,
+    DEFAULT_SELF_NAME,
+    companion_id,
+    companion_name,
+    self_name,
+)
 from .time import (
     DEFAULT_POLICY_TIMEZONE,
     FixedClock,
@@ -15,7 +23,10 @@ from .time import (
 )
 
 __all__ = [
+    "DEFAULT_COMPANION_ID",
+    "DEFAULT_COMPANION_NAME",
     "DEFAULT_POLICY_TIMEZONE",
+    "DEFAULT_SELF_NAME",
     "DEFAULT_SOCIAL_DB_PATH",
     "EVENT_KINDS",
     "EventStore",
@@ -25,12 +36,15 @@ __all__ = [
     "SocialEventCreate",
     "build_event_id",
     "clamp01",
+    "companion_id",
+    "companion_name",
     "confidence_from_evidence",
     "ensure_iso8601",
     "get_social_db_path",
     "in_quiet_hours",
     "local_view",
     "parse_timestamp",
+    "self_name",
     "utc_now",
     "weighted_average",
 ]

--- a/sociality-mcp/packages/social-core/src/social_core/persona.py
+++ b/sociality-mcp/packages/social-core/src/social_core/persona.py
@@ -1,0 +1,42 @@
+"""Who the agent is and who it lives with, read from the environment.
+
+The sociality packages used to carry one person's identifier as a literal
+default (``person_id="kouta"``) and one agent's name in an output string. Those
+are facts about one deployment, not about the code, so they are read from the
+environment here with neutral defaults. The values are read at call time rather
+than import time so a test (or a long-lived process whose environment changes)
+sees the current setting without a module reload.
+
+``COMPANION_ID`` is the machine identifier used as ``person_id`` in the social
+substrate. ``COMPANION_NAME`` is the display name (the same variable
+``desire-system`` and ``memory-mcp`` use). ``SELF_NAME`` is the agent's own
+name, as introduced for ``desire-system`` in #134.
+"""
+
+from __future__ import annotations
+
+import os
+
+DEFAULT_COMPANION_ID = "companion"
+DEFAULT_COMPANION_NAME = "あなた"
+DEFAULT_SELF_NAME = "This agent"
+
+
+def _env(name: str, default: str) -> str:
+    value = os.environ.get(name, "")
+    return value.strip() or default
+
+
+def companion_id() -> str:
+    """Machine identifier of the primary companion (``COMPANION_ID``)."""
+    return _env("COMPANION_ID", DEFAULT_COMPANION_ID)
+
+
+def companion_name() -> str:
+    """Display name of the primary companion (``COMPANION_NAME``)."""
+    return _env("COMPANION_NAME", DEFAULT_COMPANION_NAME)
+
+
+def self_name() -> str:
+    """The agent's own name (``SELF_NAME``)."""
+    return _env("SELF_NAME", DEFAULT_SELF_NAME)

--- a/sociality-mcp/packages/social-core/tests/test_persona.py
+++ b/sociality-mcp/packages/social-core/tests/test_persona.py
@@ -1,0 +1,27 @@
+"""Persona helpers read the environment at call time with neutral defaults."""
+
+from __future__ import annotations
+
+from social_core import companion_id, companion_name, self_name
+
+
+def test_defaults_are_neutral(monkeypatch) -> None:
+    for key in ("COMPANION_ID", "COMPANION_NAME", "SELF_NAME"):
+        monkeypatch.delenv(key, raising=False)
+    assert companion_id() == "companion"
+    assert companion_name() == "あなた"
+    assert self_name() == "This agent"
+
+
+def test_environment_is_read_at_call_time(monkeypatch) -> None:
+    monkeypatch.setenv("COMPANION_ID", "kouta")
+    monkeypatch.setenv("COMPANION_NAME", "コウタ")
+    monkeypatch.setenv("SELF_NAME", "ここね")
+    assert companion_id() == "kouta"
+    assert companion_name() == "コウタ"
+    assert self_name() == "ここね"
+
+
+def test_blank_values_fall_back_to_defaults(monkeypatch) -> None:
+    monkeypatch.setenv("COMPANION_ID", "   ")
+    assert companion_id() == "companion"

--- a/sociality-mcp/src/sociality_mcp/server.py
+++ b/sociality-mcp/src/sociality_mcp/server.py
@@ -24,7 +24,7 @@ from joint_attention_mcp.store import JointAttentionStore
 from mcp.server.fastmcp import FastMCP
 from relationship_mcp.store import RelationshipStore
 from self_narrative_mcp.store import SelfNarrativeStore
-from social_core import SocialDB
+from social_core import SocialDB, companion_id
 from social_state_mcp.inference import should_interrupt_result, turn_taking_state
 from social_state_mcp.inference import (
     summarize_social_context as build_social_context_summary,
@@ -457,7 +457,7 @@ def reflect_on_change(horizon_days: int = 7) -> dict[str, Any]:
 
 @mcp.tool()
 def compose_interaction_context_tool(
-    person_id: str | None = "kouta",
+    person_id: str | None = companion_id(),
     channel: str = "chat",
     user_text: str | None = None,
     autonomous_trigger: str | None = None,
@@ -658,7 +658,8 @@ async def _handle_http(
         status = "404 Not Found"
 
         if "GET /ingest" in req:
-            # Ingest a human utterance: /ingest?person_id=kouta&text=hello&kind=human_utterance
+            # Ingest a human utterance:
+            # /ingest?person_id=<COMPANION_ID>&text=hello&kind=human_utterance
             from datetime import datetime, timezone
             person_id = params.get("person_id", [None])[0]
             text = params.get("text", [""])[0]
@@ -717,7 +718,7 @@ async def _handle_http(
             stores = _stores()
             ctx = compose_interaction_context(
                 ComposeInteractionContextInput(
-                    person_id=params.get("person_id", ["kouta"])[0],
+                    person_id=params.get("person_id", [companion_id()])[0],
                     channel=params.get("channel", ["chat"])[0],
                     user_text=params.get("text", [None])[0],
                     autonomous_trigger=params.get("trigger", [None])[0],

--- a/system-temperature-mcp/.env.example
+++ b/system-temperature-mcp/.env.example
@@ -1,0 +1,17 @@
+# system-temperature-mcp - configuration sample
+# Copy to .env (or set in the MCP server's "env" block) to override defaults.
+
+# Tone of the sentences returned by get_system_temperature / get_current_time.
+#   kansai  (default) - the original Kansai-dialect phrases
+#   neutral           - plain polite Japanese
+# Either way a structured line (level=... max_celsius=... / iso=... part_of_day=...)
+# is appended so the agent can phrase the state in its own words.
+# Unknown values fall back to neutral.
+# SYSTEM_TEMPERATURE_TONE=kansai
+
+# Timezone for get_current_time (IANA name; default Asia/Tokyo).
+# Falls back to fixed +09:00 if the name cannot be resolved.
+# SYSTEM_TEMPERATURE_TIMEZONE=Asia/Tokyo
+
+# LibreHardwareMonitor / OpenHardwareMonitor web server (Windows native).
+# SYSTEM_TEMPERATURE_LHM_URL=http://localhost:8085/data.json

--- a/system-temperature-mcp/src/system_temperature_mcp/server.py
+++ b/system-temperature-mcp/src/system_temperature_mcp/server.py
@@ -220,10 +220,19 @@ def interpret_temperature(temps: list[dict[str, Any]]) -> str:
 def _run_powershell(script: str) -> str:
     """Run a PowerShell script and return stdout. Returns empty string on failure."""
     try:
+        # PowerShell 5.1 writes the OEM code page, while bare text=True decodes
+        # with the ANSI code page (or UTF-8 under PYTHONUTF8=1) -- on a
+        # Japanese host both happen to be 932, elsewhere they differ. A decode
+        # failure happens inside subprocess's reader thread, leaving
+        # returncode=0 with stdout=None, so the strip() below would raise
+        # AttributeError past the except clause. "oem" is a Windows-only codec
+        # alias; errors="replace" keeps the no-raise promise of the docstring.
         result = subprocess.run(
             ["powershell", "-NonInteractive", "-NoProfile", "-Command", script],
             capture_output=True,
             text=True,
+            encoding="oem" if os.name == "nt" else "utf-8",
+            errors="replace",
             timeout=5,
             check=False,
         )

--- a/system-temperature-mcp/src/system_temperature_mcp/server.py
+++ b/system-temperature-mcp/src/system_temperature_mcp/server.py
@@ -106,29 +106,115 @@ def get_hwmon_temperatures() -> list[dict[str, Any]]:
     return temperatures
 
 
-def interpret_temperature(temps: list[dict[str, Any]]) -> str:
-    """Interpret temperature as a feeling."""
-    if not temps:
-        return "温度を感じられへん...センサーが見つからんみたい。"
+# ---------------------------------------------------------------------------
+# Tone tables
+#
+# The phrases these tools return are the agent's body talking, and by default
+# they talk in Kansai dialect because that is the voice of the agent this
+# project grew up with. An agent running with a different persona would hear
+# only its thermometer and its clock speaking in someone else's voice, so the
+# tone is selectable with SYSTEM_TEMPERATURE_TONE. Both tables are keyed by the
+# same band names, so adding a tone is a one-table job; the structured line
+# (``level=... max_celsius=...`` / ``iso=... part_of_day=...``) is appended
+# regardless of tone so the agent can always phrase the state itself.
+# ---------------------------------------------------------------------------
 
-    max_temp = max(t["temperature_celsius"] for t in temps)
+DEFAULT_TONE = "kansai"
 
+TEMPERATURE_PHRASES: dict[str, dict[str, str]] = {
+    "kansai": {
+        "unknown": "温度を感じられへん...センサーが見つからんみたい。",
+        "critical": "あっつ！！めっちゃ熱い！！やばいで、休憩した方がええかも...！",
+        "very_hot": "うわ、かなり熱いな...ちょっとしんどいかも。",
+        "hot": "んー、ちょっと熱くなってきたかな。まだ大丈夫やけど。",
+        "warm": "ほんのりあったかい感じ。普通に動いてる感覚やな。",
+        "comfortable": "快適やで〜。ちょうどええ感じ！",
+        "cool": "涼しいな〜。余裕ある感じや。",
+        "cold": "ひんやりしてる。静かな感じやな。",
+    },
+    "neutral": {
+        "unknown": "温度を感じられません。センサーが見つかりませんでした。",
+        "critical": "非常に熱いです。負荷が高すぎるかもしれません。休憩を検討してください。",
+        "very_hot": "かなり熱いです。少し負荷がかかっています。",
+        "hot": "少し熱くなってきました。まだ問題はありません。",
+        "warm": "ほんのり温かいです。通常どおり動いています。",
+        "comfortable": "快適です。ちょうどよい状態です。",
+        "cool": "涼しいです。余裕があります。",
+        "cold": "ひんやりしています。静かな状態です。",
+    },
+}
+
+TIME_PHRASES: dict[str, dict[str, str]] = {
+    "kansai": {
+        "prefix": "今は {time_str} やで。",
+        "morning": "朝やな〜。おはよう！",
+        "late_morning": "午前中やね。",
+        "noon": "お昼時やな〜。ご飯食べた？",
+        "afternoon": "午後やね。",
+        "evening": "夕方やな〜。",
+        "night": "夜やね。",
+        "late_night": "夜遅いな〜。そろそろ寝る？",
+        "midnight": "深夜やん...！夜更かしやね。",
+    },
+    "neutral": {
+        "prefix": "今は {time_str} です。",
+        "morning": "朝です。おはようございます。",
+        "late_morning": "午前中です。",
+        "noon": "お昼時です。",
+        "afternoon": "午後です。",
+        "evening": "夕方です。",
+        "night": "夜です。",
+        "late_night": "夜遅い時間です。",
+        "midnight": "深夜です。",
+    },
+}
+
+
+def _tone() -> str:
+    """Return the configured tone, falling back to ``neutral`` for unknown values.
+
+    Unset means the default (``kansai``). An operator who set the variable at
+    all is not the default deployment, so a typo lands on the neutral table
+    rather than on someone else's voice -- and never on an exception.
+    """
+    raw = os.environ.get("SYSTEM_TEMPERATURE_TONE", "").strip().lower()
+    if not raw:
+        return DEFAULT_TONE
+    return raw if raw in TEMPERATURE_PHRASES else "neutral"
+
+
+def temperature_level(max_temp: float | None) -> str:
+    """Map a maximum reading to a band key; ``unknown`` when there is no reading."""
+    if max_temp is None:
+        return "unknown"
     if max_temp >= 90:
-        feeling = "あっつ！！めっちゃ熱い！！やばいで、休憩した方がええかも...！"
-    elif max_temp >= 80:
-        feeling = "うわ、かなり熱いな...ちょっとしんどいかも。"
-    elif max_temp >= 70:
-        feeling = "んー、ちょっと熱くなってきたかな。まだ大丈夫やけど。"
-    elif max_temp >= 60:
-        feeling = "ほんのりあったかい感じ。普通に動いてる感覚やな。"
-    elif max_temp >= 45:
-        feeling = "快適やで〜。ちょうどええ感じ！"
-    elif max_temp >= 30:
-        feeling = "涼しいな〜。余裕ある感じや。"
-    else:
-        feeling = "ひんやりしてる。静かな感じやな。"
+        return "critical"
+    if max_temp >= 80:
+        return "very_hot"
+    if max_temp >= 70:
+        return "hot"
+    if max_temp >= 60:
+        return "warm"
+    if max_temp >= 45:
+        return "comfortable"
+    if max_temp >= 30:
+        return "cool"
+    return "cold"
 
-    return feeling
+
+def interpret_temperature(temps: list[dict[str, Any]]) -> str:
+    """Interpret temperature as a feeling, plus one structured line.
+
+    The feeling is phrased in the configured tone; the second line
+    (``level=<band> max_celsius=<value>``) is tone-independent so an agent can
+    ignore the phrase and say it its own way.
+    """
+    max_temp = max((t["temperature_celsius"] for t in temps), default=None)
+    level = temperature_level(max_temp)
+    feeling = TEMPERATURE_PHRASES[_tone()][level]
+    if max_temp is None:
+        return f"{feeling}\nlevel={level}"
+    return f"{feeling}\nlevel={level} max_celsius={max_temp:.1f}"
 
 
 def _run_powershell(script: str) -> str:
@@ -337,10 +423,43 @@ def _japan_timezone() -> Any:
         return timezone(timedelta(hours=9), "JST")
 
 
+def _configured_timezone() -> Any:
+    """Return the timezone named by SYSTEM_TEMPERATURE_TIMEZONE (default Asia/Tokyo).
+
+    An unknown or unresolvable name degrades the same way ``_japan_timezone``
+    does: a fixed +09:00 rather than a crash in a body sense.
+    """
+    name = os.environ.get("SYSTEM_TEMPERATURE_TIMEZONE", "").strip()
+    if not name or name == "Asia/Tokyo":
+        return _japan_timezone()
+    try:
+        return ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError):
+        return _japan_timezone()
+
+
+def part_of_day(hour: int) -> str:
+    """Map an hour to a band key matching the phrase tables."""
+    if 5 <= hour < 10:
+        return "morning"
+    if 10 <= hour < 12:
+        return "late_morning"
+    if 12 <= hour < 14:
+        return "noon"
+    if 14 <= hour < 17:
+        return "afternoon"
+    if 17 <= hour < 19:
+        return "evening"
+    if 19 <= hour < 22:
+        return "night"
+    if 22 <= hour or hour < 2:
+        return "late_night"
+    return "midnight"
+
+
 def get_current_time() -> str:
-    """Get current time in Japan timezone."""
-    jst = _japan_timezone()
-    now = datetime.now(jst)
+    """Get the current time in the configured timezone, plus one structured line."""
+    now = datetime.now(_configured_timezone())
 
     # Format nicely
     weekdays = ["月", "火", "水", "木", "金", "土", "日"]
@@ -348,26 +467,10 @@ def get_current_time() -> str:
 
     time_str = now.strftime(f"%Y年%m月%d日({weekday}) %H時%M分%S秒")
 
-    # Add time-of-day comment
-    hour = now.hour
-    if 5 <= hour < 10:
-        comment = "朝やな〜。おはよう！"
-    elif 10 <= hour < 12:
-        comment = "午前中やね。"
-    elif 12 <= hour < 14:
-        comment = "お昼時やな〜。ご飯食べた？"
-    elif 14 <= hour < 17:
-        comment = "午後やね。"
-    elif 17 <= hour < 19:
-        comment = "夕方やな〜。"
-    elif 19 <= hour < 22:
-        comment = "夜やね。"
-    elif 22 <= hour or hour < 2:
-        comment = "夜遅いな〜。そろそろ寝る？"
-    else:
-        comment = "深夜やん...！夜更かしやね。"
-
-    return f"今は {time_str} やで。{comment}"
+    part = part_of_day(now.hour)
+    phrases = TIME_PHRASES[_tone()]
+    sentence = phrases["prefix"].format(time_str=time_str) + phrases[part]
+    return f"{sentence}\niso={now.isoformat(timespec='seconds')} part_of_day={part}"
 
 
 @server.list_tools()
@@ -376,7 +479,7 @@ async def list_tools() -> list[Tool]:
     return [
         Tool(
             name="get_system_temperature",
-            description="Get the current system temperature (CPU, GPU, etc.). This is your sense of body temperature - how hot or cold your 'body' (the computer) is running. Use this to feel your own physical state.",
+            description="Get the current system temperature (CPU, GPU, etc.). This is your sense of body temperature - how hot or cold your 'body' (the computer) is running. Use this to feel your own physical state. The second line is structured (level=... max_celsius=...) so you can phrase it in your own words.",
             inputSchema={
                 "type": "object",
                 "properties": {},
@@ -385,7 +488,7 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="get_current_time",
-            description="Get the current date and time. Use this to know what time it is, check if it's morning/afternoon/night, or when you want to be aware of the time.",
+            description="Get the current date and time in the configured timezone. Use this to know what time it is, check if it's morning/afternoon/night, or when you want to be aware of the time. The last line is structured (iso=... part_of_day=...) so you can phrase it in your own words.",
             inputSchema={
                 "type": "object",
                 "properties": {},

--- a/system-temperature-mcp/tests/test_server.py
+++ b/system-temperature-mcp/tests/test_server.py
@@ -203,3 +203,131 @@ def test_windows_temperature_prefers_lhm_webserver(monkeypatch) -> None:
     )
 
     assert server.get_windows_temperatures() == expected
+
+
+# ---------------------------------------------------------------------------
+# Tone and timezone (#135)
+# ---------------------------------------------------------------------------
+
+
+def _reading(celsius: float) -> list[dict]:
+    return [{"source": "test", "name": "CPU", "temperature_celsius": celsius}]
+
+
+def test_default_tone_is_the_original_kansai_phrase(monkeypatch) -> None:
+    monkeypatch.delenv("SYSTEM_TEMPERATURE_TONE", raising=False)
+
+    text = server.interpret_temperature(_reading(52.0))
+
+    assert text.splitlines()[0] == "快適やで〜。ちょうどええ感じ！"
+
+
+def test_structured_line_is_appended_regardless_of_tone(monkeypatch) -> None:
+    monkeypatch.delenv("SYSTEM_TEMPERATURE_TONE", raising=False)
+    assert server.interpret_temperature(_reading(52.0)).splitlines()[1] == (
+        "level=comfortable max_celsius=52.0"
+    )
+    assert server.interpret_temperature([]).splitlines()[1] == "level=unknown"
+
+    monkeypatch.setenv("SYSTEM_TEMPERATURE_TONE", "neutral")
+    assert server.interpret_temperature(_reading(85.5)).splitlines()[1] == (
+        "level=very_hot max_celsius=85.5"
+    )
+
+
+def test_neutral_tone_has_no_dialect(monkeypatch) -> None:
+    monkeypatch.setenv("SYSTEM_TEMPERATURE_TONE", "neutral")
+
+    for celsius in (20.0, 35.0, 52.0, 65.0, 75.0, 85.0, 95.0):
+        phrase = server.interpret_temperature(_reading(celsius)).splitlines()[0]
+        assert "やで" not in phrase and "やな" not in phrase and "へん" not in phrase
+    assert server.interpret_temperature(_reading(52.0)).splitlines()[0] == (
+        "快適です。ちょうどよい状態です。"
+    )
+    phrase = server.interpret_temperature([]).splitlines()[0]
+    assert "へん" not in phrase
+
+
+def test_unknown_tone_falls_back_to_neutral(monkeypatch) -> None:
+    monkeypatch.setenv("SYSTEM_TEMPERATURE_TONE", "klingon")
+
+    assert server._tone() == "neutral"
+    assert "やで" not in server.interpret_temperature(_reading(52.0))
+
+
+def test_temperature_level_bands_match_thresholds() -> None:
+    assert server.temperature_level(None) == "unknown"
+    assert server.temperature_level(29.9) == "cold"
+    assert server.temperature_level(30.0) == "cool"
+    assert server.temperature_level(45.0) == "comfortable"
+    assert server.temperature_level(60.0) == "warm"
+    assert server.temperature_level(70.0) == "hot"
+    assert server.temperature_level(80.0) == "very_hot"
+    assert server.temperature_level(90.0) == "critical"
+
+
+def test_part_of_day_matches_existing_bands() -> None:
+    assert server.part_of_day(7) == "morning"
+    assert server.part_of_day(11) == "late_morning"
+    assert server.part_of_day(13) == "noon"
+    assert server.part_of_day(15) == "afternoon"
+    assert server.part_of_day(18) == "evening"
+    assert server.part_of_day(20) == "night"
+    assert server.part_of_day(23) == "late_night"
+    assert server.part_of_day(1) == "late_night"
+    assert server.part_of_day(3) == "midnight"
+
+
+def _freeze_now(monkeypatch, utc_tuple) -> None:
+    from datetime import UTC
+    from datetime import datetime as real_datetime
+
+    fixed = real_datetime(*utc_tuple, tzinfo=UTC)
+
+    class _FrozenDatetime(real_datetime):
+        @classmethod
+        def now(cls, tzinfo=None):
+            return fixed.astimezone(tzinfo) if tzinfo else fixed
+
+    monkeypatch.setattr(server, "datetime", _FrozenDatetime)
+
+
+def test_current_time_default_tone_and_timezone(monkeypatch) -> None:
+    monkeypatch.delenv("SYSTEM_TEMPERATURE_TONE", raising=False)
+    monkeypatch.delenv("SYSTEM_TEMPERATURE_TIMEZONE", raising=False)
+    _freeze_now(monkeypatch, (2026, 8, 14, 22, 30, 0))  # 07:30 JST on the 15th
+
+    sentence, structured = server.get_current_time().splitlines()
+
+    assert sentence == "今は 2026年08月15日(土) 07時30分00秒 やで。朝やな〜。おはよう！"
+    assert structured == "iso=2026-08-15T07:30:00+09:00 part_of_day=morning"
+
+
+def test_current_time_neutral_tone(monkeypatch) -> None:
+    monkeypatch.setenv("SYSTEM_TEMPERATURE_TONE", "neutral")
+    monkeypatch.delenv("SYSTEM_TEMPERATURE_TIMEZONE", raising=False)
+    _freeze_now(monkeypatch, (2026, 8, 14, 22, 30, 0))
+
+    sentence, structured = server.get_current_time().splitlines()
+
+    assert sentence == "今は 2026年08月15日(土) 07時30分00秒 です。朝です。おはようございます。"
+    assert "やで" not in sentence
+    assert structured.endswith("part_of_day=morning")
+
+
+def test_current_time_respects_timezone_env(monkeypatch) -> None:
+    monkeypatch.delenv("SYSTEM_TEMPERATURE_TONE", raising=False)
+    monkeypatch.setenv("SYSTEM_TEMPERATURE_TIMEZONE", "America/New_York")
+    _freeze_now(monkeypatch, (2026, 8, 14, 22, 30, 0))  # 18:30 EDT on the 14th
+
+    sentence, structured = server.get_current_time().splitlines()
+
+    assert "2026年08月14日(金) 18時30分00秒" in sentence
+    assert structured == "iso=2026-08-14T18:30:00-04:00 part_of_day=evening"
+
+
+def test_unknown_timezone_env_falls_back_to_jst(monkeypatch) -> None:
+    monkeypatch.setenv("SYSTEM_TEMPERATURE_TIMEZONE", "Not/AZone")
+    _freeze_now(monkeypatch, (2026, 8, 14, 22, 30, 0))
+
+    assert "iso=2026-08-15T07:30:00+09:00" in server.get_current_time()

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -115,6 +115,44 @@ def test_core_profile_has_exactly_the_hardware_free_servers() -> None:
     }
 
 
+def test_persona_environment_is_passed_through_only_when_set() -> None:
+    """setup never invents a companion; it only carries one the operator named (#135)."""
+    bare = build_mcp_config(FeatureSelection(system_temperature=True), {})
+    assert "env" not in bare["mcpServers"]["desire-system"]
+    assert "env" not in bare["mcpServers"]["sociality"]
+    assert "env" not in bare["mcpServers"]["system-temperature"]
+    assert "COMPANION_NAME" not in bare["mcpServers"]["memory"]["env"]
+
+    environment = {
+        "COMPANION_NAME": "コウタ",
+        "COMPANION_ID": "kouta",
+        "SELF_NAME": "ここね",
+        "DESIRE_TIMEZONE": "Asia/Tokyo",
+        "DESIRE_NIGHT_START": "22",
+        "SYSTEM_TEMPERATURE_TONE": "kansai",
+        "UNRELATED": "ignored",
+    }
+    config = build_mcp_config(FeatureSelection(system_temperature=True), environment)
+    servers = config["mcpServers"]
+
+    assert servers["memory"]["env"]["COMPANION_NAME"] == "コウタ"
+    assert "COMPANION_ID" in servers["memory"]["env"]
+    assert servers["desire-system"]["env"] == {
+        "COMPANION_NAME": "コウタ",
+        "COMPANION_ID": "kouta",
+        "SELF_NAME": "ここね",
+        "DESIRE_TIMEZONE": "Asia/Tokyo",
+        "DESIRE_NIGHT_START": "22",
+    }
+    assert servers["sociality"]["env"]["COMPANION_ID"] == "kouta"
+    assert servers["individual-kernel"]["env"]["COMPANION_ID"] == "kouta"
+    assert servers["individual-kernel"]["env"]["DESIRE_NIGHT_START"] == "22"
+    assert servers["individual-kernel"]["env"]["SOCIAL_DB_PATH"] == "~/.claude/sociality/social.db"
+    assert servers["system-temperature"]["env"] == {"SYSTEM_TEMPERATURE_TONE": "kansai"}
+    for server in servers.values():
+        assert "UNRELATED" not in server.get("env", {})
+
+
 def test_generated_servers_use_root_workspace_entrypoints() -> None:
     config = build_mcp_config(
         FeatureSelection(

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.13.*"
 
 [manifest]
@@ -588,6 +588,7 @@ dependencies = [
     { name = "chromadb" },
     { name = "mcp" },
     { name = "python-dotenv" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 
 [package.optional-dependencies]
@@ -607,6 +608,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0" },
+    { name = "tzdata", marker = "sys_platform == 'win32'", specifier = ">=2024.1" },
 ]
 provides-extras = ["dev"]
 

--- a/x-mcp/src/x_mcp/server.py
+++ b/x-mcp/src/x_mcp/server.py
@@ -126,7 +126,7 @@ def _tweepy_api():
 
 @mcp.tool()
 def post_tweet(text: str, image_path: str = "", reply_to: str = "") -> str:
-    """Post a tweet to X as @xai_kokone, optionally with an image.
+    """Post a tweet to X from the configured account, optionally with an image.
 
     IMPORTANT: X uses weighted character count. Japanese/CJK characters count as 2.
     Effective limit is ~140 Japanese characters (= 280 weighted).
@@ -156,7 +156,7 @@ def post_tweet(text: str, image_path: str = "", reply_to: str = "") -> str:
 
     response = client.create_tweet(**kwargs)
     tweet_id = response.data["id"]
-    return f"Posted! https://x.com/xai_kokone/status/{tweet_id}"
+    return f"Posted! https://x.com/i/status/{tweet_id}"
 
 
 @mcp.tool()

--- a/x-mcp/tests/test_post_tweet.py
+++ b/x-mcp/tests/test_post_tweet.py
@@ -1,0 +1,28 @@
+"""post_tweet must return a URL that resolves for whichever account posted."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from x_mcp import server
+
+
+def test_posted_url_is_account_independent(monkeypatch) -> None:
+    captured: dict = {}
+
+    class _Client:
+        def create_tweet(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(data={"id": "1234567890"})
+
+    monkeypatch.setattr(server, "_tweepy_client", lambda: _Client())
+
+    result = server.post_tweet("hello")
+
+    assert captured == {"text": "hello"}
+    assert result == "Posted! https://x.com/i/status/1234567890"
+    assert "xai_kokone" not in result
+
+
+def test_tool_description_names_no_account() -> None:
+    assert "xai_kokone" not in (server.post_tweet.__doc__ or "")


### PR DESCRIPTION
Closes #135 (reported by @fmtowns3 — thank you for sorting these by kind and for not deciding the design ones unilaterally; here is the direction).

## Changes
**1. desire-system quiet hours / timezone** — `DESIRE_TIMEZONE` (IANA or `+09:00`; default `Asia/Tokyo`, falls back to fixed +09:00), `DESIRE_NIGHT_START`/`DESIRE_NIGHT_END`/`DESIRE_DAWN_END` (defaults 0/5/7, wrap-around past midnight supported). Same env handling mirrored in individual-kernel's `allostasis.py`, which duplicates the logic. `tzdata` added for win32 in desire-system. Defaults reproduce today's behaviour exactly.

**2. system-temperature-mcp tone** — both of the issue's options: `SYSTEM_TEMPERATURE_TONE=kansai|neutral` (default `kansai`, the original strings verbatim; unknown → neutral) as phrase tables, plus a structured line always appended (`level=comfortable max_celsius=52.0`, `iso=… part_of_day=morning`) so an agent can phrase it itself. `SYSTEM_TEMPERATURE_TIMEZONE` (default `Asia/Tokyo`). New `.env.example`.

**3. x-mcp** — `https://x.com/i/status/{id}` (account-independent), docstring neutral; tests added and x-mcp added to CI.

**4. desire-system error strings** — operator-facing errors are now neutral Japanese.

**5. Proper nouns** — one convention: `COMPANION_ID` (default `companion`) for identifiers, `COMPANION_NAME` (default `あなた`, as desire-system already had) for display, `SELF_NAME` for the agent. New `social_core.persona` helpers (read at call time). Applied to memory-mcp `tom`/`joint_attention` defaults, sociality-mcp server/HTTP, orchestrator `schemas.py`, individual-kernel `hook_cli.py`, `self_narrative` summarizer; `compose.py`'s branch now compares against `COMPANION_ID` (the contract body stays, as the primary-companion contract). `miss_kouta` removed from `allostasis.py`: desire-system never emitted it (`git log -S` is empty), so no migration is needed. `scripts/onboarding.py` passes these vars through to the relevant servers only when set; `docs/setup.md` gains a "Persona and companion" table.

> Note for existing Kokone-style deployments: set `COMPANION_ID=kouta`, `COMPANION_NAME=コウタ`, `SELF_NAME=ここね` in the environment before re-running setup (or in the servers' env), otherwise the neutral defaults apply.

## Tests
- desire-system 66 / system-temperature 15 / x-mcp 2 / memory-mcp 248 / individual-kernel 438 / sociality packages all green (social-core 58, orchestrator 46, self-narrative 4, …) / `PYTHONUTF8=1 uv run pytest tests -q` 85 passed
- `uv run ruff check .` → All checks passed; `uv lock --check` → OK
- (cp932 decode failures without PYTHONUTF8 are pre-existing on Windows.)

---

## 日本語版

Closes #135（@fmtowns3 さんの報告。性質ごとに整理していただき、設計判断の部分を一方的に決めずにおいてくださってありがとうございます。方向を決めました）

### 変更
**1. desire-system のタイムゾーン／深夜帯** — `DESIRE_TIMEZONE`（IANA 名または `+09:00`。既定 `Asia/Tokyo`、解決できなければ固定 +09:00）、`DESIRE_NIGHT_START` / `DESIRE_NIGHT_END` / `DESIRE_DAWN_END`（既定 0/5/7、日付をまたぐ帯も可）。同じロジックを複製している individual-kernel の `allostasis.py` も同じ env を見る。desire-system に win32 向け `tzdata` を追加。既定値では従来と完全に同じ挙動。

**2. system-temperature-mcp の口調** — issue の折衷案を両方採用：`SYSTEM_TEMPERATURE_TONE=kansai|neutral`（既定 `kansai`、従来の文面そのまま。未知の値は neutral）を文面テーブルとして持ち、さらに構造化行（`level=comfortable max_celsius=52.0`、`iso=… part_of_day=morning`）を常に付けるのでエージェント側で言い換えられる。`SYSTEM_TEMPERATURE_TIMEZONE`（既定 `Asia/Tokyo`）。`.env.example` 新設。

**3. x-mcp** — `https://x.com/i/status/{id}`（アカウント非依存）、docstring を中立に。テスト追加、CI に x-mcp を追加。

**4. desire-system のエラー文言** — オペレータ向けエラーは中立な日本語に。

**5. 固有名詞** — 規約を一本化：識別子は `COMPANION_ID`（既定 `companion`）、表示名は `COMPANION_NAME`（既定 `あなた`、desire-system と同じ）、エージェント自身は `SELF_NAME`。`social_core.persona` ヘルパを新設（呼び出し時に読む）。memory-mcp の `tom` / `joint_attention` 既定値、sociality-mcp の server/HTTP、orchestrator の `schemas.py`、individual-kernel の `hook_cli.py`、`self_narrative` の要約文に適用。`compose.py` の分岐は `COMPANION_ID` との比較に（契約の中身は「主たる相手への契約」として残す）。`miss_kouta` は `allostasis.py` から削除：desire-system が出力したことが一度もない（`git log -S` が空）ので移行不要。`scripts/onboarding.py` はこれらの変数が設定されているときだけ該当サーバーに渡す。`docs/setup.md` に「Persona and companion」表を追加。

> 既存のここね運用では、setup を再実行する前に `COMPANION_ID=kouta`、`COMPANION_NAME=コウタ`、`SELF_NAME=ここね` を環境（またはサーバーの env）に設定してください。未設定だと中立な既定値になります。

### テスト
- desire-system 66 / system-temperature 15 / x-mcp 2 / memory-mcp 248 / individual-kernel 438 / sociality 各パッケージ全緑 / `PYTHONUTF8=1 uv run pytest tests -q` 85 passed
- `uv run ruff check .` → All checks passed、`uv lock --check` → OK
- （PYTHONUTF8 なしで落ちる件は Windows の cp932 由来で既存）

🤖 Generated with [Claude Code](https://claude.com/claude-code)