### PR TITLE
feat(boundary): let a privacy zone name a camera, not just a preset

### DIFF
--- a/sociality-mcp/packages/boundary-mcp/README.md
+++ b/sociality-mcp/packages/boundary-mcp/README.md
@@ -18,11 +18,13 @@ Policy file:
 How `evaluate_action` reads the policy:
 
 - `[[privacy_zones]]` match when `context.zone` (or `context.zone_name`) equals the zone `name`,
-  or `context.camera_preset` is in its `camera_presets`. An action in the zone's
+  when `context.camera_preset` is in its `camera_presets`, or when `context.camera` is in its
+  `cameras`. Use `cameras` for a camera that is bolted in place: it never moves to a preset, so
+  no preset list can describe what it sees. An action in the zone's
   `deny_actions` is denied. High urgency still lets in-room actions such as `speak_loud`
   through with `allow_with_override`; publishing actions (`post_image`, `post_text`,
   `post_tweet`, ...) stay denied, because an emergency does not create consent to publish.
-  A call that passes neither key matches no zone.
+  A call that passes none of the three keys matches no zone.
 - `[[posting_rules]]` with `require_review_if_person_present = true` denies a post while a
   person is present (`context.scene_contains_face`, `context.person_present`, or
   `payload_preview.person_mentions`) until the caller has run `review_social_post` and

--- a/sociality-mcp/packages/boundary-mcp/src/boundary_mcp/policy.py
+++ b/sociality-mcp/packages/boundary-mcp/src/boundary_mcp/policy.py
@@ -22,6 +22,9 @@ class GlobalPolicy:
 class PrivacyZone:
     name: str
     camera_presets: list[str] = field(default_factory=list)
+    # A fixed camera never moves to a preset, so a preset list cannot describe
+    # it. Naming the camera itself is the only way to place one in a zone.
+    cameras: list[str] = field(default_factory=list)
     deny_actions: list[str] = field(default_factory=list)
 
 
@@ -59,13 +62,15 @@ class SocialPolicy:
         *,
         zone_name: str | None = None,
         camera_preset: str | None = None,
+        camera: str | None = None,
     ) -> list[PrivacyZone]:
-        """Zones that apply to a location given by name and/or camera preset.
+        """Zones that apply to a location given by name, preset and/or camera.
 
         A caller that knows only the zone name passes ``zone_name``; one that
-        knows only where the camera points passes ``camera_preset``. With
-        neither, no zone matches, so callers that never describe a location
-        keep their previous behaviour (#150).
+        knows only where the camera points passes ``camera_preset``; one whose
+        camera does not move passes ``camera``. With none of the three, no zone
+        matches, so callers that never describe a location keep their previous
+        behaviour (#150).
         """
 
         matched: list[PrivacyZone] = []
@@ -73,6 +78,8 @@ class SocialPolicy:
             if zone_name is not None and zone.name == zone_name:
                 matched.append(zone)
             elif camera_preset is not None and camera_preset in zone.camera_presets:
+                matched.append(zone)
+            elif camera is not None and camera in zone.cameras:
                 matched.append(zone)
         return matched
 
@@ -134,6 +141,7 @@ def load_policy(path: str | Path | None = None) -> SocialPolicy:
             PrivacyZone(
                 name=item["name"],
                 camera_presets=list(item.get("camera_presets", [])),
+                cameras=list(item.get("cameras", [])),
                 deny_actions=list(item.get("deny_actions", [])),
             )
             for item in data.get("privacy_zones", [])

--- a/sociality-mcp/packages/boundary-mcp/src/boundary_mcp/store.py
+++ b/sociality-mcp/packages/boundary-mcp/src/boundary_mcp/store.py
@@ -132,6 +132,7 @@ class BoundaryStore:
         zones = self.policy.privacy_zones_for(
             zone_name=context.get("zone") or context.get("zone_name"),
             camera_preset=context.get("camera_preset"),
+            camera=context.get("camera"),
         )
         for zone in zones:
             if action_type not in set(zone.deny_actions):

--- a/sociality-mcp/packages/boundary-mcp/tests/conftest.py
+++ b/sociality-mcp/packages/boundary-mcp/tests/conftest.py
@@ -42,3 +42,36 @@ def store(tmp_path: Path, policy_path: Path) -> BoundaryStore:
     boundary_store = BoundaryStore(tmp_path / "social.db", policy_path=policy_path)
     yield boundary_store
     boundary_store.close()
+
+
+@pytest.fixture
+def fixed_camera_policy_path(tmp_path: Path) -> Path:
+    """A zone named by camera rather than by preset.
+
+    A camera bolted to one place never moves to a preset, so ``camera_presets``
+    cannot describe it. Everything it sees is inside the zone.
+    """
+
+    path = tmp_path / "socialPolicy-fixed-camera.toml"
+    path.write_text(
+        """
+[global]
+timezone = "Asia/Tokyo"
+
+[[privacy_zones]]
+name = "customer_site"
+cameras = ["wifi-cam-car"]
+deny_actions = ["post_image", "post_tweet"]
+""".strip(),
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.fixture
+def fixed_camera_store(tmp_path: Path, fixed_camera_policy_path: Path) -> BoundaryStore:
+    boundary_store = BoundaryStore(
+        tmp_path / "fixed-camera.db", policy_path=fixed_camera_policy_path
+    )
+    yield boundary_store
+    boundary_store.close()

--- a/sociality-mcp/packages/boundary-mcp/tests/test_boundary.py
+++ b/sociality-mcp/packages/boundary-mcp/tests/test_boundary.py
@@ -242,3 +242,37 @@ def test_preferred_nudge_style_is_returned_for_the_person(store):
 
     assert with_rule.nudge_style == "brief_gentle"
     assert without_rule.nudge_style is None
+
+
+def test_privacy_zone_matches_a_fixed_camera_by_name(fixed_camera_store):
+    """A camera that never moves has no preset, so the zone names the camera."""
+    result = fixed_camera_store.evaluate_action(
+        action_type="post_image",
+        person_id="kouta",
+        context={"camera": "wifi-cam-car", "time_local": "2026-04-15T14:00:00+09:00"},
+    )
+
+    assert result.decision == "deny"
+    assert any("customer_site" in reason for reason in result.reasons)
+
+
+def test_a_camera_outside_that_zone_is_not_denied(fixed_camera_store):
+    result = fixed_camera_store.evaluate_action(
+        action_type="post_image",
+        person_id="kouta",
+        context={"camera": "wifi-cam-1f", "time_local": "2026-04-15T14:00:00+09:00"},
+    )
+
+    assert result.decision == "allow"
+
+
+def test_a_fixed_camera_zone_holds_under_high_urgency(fixed_camera_store):
+    """Publishing is a hard deny upstream (#160); naming the camera keeps that."""
+    result = fixed_camera_store.evaluate_action(
+        action_type="post_image",
+        person_id="kouta",
+        urgency="high",
+        context={"camera": "wifi-cam-car", "time_local": "2026-04-15T14:00:00+09:00"},
+    )
+
+    assert result.decision == "deny"


### PR DESCRIPTION
Follows up on your closing note in #150 -- "固定カメラの件（`cameras = [...]`）は
別件として残しています". This is that part.

### Why a preset list cannot cover it

`camera_presets` describes *where a camera is pointing*, which names a place only
while the camera body itself stays put. **Two shapes break that, and both are
already described in this project.**

**A camera with no presets at all.** `usb-webcam-mcp`, in this repository,
exposes `list_cameras` and `see` and nothing else -- no pan, no tilt, no
presets. No `camera_presets` list can describe any camera it drives, so a
privacy zone cannot cover one today. (`ip-webcam-mcp` in `embodied-codex` reads
the same way, a single `see` against `/shot.jpg`. I have read its `server.py`,
not run it.)

**A camera that is carried.** `CLAUDE.md:420` documents going out for a walk
with the camera on your shoulder, and the `embodied-codex` README describes the
same walk with a phone as the camera. The presets still exist there, but they
stop denoting a place: preset 3 is a position relative to a mount that is itself
moving. On a walk, what is in frame is whoever you happen to be standing in
front of, and it changes with every step.

Naming the camera is the only key that survives both.

    [[privacy_zones]]
    name = "customer_site"
    cameras = ["wifi-cam-car"]
    deny_actions = ["post_image", "post_tweet"]

The case that sent me looking is the second shape from the other end: a camera
mounted on a vehicle. It does not pan, and its whole frame is whatever the
vehicle is parked in front of, so nameplates and street numbers are in shot by
default rather than by accident.

### What changed

`privacy_zones_for` gains a third key beside `zone_name` and `camera_preset`,
`evaluate_action` passes `context["camera"]` into it, and the README's list of
match keys is updated in the same commit because it states the rule.

Additive. `cameras` defaults to empty, so a policy that does not use it behaves
exactly as before, and a caller that never sets `context["camera"]` matches no
zone through this key.

### The third test is the point

Two of the three tests are the obvious ones -- the named camera is denied, a
different camera is not. The third pins the interaction with #160: a zone matched
by camera name inherits the publishing hard deny, so `urgency="high"` does not
lift it.

That is the property this key exists for. A camera whose whole field of view is
someone else's property is exactly the place where an emergency must not turn
into consent to publish. If the two features are ever refactored apart, that test
should fail rather than the behaviour quietly changing.

### What this does not do

**It is as honest as the caller.** `context["camera"]` is supplied by the caller,
the same way `context["camera_preset"]` already is. A caller that does not name
its camera matches no zone. That is a property of the whole `context` interface
rather than something this key introduces, but it is worth saying plainly: this
makes a fixed camera *expressible* in policy, not *enforced* against a caller who
declines to say where the image came from.

**I did not touch `examples/configs/socialPolicy.example.toml`.** The example is
a bedroom scenario with a PTZ camera, and inventing a second zone there to show
the key felt like adding a story the example was not telling. Happy to add one if
you would rather it be discoverable from the example as well as the README.

### One thing I noticed next door, deliberately not in this PR

`PUBLISHING_ACTIONS` is `post_image` / `post_text` / `post_tweet` / `post_video` /
`share_image` / `publish`. It has no "send to one named recipient" member, so a
`deny_actions = ["send_mail"]` in a privacy zone is still lifted by high urgency.

As a reading of "publishes something outside the room" that is coherent, so I do
not think it is a bug, and I have not filed anything. Raising it only because you
asked in #150 whether any of it points the wrong way. If the vocabulary is ever
widened I would rather bring it as a discussion than a patch.

### Checked before opening

- `uv lock --check`
- `uv run ruff check sociality-mcp/packages/boundary-mcp` -- clean
- `uv run pytest sociality-mcp/packages/boundary-mcp/tests` -- **31 passed**
  (28 existing plus the three new ones)
- The diff is ASCII only, and `grep` for `confidential` across it returns zero --
  this branch carries nothing but the `cameras` key

---

## 日本語

#150 を閉じられたときの一文の続きです。

> 固定カメラの件（`cameras = [...]`）は別件として残しています。

### プリセット一覧では表せない理由

`camera_presets` は「カメラが**どこを向いているか**」を表します。
**それが場所を指すのは、カメラの筐体そのものが動かない間だけです。**
そこが崩れる形が 2 つあり、**どちらもこのプロジェクトに既に書かれています。**

**1. プリセットが存在しないカメラ。** このリポジトリの `usb-webcam-mcp` は
`list_cameras` と `see` だけを公開しています。**パンもチルトもプリセットもありません。**
`camera_presets` ではあのサーバーが扱うカメラを**一台も指せない**ので、
privacy zone が今のところまったく掛かりません。
（`embodied-codex` の `ip-webcam-mcp` も同じ形に読めます ——
`/shot.jpg` に対する `see` 一つだけ。`server.py` を読んだだけで、動かしてはいません。）

**2. 持ち歩くカメラ。** `CLAUDE.md:420` に、カメラを**肩に載せて散歩に出る**構成が
書かれています。`embodied-codex` の README も、スマホを同じように持ち出す形を
説明しています。**この場合プリセットは存在しますが、場所を指さなくなります。**
プリセット 3 は「動いている取り付け台に対する相対位置」でしかありません。
散歩の最中に画角へ入るのは**そのとき目の前にいる誰か**で、一歩ごとに変わります。

**両方を生き延びる鍵は、カメラを名指しすることだけです。**

    [[privacy_zones]]
    name = "customer_site"
    cameras = ["wifi-cam-car"]
    deny_actions = ["post_image", "post_tweet"]

探すきっかけになったのは、2 の形を裏から見た事例です。**自動車に載せたカメラ。**
パンしませんし、画角はまるごと「駐めた先にあるもの」なので、
表札や番地は**事故ではなく既定で**写り込みます。

### 変更点

`privacy_zones_for` に `zone_name` / `camera_preset` と並ぶ 3 つ目の鍵を足し、
`evaluate_action` が `context["camera"]` を渡します。
**README の一致条件も同じコミットで直しました。** あそこが規則を述べている場所なので。

追加のみです。`cameras` の既定は空なので、使っていない policy はこれまでどおり。
`context["camera"]` を渡さない呼び出しは、この鍵ではどのゾーンにも当たりません。

### 3 つ目のテストが本題

2 つは当たり前のほう（名指ししたカメラは deny、別のカメラは deny しない）。
**3 つ目が #160 との噛み合わせを固定します。**
カメラ名で当たったゾーンも公開系の hard deny を継ぐので、
`urgency="high"` では覆せません。

**この鍵が在る理由がそこです。** 視野全体が他人の敷地であるカメラは、
**緊急事態が公開の同意に化けてはいけない場所**そのものです。
将来この 2 つが分離されたとき、挙動が静かに変わるのではなく
**テストが落ちてほしい。**

### やっていないこと

**呼び出し側の正直さ以上には強くなりません。** `context["camera"]` は
`context["camera_preset"]` と同じく呼び出し側が申告するものです。
カメラを名乗らなければ、どのゾーンにも当たりません。
これは `context` という受け口全体の性質で、この鍵が持ち込んだものではありませんが、
**はっきり書いておきます。** 固定カメラを policy で**表せる**ようにしただけで、
出所を言わない呼び出し側に**強制する**ものではありません。

**`examples/configs/socialPolicy.example.toml` は触っていません。**
あの例は PTZ カメラの寝室の話なので、鍵を見せるために 2 つ目のゾーンを足すのは、
例が語っていない筋書きを持ち込むことになると感じました。
**README だけでなく例からも見つかるほうが良ければ、足します。**

### 隣で気づいたこと（意図的にこの PR に入れていません）

`PUBLISHING_ACTIONS` は `post_image` / `post_text` / `post_tweet` /
`post_video` / `share_image` / `publish` の 6 つです。
**「特定の相手へ送る」系が入っていない**ので、privacy zone に
`deny_actions = ["send_mail"]` と書いても、高 urgency では素通りします。

「部屋の外へ**公開**する」の読みとしては筋が通っているので、
**バグだとは思っていませんし、何も出していません。**
#150 で「逆の方針のほうが良い箇所があれば」と書かれていたので挙げるだけです。
語彙を広げる話になるなら、パッチではなく discussion で持っていきます。

### 出す前に確かめたこと

- `uv lock --check`
- `uv run ruff check sociality-mcp/packages/boundary-mcp` クリーン
- `uv run pytest sociality-mcp/packages/boundary-mcp/tests` **31 passed**
  （既存 28 ＋ 新規 3）
- 差分は **ASCII のみ**。`confidential` の grep は **0 件** ——
  このブランチには `cameras` 以外は入っていません
