### PR TITLE
docs: seven corrections measured against the code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ embodied-claude/
 ├── memory-mcp/            # 長期記憶システム（Python）
 │   └── src/memory_mcp/
 │       ├── server.py      # MCP サーバー実装
-│       ├── memory.py      # ChromaDB 操作
+│       ├── memory.py      # 記憶ストア操作（SQLite + numpy）
 │       ├── types.py       # 型定義（Emotion, Category）
 │       └── config.py      # 設定管理
 │
@@ -443,7 +443,7 @@ tts-mcp と組み合わせることで**完全な音声対話**が実現する�
 - [go2rtc](https://github.com/AlexxIT/go2rtc) - RTSPストリーム中継・オーディオバックチャンネル
 - [claude-code-webui](https://github.com/sugyan/claude-code-webui) - Claude Code の Web UI
 - [Tailscale](https://tailscale.com/) - メッシュ VPN
-- [ChromaDB](https://www.trychroma.com/) - ベクトルデータベース
+- [sentence-transformers](https://www.sbert.net/) - 埋め込みモデル（記憶の検索に使用）
 - [OpenAI Whisper](https://github.com/openai/whisper) - 音声認識
 - [ElevenLabs](https://elevenlabs.io/) - 音声合成 API
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,7 +256,7 @@ file/network side effect は committed field と matching intention がない限
 
 | ツール | パラメータ | 説明 |
 |--------|-----------|------|
-| `record_counterfactual` | payload | 拒否した代替行為を typed record で残す（source ∈ boundary_deny / attention_lost_bid / deliberate_choice / policy / ignition_failed）。evidence_type は Phase 1 EvidenceType を再利用 |
+| `record_counterfactual` | payload | 拒否した代替行為を typed record で残す（source ∈ boundary_deny / attention_lost_bid / deliberate_choice / policy / ignition_failed）。evidence_type ∈ observed / inferred / remembered / heard / assumed（Phase 1 EvidenceType の再利用） |
 | `query_counterfactuals` | since?, source?, tick_id?, person_id?, limit? | 直近の counterfactual を返す |
 | `sleep_consolidate` | force?, dry_run? | quiet hours で morning_briefing.json を書き出す scheduler glue |
 | `record_tick_frame` | payload | per-tick の ConsciousFrame を保存。winning_memory_ids / dominant_desire / prediction_error / chosen_action_ref など FK だけ持つ |

--- a/docs/autonomous-files.md
+++ b/docs/autonomous-files.md
@@ -39,6 +39,23 @@ point at it:
   installed, and merely notes their absence before that.
 - This page exists.
 
+## What the script needs on PATH
+
+`autonomous-action.sh` shells out to two commands that nothing else in the
+repository requires. Neither absence stops the heartbeat, and only one of the
+four call sites says anything:
+
+| Command | Used for | If it is missing |
+|---|---|---|
+| `jq` | Collecting `permissions.allow` out of `.claude/settings*.json` | `ALLOWED_TOOLS` comes back empty, `--allowedTools` is not passed to `claude -p` at all, and the `--- ALLOWED_TOOLS ---` block in the log is empty |
+| `jq` | Reading `.session_id` out of the result JSON | The session file is not updated, so the next heartbeat starts a new session instead of resuming |
+| `bun` | `scripts/desire-tick.ts` | stderr is captured and logged as `[欲望エラー]` -- **the one that says so** |
+| `bun` | `scripts/interoception.ts` | stderr goes to `/dev/null`; the interoception line is simply absent |
+
+The session one is the quiet one. Nothing in the log distinguishes "resumed the
+previous session" from "started a fresh one because `jq` was not there", and a
+heartbeat that never resumes looks like a heartbeat with a short memory.
+
 ## Templates
 
 Minimal, neutral starting points are in `examples/`:

--- a/docs/organism-daemon.md
+++ b/docs/organism-daemon.md
@@ -108,6 +108,39 @@ The command respects the flag: with `organism_daemon = false` it returns
 `{"ran": false}` and touches nothing, so the entry can be installed before the
 flag is flipped and will simply idle until it is.
 
+On Windows the equivalent is Task Scheduler, and both of the crontab lessons
+apply harder, because a scheduled task starts with an even sparser `PATH` than
+cron. `schtasks /TR` also cannot carry the redirection, so the command goes in
+a one-line wrapper:
+
+```bat
+@echo off
+set "UV="
+for /f "delims=" %%I in ('where uv 2^>nul') do if not defined UV set "UV=%%I"
+if not defined UV if exist "%USERPROFILE%\.local\bin\uv.exe" set "UV=%USERPROFILE%\.local\bin\uv.exe"
+if not defined UV exit /b 3
+set "PYTHONIOENCODING=utf-8"
+"%UV%" run --directory "C:\path\to\embodied-claude" efpf-hook organism-step >> "%~dp0organism.log" 2>&1
+```
+
+```bat
+schtasks /Create /F /TN "EmbodiedClaude-Organism" ^
+  /TR "\"C:\path\to\run-organism.cmd\"" /SC MINUTE /MO 15 /RU "%USERNAME%" /IT
+```
+
+Three things this shape is buying, measured on Windows 11:
+
+- `where uv` first, with an explicit fallback: `uv` installs to
+  `%USERPROFILE%\.local\bin`, which a scheduled task does not have.
+- `PYTHONIOENCODING=utf-8`: the task runs under the OEM code page, and a
+  non-ASCII byte in the output otherwise stops the write, not just the display.
+- The redirection is written **before** the exit code in any `echo` that reports
+  it. `echo exit=%RC%>>"%LOG%"` reads the digit before `>>` as a stream handle
+  and the line vanishes.
+
+Registering a task and having it run are different things. Run it once by hand
+(`schtasks /Run /TN ...`) and read the log before trusting the schedule.
+
 ## Why the flag still ships off
 
 Unlike the flags in #111, the blocker here is not evidence -- the measurement

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -147,6 +147,32 @@ download:
 
 The first memory operation will download the model instead.
 
+### The server takes tens of seconds to start
+
+`memory-mcp` warms the embedding model before it answers anything
+(`MemoryStore.warmup()`, called during startup). Measured on `b4ded53`, Windows
+11, with the model already on disk:
+
+```text
+import         0.6 s
+warmup()      20.3 s        intfloat/multilingual-e5-base
+```
+
+The smaller default model is quicker, and the first run is slower still because
+the model has to be fetched. Either way this is longer than a short client-side
+startup timeout allows.
+
+If `memory` is missing from the server list and nothing in the logs explains
+why, raise the startup timeout before looking for a configuration error:
+
+```bash
+MCP_TIMEOUT=120000   # milliseconds
+```
+
+A server that timed out during startup is skipped, not reported. Sessions
+continue without memory, which looks like a working setup that never recalls
+anything.
+
 ## Optional Capabilities
 
 Non-interactive setup reads credentials from the current environment and writes

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -11,6 +11,11 @@ individual package directories or create package-local `.env` files.
 - Claude Code
 - Network access for the first workspace sync and memory model download
 
+The optional autonomous heartbeat needs two more on `PATH`: `jq` and
+[`bun`](https://bun.sh/). Neither is required for anything else, and
+`autonomous-action.sh` degrades quietly without them -- see
+[Autonomous Prompt Files](./autonomous-files.md).
+
 The workspace requires Python 3.13. `uv` can install and select it
 automatically.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -372,6 +372,30 @@ Setup does not merge unknown custom MCP servers into the generated profile.
 Keep a manual copy or re-add custom entries after generation. The doctor
 reports unknown entries as warnings and does not modify them.
 
+### Adding a server: the tool's name decides whether it is gated
+
+`is_external_tool` (`individual_kernel_mcp/agency.py`) classifies every
+`mcp__`-prefixed call as an outward act **unless the name contains one of a
+small set of read-only fragments** -- `__get_`, `__query_`, `__list_`,
+`__search_`, `__read_`, `__see`, `__capture`, and a few more. An outward act
+needs a matching `propose_field_action` before the PreToolUse hook will allow
+it.
+
+The classifier receives the tool name and its input, and nothing else. A server
+that declares `ToolAnnotations(readOnlyHint=True)` is not consulted: the
+annotation cannot reach the function, so the **name** has to carry it.
+
+The failure is quiet and points the wrong way. A tool that changes nothing --
+the one worth calling freely, right before acting -- is the one that gets
+gated, because naming it symmetrically with its neighbours (`x_state` beside
+`x_move`, `x_click`) puts it on the outward side. Renaming it `get_x_state` is
+enough.
+
+Defaulting unknown names to outward is the safe direction, and it is why this
+is a naming note rather than a bug. But it is only discoverable by reading
+`agency.py` or by measuring, so: check your tool names against that list before
+wiring a new server in.
+
 ### `env` blocks override the inherited environment
 
 A value in a server's `env` block wins over whatever the parent process

--- a/docs/sociality.md
+++ b/docs/sociality.md
@@ -50,11 +50,10 @@ Useful payload fields include:
 
 ```json
 {
-  "kind": "response",
+  "kind": "agent_response",
   "summary": "Answered the setup question and asked for one diagnostic result.",
   "person_id": "kouta",
-  "channel": "chat",
-  "felt_state": "attentive and uncertain about the Windows process state",
+  "felt_state": {"attentive": 0.8, "uncertain": 0.5},
   "desires_before": {"help": 0.7},
   "desires_after": {"help": 0.3},
   "related_event_ids": [],
@@ -62,9 +61,12 @@ Useful payload fields include:
 }
 ```
 
-The exact schema is validated by `RecordAgentExperienceInput`. Common kinds
-include responses, autonomous actions, boundary respect, desire satisfaction,
-user corrections, and open-loop progress.
+The exact schema is validated by `RecordAgentExperienceInput`. `kind` is an
+`ExperienceKind` literal, so the value has to be one of the names the type
+lists -- `agent_response`, not `response`. `felt_state` is a mapping, not a
+sentence. There is no `channel` field; the model is configured with
+`extra="ignore"`, so an unknown key is dropped without an error and the
+information it carried is simply lost.
 
 These records are stored in `agent_experiences`. The next
 `compose_interaction_context_tool` reads recent rows so past actions constrain


### PR DESCRIPTION
Seven documentation corrections, held back until `docs/setup.md` was free of
in-flight PRs. Each is measured against `b4ded53` rather than reasoned about,
and each is its own commit, so any of them can be dropped without disturbing
the rest.

**No code changes.** One thing I found on the way is a code defect --
`scripts/doctor.py:282` tests `"wifi-cam" in configured`, so a project that
names its cameras `wifi-cam-1f` and `wifi-cam-car` skips the ffmpeg check
without saying so. It is deliberately not in this branch. It wants its own PR
or an issue, and the fix is a judgement call I would rather not fold into a
docs change.

### The seven

| Commit | What the docs said | What the code does |
|---|---|---|
| `docs(sociality)` | The `record_agent_experience` example | It raises when copied into a call. Three reasons, one of which does not raise |
| `docs(claude)` | Memory is ChromaDB | SQLite + numpy since Phase 11 |
| `docs(claude)` | "`evidence_type` reuses `EvidenceType`" | Five literals, beside `source`'s five which were already spelled out |
| `docs(setup)` | Prerequisites list four things | The autonomous heartbeat also needs `jq` and `bun` |
| `docs(setup)` | Nothing about startup time | `memory-mcp` warms its model for ~20 s before answering |
| `docs(organism)` | A crontab line | Windows has no crontab, and `schtasks` is not a rename of it |
| `docs(setup)` | Nothing about tool naming | A tool's **name** decides whether the outward-action gate stops it |

### Three that are worth more than a line

**The sociality example fails in two visible ways and one invisible one.**
`"kind": "response"` is not an `ExperienceKind`, and `felt_state` is a mapping
rather than a sentence -- both raise, so anyone who tries the example finds
out. `"channel"` does not raise. The model sets `extra="ignore"`, so the key is
dropped and the record looks written. Correcting only the two that raise leaves
that one in place.

**Without `jq`, the heartbeat silently stops resuming.** `NEW_SESSION_ID` comes
back empty, the session file is never updated, and every heartbeat starts a new
session. Nothing in the log distinguishes that from resuming. A heartbeat that
never resumes reads as a heartbeat with a short memory, so the search goes to
the wrong place.

**Tool names decide the gate, and the failure points the wrong way.**
`is_external_tool` treats every `mcp__` call as outward unless the name carries
a read-only fragment. The classifier takes the tool name and its input, so a
server declaring `ToolAnnotations(readOnlyHint=True)` is not consulted -- the
name has to carry it. Naming a read-only tool symmetrically with its neighbours
(`x_state` beside `x_move`, `x_click`) puts the one tool that changes nothing on
the outward side. The call you would make freely, right before acting, is the
one that needs an intention. I hit this on a server of my own and only found it
by measuring.

The fragment list is **not** copied into the docs. A second copy would go stale
without saying so, which is the shape of the ChromaDB line this same branch
removes.

### Measured on one host

Two items rest on measurements from a single machine (Windows 11, Japanese
locale, both code pages 932):

- **Startup.** `import 0.6 s / warmup() 20.3 s` with
  `intfloat/multilingual-e5-base` already on disk. The generated default
  (`e5-small`) is quicker and a first run is slower, so the doc states the
  model and the conditions rather than one number.
- **The Task Scheduler entry.** `PYTHONIOENCODING=utf-8` and the
  `echo exit=%RC%>>` stream-handle detail are both things this host produced.
  Another Windows configuration may not need the first.

Happy to soften either into a report rather than an instruction if you would
rather.

### Checked before opening

- The corrected sociality example validates through
  `RecordAgentExperienceInput.model_validate`
- `store.py`'s own docstring and `memory-mcp`'s dependencies for the ChromaDB
  line; `sentence-transformers` replaces it in the link list because that is
  the dependency actually present
- `social_core/models.py:90` for the five `evidence_type` values
- All four `jq` / `bun` call sites, including which are guarded
- `is_external_tool`, `external_fragments`, `internal_fragments`, `__get_` and
  `readOnlyHint` each appear **zero** times across `docs/`, `README*.md` and
  `CLAUDE.md` on `b4ded53`
- `ruff check .` clean

---

## 日本語

ドキュメントの訂正 7 件です。`docs/setup.md` に手が入っている PR が
片付くまで溜めていました。**推論ではなく `b4ded53` に対して測ったもの**だけで、
1 件ずつ別のコミットにしてあります。**気に入らないものだけ落とせます。**

**コードは変更していません。** 途中で見つけたコードの欠陥が 1 件あります ——
`scripts/doctor.py:282` が `"wifi-cam" in configured` を見ているため、
カメラを `wifi-cam-1f` / `wifi-cam-car` のように分けて登録すると
**ffmpeg の検査が黙って素通りします。** これは意図的にこのブランチへ入れていません。
別の PR か issue にすべきものですし、直し方には判断が要るので、
docs の変更に畳み込みたくありませんでした。

### 7 件

| コミット | ドキュメントの記述 | 実装 |
|---|---|---|
| `docs(sociality)` | `record_agent_experience` の例 | **そのまま呼ぶと落ちます。**3 つの理由があり、うち 1 つは落ちません |
| `docs(claude)` | 記憶は ChromaDB | Phase 11 以降 SQLite + numpy |
| `docs(claude)` | 「`evidence_type` は `EvidenceType` を再利用」 | 5 つの値。`source` の 5 つは既に列挙されていました |
| `docs(setup)` | Prerequisites は 4 項目 | 自律 heartbeat には `jq` と `bun` も要ります |
| `docs(setup)` | 起動時間の記載なし | `memory-mcp` は応答前に約 20 秒モデルを温めます |
| `docs(organism)` | crontab の行 | Windows に crontab は無く、`schtasks` はその改名でもありません |
| `docs(setup)` | ツール名についての記載なし | **ツール名が**外向き行為ゲートの通り方を決めます |

### 一行では済まない 3 件

**sociality の例は、2 つは見える形で、1 つは見えない形で失敗します。**
`"kind": "response"` は `ExperienceKind` ではなく、`felt_state` は文ではなく
マッピングです。この 2 つは例外になるので、試した人には分かります。
**`"channel"` は例外になりません。** モデルが `extra="ignore"` なので、
鍵は捨てられ、記録は書けたように見えます。
落ちる 2 つだけ直しても、これは残ります。

**`jq` が無いと、heartbeat は黙ってセッションを継がなくなります。**
`NEW_SESSION_ID` が空になり、セッションファイルが更新されず、毎回新しい
セッションで始まります。**ログでは継続と区別がつきません。**
継がない heartbeat は「記憶の短い heartbeat」に見えるので、
探しに行く場所を間違えます。

**ツール名がゲートを決め、しかも失敗の向きが逆です。**
`is_external_tool` は `mcp__` の呼び出しを、名前が読み取り専用の語を
含まない限り外向きとして扱います。受け口はツール名と入力だけなので、
`ToolAnnotations(readOnlyHint=True)` を宣言しても参照されません。
**名前が代わりに背負います。**

読み取り専用のツールを隣と揃えて命名すると（`x_move` / `x_click` の隣に
`x_state`）、**何も変えない唯一のツールが外向き側に置かれます。**
行動の直前に気軽に呼びたい呼び出しが、intention を要求される側になる。
自作のサーバーで踏み、測って初めて気づきました。

**内部語の一覧は docs に写していません。** 写すと、何も言わずに古びる
2 つ目の写しができます。それは**このブランチが消している ChromaDB の行と
同じ形**です。

### 1 台でしか測れていないもの

2 件は単一の機械での実測に依っています（Windows 11・日本語ロケール・
コードページは両方 932）。

- **起動時間。** `import 0.6 秒 / warmup() 20.3 秒`
  （`intfloat/multilingual-e5-base`・モデル取得済み）。生成される既定の
  `e5-small` はより速く、初回はより遅いので、**単一の数字ではなく
  モデル名と条件を書いています。**
- **Task Scheduler の項目。** `PYTHONIOENCODING=utf-8` と
  `echo exit=%RC%>>` のストリームハンドルの件は、どちらもこの機械で出たものです。
  別の Windows 構成では前者が要らない可能性があります。

**指示ではなく報告の書きぶりに緩めたほうがよければ、そうします。**

### 出す前に確かめたこと

- 直した sociality の例が `RecordAgentExperienceInput.model_validate` を通ること
- ChromaDB の行は `store.py` の docstring と `memory-mcp` の依存の両方で確認。
  リンク一覧の置き換え先を `sentence-transformers` にしたのは、
  **実際に依存に在るのがそれだから**です
- `evidence_type` の 5 値は `social_core/models.py:90`
- `jq` / `bun` の 4 箇所すべて（ガードの有無も）
- `is_external_tool` / `external_fragments` / `internal_fragments` / `__get_` /
  `readOnlyHint` が `docs/` `README*.md` `CLAUDE.md` に **0 件**（`b4ded53`）
- `ruff check .` クリーン
