### PR TITLE
fix(doctor): 設定ファイルを locale ではなく UTF-8 で読む (#149)

### DIFF
--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -212,10 +212,16 @@ def check_workspace_packages(
 
     pyproject_path = repo_root / "pyproject.toml"
     try:
-        project = tomllib.loads(pyproject_path.read_text())
+        project = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
         requirements = project["project"]["dependencies"]
         optional = project["project"].get("optional-dependencies", {})
-    except (OSError, KeyError, TypeError, tomllib.TOMLDecodeError) as error:
+    except (
+        OSError,
+        KeyError,
+        TypeError,
+        UnicodeDecodeError,
+        tomllib.TOMLDecodeError,
+    ) as error:
         return [
             CheckResult(
                 CheckStatus.ERROR,
@@ -478,7 +484,7 @@ def check_autonomous_files(repo_root: Path) -> list[CheckResult]:
 
 def _load_config(path: Path) -> tuple[dict[str, Any] | None, CheckResult]:
     try:
-        value = json.loads(path.read_text())
+        value = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         return None, CheckResult(
             CheckStatus.ERROR,
@@ -486,7 +492,7 @@ def _load_config(path: Path) -> tuple[dict[str, Any] | None, CheckResult]:
             f"configuration does not exist: {path}",
             "Run ./scripts/setup.sh.",
         )
-    except (OSError, json.JSONDecodeError) as error:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
         return None, CheckResult(
             CheckStatus.ERROR,
             "config:file",
@@ -598,8 +604,8 @@ def _check_social_policy(repo_root: Path) -> CheckResult:
             "Run ./scripts/setup.sh to create the example policy.",
         )
     try:
-        tomllib.loads(policy_path.read_text())
-    except (OSError, tomllib.TOMLDecodeError) as error:
+        tomllib.loads(policy_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
         return CheckResult(
             CheckStatus.ERROR,
             "social-policy",

--- a/tests/test_doctor_cli.py
+++ b/tests/test_doctor_cli.py
@@ -171,3 +171,45 @@ def test_hook_gate_check_is_silent_without_a_committed_pre_tool_use_hook(
     tmp_path: Path,
 ) -> None:
     assert doctor.check_hook_gate(tmp_path, None, tmp_path / ".mcp.json") is None
+
+
+def test_config_files_are_read_as_utf8_regardless_of_locale(tmp_path: Path) -> None:
+    """Config files are UTF-8 on disk; the locale codec must not decide their contents (#149)."""
+    mic_device = "マイク (Realtek Audio)"  # a Japanese Windows device name
+    config_path = tmp_path / ".mcp.json"
+    config_path.write_text(
+        json.dumps({"mcpServers": {"cam": {"env": {"MIC_DEVICE": mic_device}}}}),
+        encoding="utf-8",
+    )
+    (tmp_path / "socialPolicy.toml").write_text(
+        '# quiet hours — keep the night calm\n[global]\ntimezone = "Asia/Tokyo"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        '# ワークスペース\n[project]\nname = "x"\ndependencies = ["memory-mcp"]\n',
+        encoding="utf-8",
+    )
+
+    config, result = doctor._load_config(config_path)
+
+    assert result.status is CheckStatus.OK
+    assert config is not None
+    assert config["mcpServers"]["cam"]["env"]["MIC_DEVICE"] == mic_device
+    assert doctor._check_social_policy(tmp_path).status is CheckStatus.OK
+    packages = doctor.check_workspace_packages(tmp_path, {"mcpServers": {"memory": {}}})
+    assert [item.status for item in packages] == [CheckStatus.OK]
+
+
+def test_undecodable_config_files_become_check_errors_not_tracebacks(tmp_path: Path) -> None:
+    """A byte sequence that is not UTF-8 is reported, not raised (#149)."""
+    bad = b"\xff\xfe not utf-8"
+    (tmp_path / ".mcp.json").write_bytes(bad)
+    (tmp_path / "socialPolicy.toml").write_bytes(bad)
+    (tmp_path / "pyproject.toml").write_bytes(bad)
+
+    config, result = doctor._load_config(tmp_path / ".mcp.json")
+    assert config is None
+    assert result.status is CheckStatus.ERROR
+    assert doctor._check_social_policy(tmp_path).status is CheckStatus.ERROR
+    packages = doctor.check_workspace_packages(tmp_path, {"mcpServers": {"memory": {}}})
+    assert [item.status for item in packages] == [CheckStatus.ERROR]


### PR DESCRIPTION
## 概要

`scripts/doctor.py` が `pyproject.toml` / `.mcp.json` / `socialPolicy.toml` を `read_text()` で encoding 指定なしに読んでいたため、日本語 Windows（cp932）では

- コメントの em-dash などで `UnicodeDecodeError` が捕まらず traceback で落ちる
- `MIC_DEVICE` のカタカナが別の文字に化けたまま `ok` と報告する

の二通りに壊れていました。#149 で fmtowns3 さんが実測つきで報告してくださった内容です。

## 変更

- 3 箇所の `read_text()` に `encoding="utf-8"` を指定（実行時の `boundary_mcp.policy` と同じ書き方に揃えました）
- それぞれの `except` に `UnicodeDecodeError` を追加。UTF-8 として読めないファイルは traceback ではなく `ERROR` の検査結果になります
- テスト 2 本を追加
  - 非 ASCII を含む UTF-8 の設定ファイルが locale に関係なくそのまま読めること
  - UTF-8 として不正なバイト列が検査結果として報告されること

`subprocess` で外部コマンドの出力を読む箇所は、issue のご指摘どおり OEM コードページのままなので触っていません。

## 確認

```
uv run ruff check scripts/doctor.py tests/test_doctor_cli.py  # All checks passed
uv run pytest tests/test_doctor_cli.py -q                      # 8 passed
```

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxBXjcocf3Y58yQMpSZtHt
