### PR TITLE
fix(wifi-cam): 入っている文字起こしバックエンドを既定にし、未導入メッセージを Transcript から分ける (#151)

### DIFF
--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import platform
@@ -274,10 +275,78 @@ def check_workspace_packages(
     return results
 
 
+TRANSCRIBE_BACKENDS: tuple[str, ...] = ("openai-whisper", "faster-whisper")
+TRANSCRIBE_BACKEND_MODULES = {"openai-whisper": "whisper", "faster-whisper": "faster_whisper"}
+TRANSCRIBE_BACKEND_EXTRAS = {
+    "openai-whisper": "transcription-whisper",
+    "faster-whisper": "transcription-faster",
+}
+
+
+def _module_available(name: str) -> bool:
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def check_transcription_backend(
+    server: Mapping[str, Any],
+    environment: Mapping[str, str] | None = None,
+    *,
+    module_available: Callable[[str], bool] = _module_available,
+) -> CheckResult:
+    """Check that the transcription backend `listen` will use is importable.
+
+    Mirrors wifi_cam_mcp.config: an explicit TRANSCRIBE_BACKEND (server env,
+    then process env) wins; otherwise the first installed backend is used.
+    Without this check a `transcription-faster`-only install looked healthy
+    while `listen` could never transcribe (#151).
+    """
+
+    source = os.environ if environment is None else environment
+    server_env = server.get("env", {}) if isinstance(server, Mapping) else {}
+    explicit = str(
+        (server_env.get("TRANSCRIBE_BACKEND") if isinstance(server_env, Mapping) else None)
+        or source.get("TRANSCRIBE_BACKEND")
+        or ""
+    ).strip().lower()
+    subject = "wifi-cam:transcription"
+    if explicit:
+        module = TRANSCRIBE_BACKEND_MODULES.get(explicit)
+        if module is None:
+            return CheckResult(
+                CheckStatus.ERROR,
+                subject,
+                f"TRANSCRIBE_BACKEND={explicit!r} is not a known backend",
+                "Use openai-whisper or faster-whisper.",
+            )
+        if module_available(module):
+            return CheckResult(CheckStatus.OK, subject, f"{explicit} is installed")
+        return CheckResult(
+            CheckStatus.WARN,
+            subject,
+            f"TRANSCRIBE_BACKEND={explicit} but module {module!r} is not importable; "
+            "listen will record audio without a transcript",
+            f"Run uv sync --extra {TRANSCRIBE_BACKEND_EXTRAS[explicit]}, "
+            "or set TRANSCRIBE_BACKEND to the backend you installed.",
+        )
+    for backend in TRANSCRIBE_BACKENDS:
+        if module_available(TRANSCRIBE_BACKEND_MODULES[backend]):
+            return CheckResult(CheckStatus.OK, subject, f"{backend} is installed (auto-detected)")
+    return CheckResult(
+        CheckStatus.WARN,
+        subject,
+        "no transcription backend is installed; listen will record audio without a transcript",
+        "Run uv sync --extra transcription-whisper (or --extra transcription-faster).",
+    )
+
+
 def check_optional_dependencies(
     config: Mapping[str, Any],
     *,
     which: Callable[[str], str | None] = shutil.which,
+    module_available: Callable[[str], bool] = _module_available,
 ) -> list[CheckResult]:
     """Check non-blocking executables used by selected optional capabilities."""
 
@@ -299,6 +368,11 @@ def check_optional_dependencies(
                     "Install ffmpeg, then rerun uv run python scripts/doctor.py.",
                 )
             )
+        results.append(
+            check_transcription_backend(
+                configured["wifi-cam"], module_available=module_available
+            )
+        )
 
     if "tts" in configured:
         player = next((name for name in ("mpv", "ffplay") if which(name)), None)

--- a/tests/test_doctor_cli.py
+++ b/tests/test_doctor_cli.py
@@ -213,3 +213,32 @@ def test_undecodable_config_files_become_check_errors_not_tracebacks(tmp_path: P
     assert doctor._check_social_policy(tmp_path).status is CheckStatus.ERROR
     packages = doctor.check_workspace_packages(tmp_path, {"mcpServers": {"memory": {}}})
     assert [item.status for item in packages] == [CheckStatus.ERROR]
+def test_transcription_check_follows_installed_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """doctor must notice when the backend listen will use is not importable (#151)."""
+    monkeypatch.delenv("TRANSCRIBE_BACKEND", raising=False)
+
+    def only_faster(name: str) -> bool:
+        return name == "faster_whisper"
+
+    auto = doctor.check_transcription_backend({}, {}, module_available=only_faster)
+    assert auto.status is CheckStatus.OK
+    assert "faster-whisper" in auto.detail
+
+    explicit_missing = doctor.check_transcription_backend(
+        {"env": {"TRANSCRIBE_BACKEND": "openai-whisper"}}, {}, module_available=only_faster
+    )
+    assert explicit_missing.status is CheckStatus.WARN
+    assert "transcription-whisper" in explicit_missing.remediation
+
+    nothing = doctor.check_transcription_backend({}, {}, module_available=lambda _n: False)
+    assert nothing.status is CheckStatus.WARN
+
+    unknown = doctor.check_transcription_backend(
+        {}, {"TRANSCRIBE_BACKEND": "vosk"}, module_available=only_faster
+    )
+    assert unknown.status is CheckStatus.ERROR
+
+    results = doctor.check_optional_dependencies(
+        {"mcpServers": {"wifi-cam": {}}}, which=lambda _n: None, module_available=only_faster
+    )
+    assert [r.subject for r in results] == ["wifi-cam:ffmpeg", "wifi-cam:transcription"]

--- a/wifi-cam-mcp/README.md
+++ b/wifi-cam-mcp/README.md
@@ -25,6 +25,20 @@ Tapo C210などのWiFiカメラをMCP経由で制御して、AIに部屋を見�
 | `camera_go_to_preset` | プリセット位置に移動（`preset_id`） |
 | `listen` | マイクで聞く（`duration` 秒、`transcribe` で文字起こし） |
 
+### 文字起こしのバックエンド
+
+文字起こしは optional で、root の extras から片方（または両方）を選んで入れます。
+
+| extra | パッケージ | `TRANSCRIBE_BACKEND` の値 |
+|-------|-----------|---------------------------|
+| `transcription-whisper` | openai-whisper | `openai-whisper` |
+| `transcription-faster` | faster-whisper（CTranslate2） | `faster-whisper` |
+
+`TRANSCRIBE_BACKEND` を設定しなければ **入っているほうを自動で使います**（両方あれば
+`openai-whisper`）。どちらも入っていないときは録音だけ行い、応答の `--- Transcript ---`
+ではなく `--- No transcript ---` の見出しの下に理由を返します。`uv run python scripts/doctor.py`
+の `wifi-cam:transcription` でも確認できます。
+
 ### 右カメラ（両目）を追加する
 
 同じ場所に 2 台目のカメラを置き、`TAPO_RIGHT_*` を設定すると、起動時に右カメラへ

--- a/wifi-cam-mcp/README_WinNative.md
+++ b/wifi-cam-mcp/README_WinNative.md
@@ -63,8 +63,9 @@ MIC_SOURCE=camera
 # MIC_SOURCE=local のときのみ有効。未設定なら先頭の音声デバイスを自動選択する。
 # MIC_DEVICE=マイク配列 (Realtek(R) Audio)
 
-# 認識バックエンド: openai-whisper（既定）/ faster-whisper
-TRANSCRIBE_BACKEND=openai-whisper
+# 認識バックエンド: openai-whisper / faster-whisper
+# 未設定なら、入っているほう（両方あれば openai-whisper）を自動で選ぶ
+# TRANSCRIBE_BACKEND=openai-whisper
 
 # モデルサイズ: tiny / base / small / medium / large
 # 実マイクを通すなら small を推奨（§5-1）
@@ -231,7 +232,7 @@ GPU なし・2 コアの環境では以下のようになる:
 |---|---|---|
 | `MIC_SOURCE` | `camera` | `camera`（RTSP）/ `local`（PC のマイク） |
 | `MIC_DEVICE` | 未設定 | Windows の DirectShow デバイス名。未設定なら自動検出 |
-| `TRANSCRIBE_BACKEND` | `openai-whisper` | `openai-whisper` / `faster-whisper` |
+| `TRANSCRIBE_BACKEND` | 自動検出 | `openai-whisper` / `faster-whisper`。未設定なら import できるほう（両方あれば `openai-whisper`）。どちらも無ければ `listen` は録音だけ行い、transcript の代わりに理由を返す |
 | `TRANSCRIBE_MODEL` | `base` | `tiny` / `base` / `small` / `medium` / `large` |
 
 `faster-whisper` は CTranslate2 を使用し、CPU では `int8`、CUDA が利用可能なら `float16` を自動選択する。

--- a/wifi-cam-mcp/src/wifi_cam_mcp/camera.py
+++ b/wifi-cam-mcp/src/wifi_cam_mcp/camera.py
@@ -16,7 +16,12 @@ from pathlib import Path
 from PIL import Image
 
 from ._behavior import get_behavior
-from .config import CameraConfig
+from .config import (
+    TRANSCRIBE_BACKEND_EXTRAS,
+    TRANSCRIBE_BACKEND_MODULES,
+    CameraConfig,
+    transcribe_backend_available,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +60,9 @@ class AudioResult:
     timestamp: str
     duration: float
     transcript: str | None = None
+    # Why no transcript was produced (backend missing, model failure). Kept
+    # apart from ``transcript`` so a diagnostic never reads as heard speech.
+    transcript_error: str | None = None
 
 
 @dataclass(frozen=True)
@@ -957,8 +965,9 @@ class TapoCamera:
             audio_base64 = base64.standard_b64encode(audio_data).decode("utf-8")
 
             transcript = None
+            transcript_error = None
             if transcribe:
-                transcript = await self._transcribe_audio(file_path)
+                transcript, transcript_error = await self._transcribe_audio(file_path)
 
             return AudioResult(
                 audio_base64=audio_base64,
@@ -966,11 +975,12 @@ class TapoCamera:
                 timestamp=timestamp,
                 duration=duration,
                 transcript=transcript,
+                transcript_error=transcript_error,
             )
         except Exception as e:
             raise RuntimeError(f"Failed to record audio: {e!s}") from e
 
-    async def _transcribe_audio(self, audio_path: str) -> str | None:
+    async def _transcribe_audio(self, audio_path: str) -> tuple[str | None, str | None]:
         """Transcribe audio file using Whisper.
 
         The backend (openai-whisper or faster-whisper) and model size are
@@ -980,26 +990,27 @@ class TapoCamera:
             audio_path: Path to the audio file
 
         Returns:
-            Transcribed text or None if transcription fails
+            ``(transcript, error)``. Exactly one side is set: the transcript
+            when transcription ran, otherwise a human-readable reason. The
+            reason is never returned in the transcript slot (#151).
         """
         backend = self._transcribe_backend
-        if backend == "faster-whisper":
-            try:
-                import faster_whisper  # noqa: F401
-            except ImportError:
-                return "[faster-whisper not installed. Run: pip install faster-whisper]"
-        else:
-            try:
-                import whisper  # noqa: F401
-            except ImportError:
-                return "[Whisper not installed. Run: pip install openai-whisper]"
+        if not transcribe_backend_available(backend):
+            module = TRANSCRIBE_BACKEND_MODULES.get(backend, backend)
+            extra = TRANSCRIBE_BACKEND_EXTRAS.get(backend)
+            hint = f"uv sync --extra {extra}" if extra else f"pip install {backend}"
+            return None, (
+                f"{backend} is not installed (module {module!r} not found). "
+                f"Install it with `{hint}`, or point TRANSCRIBE_BACKEND at an installed backend."
+            )
 
         try:
             model = await asyncio.to_thread(
                 _get_whisper_model, backend, self._transcribe_model
             )
-            return await asyncio.to_thread(
+            transcript = await asyncio.to_thread(
                 _transcribe_with_model, backend, model, audio_path
             )
         except Exception as e:
-            return f"[Transcription failed: {e!s}]"
+            return None, f"transcription with {backend} failed: {e!s}"
+        return transcript, None

--- a/wifi-cam-mcp/src/wifi_cam_mcp/config.py
+++ b/wifi-cam-mcp/src/wifi_cam_mcp/config.py
@@ -1,5 +1,6 @@
 """Configuration for WiFi Camera MCP Server."""
 
+import importlib.util
 import os
 import tempfile
 from dataclasses import dataclass, field
@@ -24,6 +25,47 @@ def _environment_bool(name: str, default: bool) -> bool:
 
 def _default_capture_dir() -> str:
     return str(Path(tempfile.gettempdir()) / "wifi-cam-mcp")
+
+
+# Transcription backends, in the order auto-detection prefers them. Each maps
+# to the importable module and to the root-workspace extra that installs it.
+TRANSCRIBE_BACKENDS: tuple[str, ...] = ("openai-whisper", "faster-whisper")
+TRANSCRIBE_BACKEND_MODULES: dict[str, str] = {
+    "openai-whisper": "whisper",
+    "faster-whisper": "faster_whisper",
+}
+TRANSCRIBE_BACKEND_EXTRAS: dict[str, str] = {
+    "openai-whisper": "transcription-whisper",
+    "faster-whisper": "transcription-faster",
+}
+
+
+def _module_available(name: str) -> bool:
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def transcribe_backend_available(backend: str) -> bool:
+    """True when the package behind ``backend`` is importable."""
+    module = TRANSCRIBE_BACKEND_MODULES.get(backend)
+    return module is not None and _module_available(module)
+
+
+def default_transcribe_backend() -> str:
+    """Pick the transcription backend that is actually installed.
+
+    The two root extras (``transcription-whisper`` / ``transcription-faster``)
+    read as alternatives, so the default must follow whichever one the user
+    chose instead of always pointing at openai-whisper (#151). openai-whisper
+    wins when both are present; when neither is, it stays the default so the
+    "not installed" message keeps pointing at the historical choice.
+    """
+    for backend in TRANSCRIBE_BACKENDS:
+        if transcribe_backend_available(backend):
+            return backend
+    return TRANSCRIBE_BACKENDS[0]
 
 
 @dataclass(frozen=True)
@@ -148,7 +190,8 @@ class ServerConfig:
     mic_source: str = "camera"  # "camera" (RTSP) or "local" (PC microphone)
     mic_device: str | None = None  # DirectShow device name for Windows local mic
     transcribe_default: bool = True
-    transcribe_backend: str = "openai-whisper"  # "openai-whisper" or "faster-whisper"
+    # "openai-whisper" or "faster-whisper"; unset means "whichever is installed"
+    transcribe_backend: str = field(default_factory=default_transcribe_backend)
     transcribe_model: str = "base"  # Whisper model size (tiny/base/small/medium/large)
 
     @classmethod
@@ -157,8 +200,10 @@ class ServerConfig:
         mic_source = os.getenv("MIC_SOURCE", "camera").lower()
         if mic_source not in ("camera", "local"):
             raise ValueError(f"Invalid MIC_SOURCE '{mic_source}'. Must be 'camera' or 'local'.")
-        transcribe_backend = os.getenv("TRANSCRIBE_BACKEND", "openai-whisper").lower()
-        if transcribe_backend not in ("openai-whisper", "faster-whisper"):
+        transcribe_backend = (
+            os.getenv("TRANSCRIBE_BACKEND", "").strip().lower() or default_transcribe_backend()
+        )
+        if transcribe_backend not in TRANSCRIBE_BACKENDS:
             raise ValueError(
                 f"Invalid TRANSCRIBE_BACKEND '{transcribe_backend}'. "
                 "Must be 'openai-whisper' or 'faster-whisper'."

--- a/wifi-cam-mcp/src/wifi_cam_mcp/server.py
+++ b/wifi-cam-mcp/src/wifi_cam_mcp/server.py
@@ -15,7 +15,7 @@ from mcp.types import (
 )
 
 from ._behavior import get_behavior
-from .camera import TapoCamera, describe_pose
+from .camera import AudioResult, TapoCamera, describe_pose
 from .config import CameraConfig, ServerConfig
 
 logging.basicConfig(level=logging.INFO)
@@ -25,6 +25,20 @@ logger = logging.getLogger(__name__)
 def resolve_transcribe(arguments: dict[str, Any], *, default: bool) -> bool:
     """Resolve an explicit listen argument against the configured default."""
     return bool(arguments.get("transcribe", default))
+
+
+def format_listen_response(result: AudioResult) -> str:
+    """Render a listen result. Diagnostics never appear under the Transcript heading."""
+    text = f"Recorded {result.duration}s of audio at {result.timestamp}\n"
+    text += f"Audio file: {result.file_path}\n"
+    if result.transcript:
+        text += f"\n--- Transcript ---\n{result.transcript}"
+    elif result.transcript_error:
+        text += (
+            "\n--- No transcript (transcription was not performed) ---\n"
+            f"{result.transcript_error}"
+        )
+    return text
 
 
 class CameraMCPServer:
@@ -165,7 +179,7 @@ class CameraMCPServer:
                 ),
                 Tool(
                     name="listen",
-                    description="Listen with your ears (microphone) to hear what's happening around you. Use this when someone asks 'what do you hear?' or when you want to know what sounds are present. Returns transcribed text of what you heard.",
+                    description="Listen with your ears (microphone) to hear what's happening around you. Use this when someone asks 'what do you hear?' or when you want to know what sounds are present. Returns transcribed text of what you heard under a 'Transcript' heading; when no transcription backend is installed it says so under a separate 'No transcript' heading instead.",
                     inputSchema={
                         "type": "object",
                         "properties": {
@@ -485,15 +499,9 @@ class CameraMCPServer:
                             duration, transcribe, mic_source
                         )
 
-                        response_text = (
-                            f"Recorded {result.duration}s of audio at {result.timestamp}\n"
-                        )
-                        response_text += f"Audio file: {result.file_path}\n"
-
-                        if result.transcript:
-                            response_text += f"\n--- Transcript ---\n{result.transcript}"
-
-                        return [TextContent(type="text", text=response_text)]
+                        return [
+                            TextContent(type="text", text=format_listen_response(result))
+                        ]
 
                     case "see_right":
                         if not self._camera_right:

--- a/wifi-cam-mcp/tests/test_config.py
+++ b/wifi-cam-mcp/tests/test_config.py
@@ -119,3 +119,57 @@ def test_right_camera_rejects_invalid_ptz_mode(
 
     with pytest.raises(ValueError, match="PTZ mode"):
         CameraConfig.right_camera_from_env()
+
+
+def _only(installed: set[str]):
+    return lambda name: name in installed
+
+
+@pytest.mark.parametrize(
+    ("installed", "expected"),
+    (
+        ({"faster_whisper"}, "faster-whisper"),
+        ({"whisper"}, "openai-whisper"),
+        ({"whisper", "faster_whisper"}, "openai-whisper"),
+        (set(), "openai-whisper"),
+    ),
+)
+def test_transcribe_backend_defaults_to_the_installed_one(
+    monkeypatch: pytest.MonkeyPatch, installed: set[str], expected: str
+) -> None:
+    """Installing only transcription-faster must not leave listen pointing at whisper (#151)."""
+    monkeypatch.delenv("TRANSCRIBE_BACKEND", raising=False)
+    monkeypatch.setattr(config, "_module_available", _only(installed))
+
+    assert config.default_transcribe_backend() == expected
+    assert ServerConfig.from_env().transcribe_backend == expected
+    assert ServerConfig().transcribe_backend == expected
+
+
+def test_explicit_transcribe_backend_wins_over_detection(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TRANSCRIBE_BACKEND", "faster-whisper")
+    monkeypatch.setattr(config, "_module_available", _only({"whisper"}))
+
+    assert ServerConfig.from_env().transcribe_backend == "faster-whisper"
+
+
+def test_listen_response_keeps_diagnostics_out_of_the_transcript_heading() -> None:
+    from wifi_cam_mcp.camera import AudioResult
+    from wifi_cam_mcp.server import format_listen_response
+
+    heard = AudioResult("", "/tmp/a.wav", "t", 5.0, transcript="こんにちは")
+    missing = AudioResult(
+        "",
+        "/tmp/a.wav",
+        "t",
+        5.0,
+        transcript=None,
+        transcript_error="faster-whisper is not installed",
+    )
+    silent = AudioResult("", "/tmp/a.wav", "t", 5.0)
+
+    assert "--- Transcript ---\nこんにちは" in format_listen_response(heard)
+    assert "--- Transcript ---" not in format_listen_response(missing)
+    assert "--- No transcript" in format_listen_response(missing)
+    assert "faster-whisper is not installed" in format_listen_response(missing)
+    assert "Transcript" not in format_listen_response(silent)

--- a/wifi-cam-mcp/tests/test_windows_audio.py
+++ b/wifi-cam-mcp/tests/test_windows_audio.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from wifi_cam_mcp import camera as camera_module
 from wifi_cam_mcp.camera import (
     TapoCamera,
     _find_dshow_audio_device,
@@ -113,3 +114,29 @@ def test_openai_whisper_model_is_cached_by_backend_and_size(monkeypatch):
         assert loaded == ["base"]
     finally:
         _whisper_models.clear()
+
+
+@pytest.mark.asyncio
+async def test_missing_backend_is_reported_as_error_not_transcript(monkeypatch, tmp_path):
+    """The 'not installed' message must not come back as heard speech (#151)."""
+
+    async def create_subprocess_exec(*args, **kwargs):
+        Path(args[-1]).write_bytes(b"RIFF")
+        return _RecordingProcess()
+
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_subprocess_exec)
+    monkeypatch.setattr(camera_module, "transcribe_backend_available", lambda _backend: False)
+
+    camera = TapoCamera(
+        CameraConfig(host="127.0.0.1", username="user", password="pass"),
+        capture_dir=str(tmp_path),
+        mic_device="Microphone Array",
+        transcribe_backend="faster-whisper",
+    )
+    result = await camera.listen_audio(duration=1, transcribe=True, mic_source="local")
+
+    assert result.transcript is None
+    assert result.transcript_error is not None
+    assert "faster-whisper is not installed" in result.transcript_error
+    assert "transcription-faster" in result.transcript_error


### PR DESCRIPTION
## 概要

#151 で fmtowns3 さんが報告してくださった 2 点を直します。

1. `transcription-faster` だけを入れた人が、既定の `openai-whisper` を指したまま `listen` を使えない
2. 未導入の説明文が `--- Transcript ---` の見出しの下に「聞こえた内容」として返る

issue で挙げていただいた案のうち (a) (b) (c) (d) を全部入れました。「(2) だけはどの案を採っても直す価値がある」というご指摘に同感したので、そこを中心にしています。

## 変更

- **config**: `TRANSCRIBE_BACKEND` 未設定なら import できるバックエンドを自動選択（`openai-whisper` → `faster-whisper` の順。両方無ければ従来どおり `openai-whisper`）。明示した値はそのまま優先
- **camera**: `_transcribe_audio` が `(transcript, error)` を返すようにし、`AudioResult` に `transcript_error` を追加。transcript のスロットに診断文が入ることはもうありません
- **server**: `format_listen_response` を切り出し、理由は `--- No transcript (transcription was not performed) ---` という別見出しの下に出します。ツール説明もその旨を追記
- **doctor**: `wifi-cam:transcription` 検査を追加。`listen` が使うバックエンドが import できないときは WARN、未知の値は ERROR。config と同じルールで判定します
- **docs**: `README.md` に extras と自動検出の説明を追加、`README_WinNative.md` の既定値の記述を更新
- **tests**: 自動検出 4 パターン、明示値優先、未導入時に transcript が None で error が入ること、応答整形、doctor の各分岐

## 確認

```
uv lock --check
uv run ruff check wifi-cam-mcp scripts/doctor.py tests/test_doctor_cli.py   # All checks passed
uv run --package wifi-cam-mcp pytest wifi-cam-mcp/tests -q                   # 41 passed
uv run pytest tests/test_doctor_cli.py tests/test_onboarding.py -q           # 45 passed
```

未導入時の `listen` 応答はこうなります。

```
Recorded 5s of audio at ...
Audio file: ...

--- No transcript (transcription was not performed) ---
faster-whisper is not installed (module 'faster_whisper' not found). Install it with `uv sync --extra transcription-faster`, or point TRANSCRIBE_BACKEND at an installed backend.
```

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxBXjcocf3Y58yQMpSZtHt
