### PR TITLE
fix(individual-kernel): read and write the efpf hook pipes at the byte layer as UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,16 @@ and its key had not been issued (#137, reported by fmtowns3).
   Japanese host both code pages are 932 and it happened to line up; where they
   differ the output mojibakes silently instead. Found, measured and patched by
   fmtowns3 on this PR.
+- individual-kernel: the efpf hook reads its stdin payload at the byte layer
+  and decodes UTF-8 explicitly, and `_emit` writes UTF-8 bytes. When the
+  stdio text wrapper carries the locale encoding (cp932 + `surrogateescape`
+  on Japanese Windows), a UTF-8 payload with non-ASCII mojibakes into lone
+  surrogates that `hash_tool_input` cannot encode -- so an operator who had
+  correctly registered an intention got every non-ASCII outward action denied,
+  while the no-intention early return hid the bug from manual probing. Truly
+  broken input still lands in the #137 fail-closed branch, and correctness no
+  longer depends on `main()`'s stream reconfiguration taking effect. Reported
+  with the diagnosis and both fix candidates by fmtowns3 in #152.
 
 ### Changed
 

--- a/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/hook_cli.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/src/individual_kernel_mcp/hook_cli.py
@@ -61,9 +61,21 @@ def _read_input() -> dict[str, Any] | None:
     pipe that never delivers stdin therefore looked like a gate that did not
     work, when in fact the gate never saw the call (#137). Callers decide what
     "nothing arrived" means for their event; `main` fails closed for the gate.
+
+    The payload is read at the byte layer and decoded as UTF-8 explicitly:
+    hook pipes carry UTF-8 JSON regardless of the console code page, and a
+    locale text wrapper (cp932 + surrogateescape on Japanese Windows) would
+    mojibake non-ASCII into lone surrogates that later blow up the intention
+    hash instead of failing here, closed (#152).
     """
     try:
-        value = json.load(sys.stdin)
+        buffer = getattr(sys.stdin, "buffer", None)
+        raw = (
+            buffer.read()
+            if buffer is not None
+            else sys.stdin.read().encode("utf-8", "surrogateescape")
+        )
+        value = json.loads(raw.decode("utf-8"))
     except (ValueError, OSError):
         # JSONDecodeError and UnicodeDecodeError are both ValueErrors.
         return None
@@ -140,8 +152,17 @@ def _deny(reason: str) -> dict[str, Any]:
 
 
 def _emit(value: dict[str, Any]) -> None:
-    sys.stdout.write(json.dumps(value, ensure_ascii=False, separators=(",", ":")))
-    sys.stdout.write("\n")
+    # Written at the byte layer for the same reason _read_input reads it: the
+    # hook pipe is UTF-8 JSON, and ensure_ascii=False through a cp932 text
+    # wrapper would emit bytes Claude Code cannot parse (#152).
+    data = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    buffer = getattr(sys.stdout, "buffer", None)
+    if buffer is not None:
+        buffer.write(data + b"\n")
+        buffer.flush()
+    else:
+        sys.stdout.write(data.decode("utf-8"))
+        sys.stdout.write("\n")
 
 
 def _hook_context(event: str, context: str) -> dict[str, Any]:

--- a/consciousness-mcp/packages/individual-kernel-mcp/tests/test_hook_cli.py
+++ b/consciousness-mcp/packages/individual-kernel-mcp/tests/test_hook_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 import os
 import re
@@ -14,6 +15,8 @@ from individual_kernel_mcp import tick
 from individual_kernel_mcp.agency import ActionProposal
 from individual_kernel_mcp.hook_cli import (
     UNREADABLE_INPUT_REASON,
+    _emit,
+    _read_input,
     kernel_server_configured,
     stop,
 )
@@ -37,6 +40,10 @@ def _run_hook(
         [sys.executable, "-m", "individual_kernel_mcp.hook_cli", command],
         input=json.dumps(payload) if raw_input is None else raw_input,
         text=True,
+        # Claude Code speaks UTF-8 on the hook pipes; without this the parent
+        # side of the test would encode with the locale (cp932 on Japanese
+        # Windows) and never exercise the #152 path.
+        encoding="utf-8",
         capture_output=True,
         env=env,
         check=True,
@@ -566,3 +573,78 @@ def test_other_hooks_treat_unreadable_stdin_as_an_empty_payload(tmp_path: Path) 
     assert output["additionalContext"] == "No committed field is available."
 
     assert _run_hook(tmp_path, "stop-failure", None, raw_input="") == {}
+
+
+def test_pre_tool_gate_matches_non_ascii_tool_input(tmp_path) -> None:
+    """#152: a correctly registered intention with Japanese input must match."""
+    tool_name = "Write"
+    tool_input = {"file_path": "/tmp/efpf-メモ", "content": "こんにちは、あ"}
+    _run_hook(
+        tmp_path,
+        "user-prompt-submit",
+        {
+            "session_id": "session-152",
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "日本語を書く",
+        },
+    )
+    db = SocialDB(tmp_path / "hook-social.db")
+    producer = TickProducer(
+        db,
+        interoception_path=tmp_path / "interoception.json",
+        desires_path=tmp_path / "desires.json",
+    )
+    field = producer.get_current_field()
+    assert field is not None
+    FieldRuntime(db, producer=producer).propose_action(
+        ActionProposal(
+            field_id=field.field_id,
+            tool_name=tool_name,
+            tool_input=tool_input,
+            goal="日本語のファイルを書く",
+        )
+    )
+    db.close()
+
+    result = _run_hook(
+        tmp_path,
+        "pre-tool-use",
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+            "tool_use_id": "write-152",
+        },
+    )
+
+    output = result["hookSpecificOutput"]
+    assert output["permissionDecision"] == "allow", output
+
+
+def test_read_input_decodes_utf8_despite_cp932_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The byte-layer read must not care what encoding the wrapper claims."""
+    payload = {"tool_name": "Write", "tool_input": {"content": "こんにちは、あ"}}
+    raw = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    wrapper = io.TextIOWrapper(
+        io.BufferedReader(io.BytesIO(raw)),
+        encoding="cp932",
+        errors="surrogateescape",
+    )
+    monkeypatch.setattr(sys, "stdin", wrapper)
+
+    value = _read_input()
+
+    assert value is not None
+    assert value["tool_input"]["content"] == "こんにちは、あ"
+
+
+def test_emit_writes_utf8_bytes(monkeypatch: pytest.MonkeyPatch) -> None:
+    buffer = io.BytesIO()
+    wrapper = io.TextIOWrapper(buffer, encoding="cp932")
+    monkeypatch.setattr(sys, "stdout", wrapper)
+
+    _emit({"reason": "プロジェクト"})
+
+    assert buffer.getvalue() == '{"reason":"プロジェクト"}\n'.encode()


### PR DESCRIPTION
Fixes #152 (reported with the diagnosis and both fix candidates by @fmtowns3; the byte-layer variant is theirs).

## What was wrong

When the hook's stdio text wrapper carries the locale encoding (cp932 + `surrogateescape` on Japanese Windows), a UTF-8 payload containing non-ASCII decodes into lone surrogates. `hash_tool_input` cannot `.encode("utf-8")` a lone surrogate, the blanket `except Exception` converts that into a deny -- so an operator who **correctly registered an intention** got every non-ASCII outward action refused, while the `pending is None` early return made manual probes look healthy. `_emit` had the mirror problem: `ensure_ascii=False` through a cp932 stream writes bytes that are not UTF-8.

## Change

- `_read_input` reads `sys.stdin.buffer` and decodes UTF-8 explicitly. `UnicodeDecodeError` is a `ValueError`, so truly broken input keeps landing in the #137 fail-closed branch (`UNREADABLE_INPUT_REASON`) instead of passing through as mojibake and exploding at the hash.
- `_emit` writes UTF-8 bytes to `sys.stdout.buffer` (text fallback for buffer-less stand-ins).
- `main()`'s `reconfigure` stays, but the gate's correctness no longer depends on it taking effect.

One note on that last point: `main()` has forced UTF-8 stdio via `reconfigure` since #107, including at `06902fd` which #152 was measured against -- and on this (also cp932, Japanese Windows) machine the live gate has been passing Japanese `tool_input`. Reading at the byte layer makes the question of when `reconfigure` does or does not take effect moot, which is why this PR does not try to adjudicate it; details in the issue thread.

## Tests

- `_run_hook` now pins `encoding="utf-8"` on the subprocess pipes -- what Claude Code actually speaks -- so every existing hook test exercises UTF-8 pipes on Windows instead of locale ones.
- `test_pre_tool_gate_matches_non_ascii_tool_input`: end-to-end propose → hook with Japanese `file_path`/`content` returns `allow` (the exact path #152 reports as impossible).
- `test_read_input_decodes_utf8_despite_cp932_wrapper`: a cp932/surrogateescape `TextIOWrapper` over UTF-8 bytes still yields the correct Japanese string.
- `test_emit_writes_utf8_bytes`: the emitted bytes are UTF-8 with the Japanese reason intact, even under a cp932 wrapper.

22 tests pass; ruff clean.

---

## 日本語

Fixes #152（診断と修正案 2 つとも @fmtowns3 さん。バイト層案を採用しています）

### 何が問題だったか

stdio のテキストラッパが locale（日本語 Windows では cp932 + `surrogateescape`）のままだと、非 ASCII を含む UTF-8 payload が孤立サロゲートに化けます。`hash_tool_input` は孤立サロゲートを UTF-8 に符号化できず、`except Exception` が deny に変換するので、**intention を正しく登録した人ほど**非 ASCII の外向き行為が全部拒否されます。`_emit` にも同型の穴（cp932 ストリームに `ensure_ascii=False`）がありました。

### 変更

- `_read_input` は `sys.stdin.buffer` を読んで UTF-8 で明示的に復号。壊れた入力は従来どおり #137 の fail-closed 側に落ちます
- `_emit` は UTF-8 バイトを `sys.stdout.buffer` に書きます
- `main()` の `reconfigure` は残しつつ、ゲートの正しさはそれに依存しなくなりました

なお `main()` には #107 以降（#152 が測定した `06902fd` を含む）`reconfigure` による UTF-8 強制が入っていて、こちらの cp932 環境では日本語の tool_input がゲートを通っていました。バイト層で読むことで「reconfigure が効く・効かない」の問い自体を不要にする方針です。詳細は issue 側に書きます。

### テスト

- `_run_hook` の subprocess パイプを `encoding="utf-8"` に固定（Claude Code が実際に話す符号化）
- 日本語 tool_input の propose → hook が `allow` になる end-to-end テスト
- cp932 ラッパ越しでも UTF-8 が正しく読めることの単体テスト
- `_emit` が UTF-8 バイトを書くことの単体テスト

22 件パス、ruff クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)