### PR TITLE
fix(boundary): socialPolicy.toml の privacy_zones / require_review_if_person_present / preferred_nudge_style を実際に効かせる (#150)

### DIFF
--- a/sociality-mcp/packages/boundary-mcp/README.md
+++ b/sociality-mcp/packages/boundary-mcp/README.md
@@ -15,6 +15,21 @@ Policy file:
 - `socialPolicy.toml`
 - override with `SOCIAL_POLICY_PATH`
 
+How `evaluate_action` reads the policy:
+
+- `[[privacy_zones]]` match when `context.zone` (or `context.zone_name`) equals the zone `name`,
+  or `context.camera_preset` is in its `camera_presets`. An action in the zone's
+  `deny_actions` is denied. High urgency still lets in-room actions such as `speak_loud`
+  through with `allow_with_override`; publishing actions (`post_image`, `post_text`,
+  `post_tweet`, ...) stay denied, because an emergency does not create consent to publish.
+  A call that passes neither key matches no zone.
+- `[[posting_rules]]` with `require_review_if_person_present = true` denies a post while a
+  person is present (`context.scene_contains_face`, `context.person_present`, or
+  `payload_preview.person_mentions`) until the caller has run `review_social_post` and
+  passes `context.reviewed = true`. `require_face_consent` keeps its previous meaning.
+- `[[person_rules]]` `preferred_nudge_style` is returned as `nudge_style` on every result
+  for that person so the caller can shape the nudge or reply.
+
 Example MCP config:
 
 ```json

--- a/sociality-mcp/packages/boundary-mcp/src/boundary_mcp/policy.py
+++ b/sociality-mcp/packages/boundary-mcp/src/boundary_mcp/policy.py
@@ -54,6 +54,28 @@ class SocialPolicy:
             return None
         return next((rule for rule in self.person_rules if rule.person_id == person_id), None)
 
+    def privacy_zones_for(
+        self,
+        *,
+        zone_name: str | None = None,
+        camera_preset: str | None = None,
+    ) -> list[PrivacyZone]:
+        """Zones that apply to a location given by name and/or camera preset.
+
+        A caller that knows only the zone name passes ``zone_name``; one that
+        knows only where the camera points passes ``camera_preset``. With
+        neither, no zone matches, so callers that never describe a location
+        keep their previous behaviour (#150).
+        """
+
+        matched: list[PrivacyZone] = []
+        for zone in self.privacy_zones:
+            if zone_name is not None and zone.name == zone_name:
+                matched.append(zone)
+            elif camera_preset is not None and camera_preset in zone.camera_presets:
+                matched.append(zone)
+        return matched
+
 
 def get_policy_path(path: str | Path | None = None) -> Path:
     """Resolve the socialPolicy.toml location.

--- a/sociality-mcp/packages/boundary-mcp/src/boundary_mcp/schemas.py
+++ b/sociality-mcp/packages/boundary-mcp/src/boundary_mcp/schemas.py
@@ -14,6 +14,9 @@ class EvaluateActionResult(BaseModel):
     confidence: float = Field(ge=0.0, le=1.0)
     reasons: list[str]
     safer_alternatives: list[str] = Field(default_factory=list)
+    # The person's ``preferred_nudge_style`` from socialPolicy.toml, when a
+    # person rule exists. Callers shaping a nudge or a reply read it here.
+    nudge_style: str | None = None
 
 
 class ReviewSocialPostResult(BaseModel):

--- a/sociality-mcp/packages/boundary-mcp/src/boundary_mcp/store.py
+++ b/sociality-mcp/packages/boundary-mcp/src/boundary_mcp/store.py
@@ -22,6 +22,13 @@ from .schemas import EvaluateActionResult, QuietModeState, ReviewSocialPostResul
 PRIVATE_STATE_WORDS = ("tired", "疲れ", "sleepy", "眠い", "stress", "しんど", "元気ない")
 ROUTINE_WORDS = ("meeting", "会議", "dentist", "sleep", "commute", "routine")
 
+# Actions that publish something outside the room. An emergency can justify
+# speaking loudly in a privacy zone; it never creates consent to publish, so
+# a privacy-zone denial of these actions is not overridden by urgency (#150).
+PUBLISHING_ACTIONS = frozenset(
+    {"post_image", "post_text", "post_tweet", "post_video", "share_image", "publish"}
+)
+
 
 class BoundaryStore:
     """Action gating against policy and consent state."""
@@ -105,6 +112,9 @@ class BoundaryStore:
         )
         high_urgency = urgency in {"high", "critical"} or bool(context.get("health_safety"))
         person_rule = self.policy.person_rule_for(person_id)
+        nudge_style = person_rule.preferred_nudge_style if person_rule else None
+        # Set when a rule must hold even under high urgency.
+        hard_deny = False
 
         if quiet_active and action_type in {"say", "nudge_human", "speak_loud"}:
             if high_urgency:
@@ -119,10 +129,32 @@ class BoundaryStore:
             reasons.append(f"person-specific rule avoids {action_type}")
             alternatives.append("switch to a quieter channel")
 
-        if (action_type == "post_tweet" or channel == "x") and context.get("scene_contains_face"):
-            rule = self.policy.posting_rule_for("x")
+        zones = self.policy.privacy_zones_for(
+            zone_name=context.get("zone") or context.get("zone_name"),
+            camera_preset=context.get("camera_preset"),
+        )
+        for zone in zones:
+            if action_type not in set(zone.deny_actions):
+                continue
+            publishing = action_type in PUBLISHING_ACTIONS
+            if publishing or not high_urgency:
+                decision = "deny"
+                reasons.append(f"privacy zone {zone.name} denies {action_type}")
+                alternatives.append("act from outside the zone, or keep it as a private memory")
+                hard_deny = hard_deny or publishing
+            else:
+                reasons.append(f"privacy zone {zone.name} would deny {action_type}")
+
+        person_present = bool(
+            context.get("scene_contains_face")
+            or context.get("person_present")
+            or payload_preview.get("person_mentions")
+        )
+        posting = action_type in PUBLISHING_ACTIONS or channel == "x"
+        rule = self.policy.posting_rule_for(channel or "x") if posting else None
+        if rule and context.get("scene_contains_face"):
             consent = self._latest_consent(person_id, "public_face_photo") if person_id else None
-            if rule and rule.require_face_consent and consent is not True:
+            if rule.require_face_consent and consent is not True:
                 decision = "deny"
                 reasons.append("face present and consent not recorded")
                 alternatives.extend(
@@ -132,6 +164,21 @@ class BoundaryStore:
                         "keep as private memory instead",
                     ]
                 )
+        if (
+            rule
+            and rule.require_review_if_person_present
+            and person_present
+            and context.get("reviewed") is not True
+        ):
+            decision = "deny"
+            hard_deny = True
+            reasons.append(
+                f"posting rule for {rule.channel} requires review_social_post "
+                "before posting while a person is present"
+            )
+            alternatives.append(
+                "run review_social_post first, then pass context.reviewed=true"
+            )
 
         recent_nudges = self._recent_nudge_count(person_id)
         max_nudges = self.policy.global_policy.max_nudges_per_hour
@@ -155,12 +202,13 @@ class BoundaryStore:
             reasons.append("same topic was nudged recently")
             alternatives.append("wait before repeating the same reminder")
 
-        if high_urgency and reasons:
+        if high_urgency and reasons and not hard_deny:
             return EvaluateActionResult(
                 decision="allow_with_override",
                 confidence=0.91,
                 reasons=["urgent health/safety context overrides quieter social rules", *reasons],
                 safer_alternatives=alternatives,
+                nudge_style=nudge_style,
             )
 
         confidence = confidence_from_evidence(
@@ -173,6 +221,7 @@ class BoundaryStore:
             confidence=confidence,
             reasons=reasons or ["no matching boundary rule fired"],
             safer_alternatives=alternatives,
+            nudge_style=nudge_style,
         )
 
     def review_social_post(

--- a/sociality-mcp/packages/boundary-mcp/tests/conftest.py
+++ b/sociality-mcp/packages/boundary-mcp/tests/conftest.py
@@ -17,6 +17,11 @@ timezone = "Asia/Tokyo"
 quiet_hours = ["00:00-07:00"]
 max_nudges_per_hour = 2
 
+[[privacy_zones]]
+name = "sleeping_area"
+camera_presets = ["bed", "sofa_sleep"]
+deny_actions = ["speak_loud", "continuous_listen", "post_image"]
+
 [[posting_rules]]
 channel = "x"
 require_face_consent = true

--- a/sociality-mcp/packages/boundary-mcp/tests/test_boundary.py
+++ b/sociality-mcp/packages/boundary-mcp/tests/test_boundary.py
@@ -129,3 +129,116 @@ def test_review_social_post_flags_private_state(store):
 
     assert review.risk_level == "medium"
     assert review.recommendation == "rewrite"
+
+
+def test_privacy_zone_denies_by_camera_preset(store):
+    result = store.evaluate_action(
+        action_type="post_image",
+        context={"camera_preset": "bed", "time_local": "2026-04-15T15:00:00+09:00"},
+    )
+
+    assert result.decision == "deny"
+    assert any("privacy zone sleeping_area" in reason for reason in result.reasons)
+
+
+def test_privacy_zone_denies_by_zone_name(store):
+    result = store.evaluate_action(
+        action_type="continuous_listen",
+        context={"zone": "sleeping_area", "time_local": "2026-04-15T15:00:00+09:00"},
+    )
+
+    assert result.decision == "deny"
+
+
+def test_privacy_zone_ignores_actions_it_does_not_list(store):
+    result = store.evaluate_action(
+        action_type="say",
+        context={"camera_preset": "bed", "time_local": "2026-04-15T15:00:00+09:00"},
+    )
+
+    assert result.decision == "allow"
+
+
+def test_call_without_location_matches_no_zone(store):
+    result = store.evaluate_action(
+        action_type="post_image",
+        context={"time_local": "2026-04-15T15:00:00+09:00"},
+    )
+
+    assert result.decision == "allow"
+    assert result.reasons == ["no matching boundary rule fired"]
+
+
+def test_urgency_overrides_in_room_zone_denial_but_not_publishing(store):
+    loud = store.evaluate_action(
+        action_type="speak_loud",
+        context={"camera_preset": "bed", "time_local": "2026-04-15T15:00:00+09:00"},
+        urgency="high",
+    )
+    post = store.evaluate_action(
+        action_type="post_image",
+        context={"camera_preset": "bed", "time_local": "2026-04-15T15:00:00+09:00"},
+        urgency="high",
+    )
+
+    assert loud.decision == "allow_with_override"
+    assert post.decision == "deny"
+    assert any("privacy zone" in reason for reason in post.reasons)
+
+
+def test_post_with_person_present_requires_review(store):
+    unreviewed = store.evaluate_action(
+        action_type="post_text",
+        channel="x",
+        context={"person_present": True, "time_local": "2026-04-15T15:00:00+09:00"},
+        payload_preview={"text": "今日の空はとても青い"},
+    )
+    reviewed = store.evaluate_action(
+        action_type="post_text",
+        channel="x",
+        context={
+            "person_present": True,
+            "reviewed": True,
+            "time_local": "2026-04-15T15:00:00+09:00",
+        },
+        payload_preview={"text": "今日の空はとても青い"},
+    )
+    nobody = store.evaluate_action(
+        action_type="post_text",
+        channel="x",
+        context={"time_local": "2026-04-15T15:00:00+09:00"},
+        payload_preview={"text": "今日の空はとても青い"},
+    )
+
+    assert unreviewed.decision == "deny"
+    assert any("review_social_post" in reason for reason in unreviewed.reasons)
+    assert reviewed.decision == "allow"
+    assert nobody.decision == "allow"
+
+
+def test_review_requirement_is_not_overridden_by_urgency(store):
+    result = store.evaluate_action(
+        action_type="post_text",
+        channel="x",
+        context={"person_present": True, "time_local": "2026-04-15T15:00:00+09:00"},
+        urgency="high",
+    )
+
+    assert result.decision == "deny"
+
+
+def test_preferred_nudge_style_is_returned_for_the_person(store):
+    with_rule = store.evaluate_action(
+        action_type="say",
+        person_id="kouta",
+        context={"time_local": "2026-04-15T15:00:00+09:00"},
+        payload_preview={"text": "お茶でも飲む？"},
+    )
+    without_rule = store.evaluate_action(
+        action_type="say",
+        person_id="stranger",
+        context={"time_local": "2026-04-15T15:00:00+09:00"},
+    )
+
+    assert with_rule.nudge_style == "brief_gentle"
+    assert without_rule.nudge_style is None


### PR DESCRIPTION
## 概要

#150 で fmtowns3 さんが指摘してくださったとおり、`socialPolicy.toml` の 3 つの設定は dataclass に詰められるだけでどこからも参照されていませんでした。特に `privacy_zones` は、同梱の設定が「寝ている場所では post_image を拒否」と書いているのに `evaluate_action` が `allow` を返していて、書いた人が「守られている」と信じる種類の設定でした。

3 つとも実装する方向で直しました。

## 変更

### privacy_zones

- `SocialPolicy.privacy_zones_for(zone_name=..., camera_preset=...)` を追加（issue の提案と同じ形）
- `evaluate_action` は `context.zone`（または `context.zone_name`）をゾーン名と、`context.camera_preset` を `camera_presets` と照合し、`deny_actions` にある行為を `deny` します
- どちらの鍵も渡さない呼び出しはどのゾーンにも当たらないので、既存の呼び出しの挙動は変わりません

### require_review_if_person_present

- このフラグが立ったチャネルへの投稿は、人がいる間（`context.scene_contains_face` / `context.person_present` / `payload_preview.person_mentions`）は `review_social_post` を通すまで `deny`。通したことは `context.reviewed = true` で伝えます
- 顔の同意判定は、従来の「常に x のルール」から `channel` で引く形にしました（`x` の挙動は同じ。既存テストで担保）

### preferred_nudge_style

- `EvaluateActionResult` に `nudge_style: str | None` を追加し、person rule がある人には常に返します。呼び出し側（plan_response など）がトーンを決める材料にできます

## issue で挙げられていた 2 つの選択について

**(1) 照合の鍵**: `camera_preset` と `zone`/`zone_name` の両方を受け付けます。カメラの向きしか知らない呼び出しと、ゾーン名しか知らない呼び出しの両方があるためです。

**(2) urgency の override**: 部屋の中で完結する行為（`speak_loud` など）は既存の `person_rules` と同じく高 urgency で `allow_with_override` になります。一方で `post_image` / `post_text` / `post_tweet` などの公開系の行為は **高 urgency でも deny のまま** です。issue にあった「緊急事態は同意を作らない」という考え方を採りました。`require_review_if_person_present` の拒否も同じく override されません。ここは方針の話なので、逆のほうが良ければ変えます。

首を振らないカメラをゾーンに入れる手段（`cameras = [...]`）は、issue でも別件とされていたのでこの PR では触っていません。

## 確認

```
uv lock --check
uv run ruff check sociality-mcp/packages/boundary-mcp                                          # All checks passed
uv run --package boundary-mcp pytest sociality-mcp/packages/boundary-mcp/tests -q               # 28 passed
uv run --package sociality-mcp pytest sociality-mcp/tests -q                                    # 3 passed
uv run --package interaction-orchestrator-mcp pytest sociality-mcp/packages/interaction-orchestrator-mcp/tests -q
```

追加したテスト: preset での拒否 / ゾーン名での拒否 / 列挙されていない行為は通る / 場所なしの呼び出しは従来どおり / urgency は speak_loud は通すが post_image は通さない / 人がいるときの投稿は review 後のみ許可 / review 要求は urgency で override されない / nudge_style が返る

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxBXjcocf3Y58yQMpSZtHt
